### PR TITLE
Add CMake FortranCInterface to detect Fortran name mangling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,11 @@
-cmake_minimum_required (VERSION 2.8.11)
+cmake_minimum_required (VERSION 3.0.2)
 project (hippopde)
+# enable Fortran for Fortran name mangling
+enable_language(Fortran)
+
+# Create header for Fortran name mangling
+include(FortranCInterface)
+FortranCInterface_HEADER(FortranCInterface.hpp MACRO_NAMESPACE "FC_")
 
 option(WITH_MPI "Build with MPI support" ON)
 option(DEEP_CHECKING "Extra checks and asserts in the code with a high penalty on performance" ON)
@@ -26,6 +32,9 @@ find_package(LAPACK REQUIRED)
 # extended precision lapack based on xblas testing example
 #
 #set(LAPACK_LIBRARIES "-lgfortran;/export/home/petra1/work/installs/xblas-1.0.248/libxblas.a;/home/petra1/work/installs/lapack-3.7.0/libblas.a;/home/petra1/work/installs/lapack-3.7.0/liblapack.a;/home/petra1/work/installs/lapack-3.7.0/liblapack.a;/home/petra1/work/installs/lapack-3.7.0/libblas.a;/export/home/petra1/work/installs/xblas-1.0.248/libxblas.a")
+
+# include build directory for Fortran name mangling header
+include_directories(${CMAKE_BINARY_DIR})
 
 include_directories(src/Interface)
 include_directories(src/Optimization)
@@ -56,11 +65,11 @@ add_library(hiop STATIC $<TARGET_OBJECTS:hiopOptimization>
 			$<TARGET_OBJECTS:hiopUtils>)
 
 install(TARGETS hiop DESTINATION lib)
-install(FILES src/Interface/hiopInterface.hpp 
-	      src/Optimization/hiopNlpFormulation.hpp 
-	      src/Optimization/hiopAlgFilterIPM.hpp 
-	      src/Optimization/hiopIterate.hpp 
-	      src/Optimization/hiopResidual.hpp 
+install(FILES src/Interface/hiopInterface.hpp
+	      src/Optimization/hiopNlpFormulation.hpp
+	      src/Optimization/hiopAlgFilterIPM.hpp
+	      src/Optimization/hiopIterate.hpp
+	      src/Optimization/hiopResidual.hpp
 	      src/Optimization/hiopLogBarProblem.hpp
 	      src/Optimization/hiopFilter.hpp
 	      src/Optimization/hiopHessianLowRank.hpp
@@ -85,5 +94,5 @@ if (WITH_MAKETEST)
   add_test(NAME NlpDenseCons2_50K COMMAND $<TARGET_FILE:nlpDenseCons_ex2.exe> 50000 -selfcheck)
   if(WITH_MPI)
     add_test(NAME NlpDenseCons2_50K_mpi COMMAND mpirun -np 2 $<TARGET_FILE:nlpDenseCons_ex2.exe> 50000 -selfcheck)
-  endif(WITH_MPI) 
+  endif(WITH_MPI)
 endif(WITH_MAKETEST)

--- a/src/LinAlg/blasdefs.hpp
+++ b/src/LinAlg/blasdefs.hpp
@@ -1,20 +1,38 @@
 #ifndef HIOP_BLASDEFS
 #define HIOP_BLASDEFS
 
+#include "FortranCInterface.hpp"
+
+#define DDOT    FC_GLOBAL(ddot, DDOT)
+#define DNRM2   FC_GLOBAL(dnrm2, DNRM2)
+#define DSCAL   FC_GLOBAL(dscal, DSCAL)
+#define DAXPY   FC_GLOBAL(daxpy, DAXPY)
+#define DCOPY   FC_GLOBAL(dcopy, DCOPY)
+#define DGEMV   FC_GLOBAL(dgemv, DGEMV)
+#define DGEMM   FC_GLOBAL(dgemm, DGEMM)
+#define DTRSM   FC_GLOBAL(dtrsm, DTRSM)
+#define DPOTRF  FC_GLOBAL(dpotrf, DPOTRF)
+#define DPOTRS  FC_GLOBAL(dpotrs, DPOTRS)
+#define DSYTRF  FC_GLOBAL(dsytrf, DSYTRF)
+#define DSYTRS  FC_GLOBAL(dsytrs, DSYTRS)
+#define DLANGE  FC_GLOBAL(dlange, DLANGE)
+#define DPOSVX  FC_GLOBAL(dposvx, DPOSVC)
+#define DPOSVXX FC_GLOBAL(dposvxx, DPOSVXX)
+
 namespace hiop
 {
 
-extern "C" double dnrm2_(int* n, double* x, int* incx);
-extern "C" double ddot_ (int* n, double* dx, int* incx, double* dy, int* incy);
-extern "C" void   dscal_(int* n, double* da, double* dx, int* incx);
-extern "C" void   daxpy_(int* n, double* da, double* dx, int* incx, double* dy, int* incy );
-extern "C" void   dcopy_(int* n,  double* da, int* incx, double* dy, int* incy);
-extern "C" void   dgemv_(char* trans, int* m, int* n, double* alpha, double* a, int* lda,
+extern "C" double DNRM2(int* n, double* x, int* incx);
+extern "C" double DDOT(int* n, double* dx, int* incx, double* dy, int* incy);
+extern "C" void   DSCAL(int* n, double* da, double* dx, int* incx);
+extern "C" void   DAXPY(int* n, double* da, double* dx, int* incx, double* dy, int* incy );
+extern "C" void   DCOPY(int* n,  double* da, int* incx, double* dy, int* incy);
+extern "C" void   DGEMV(char* trans, int* m, int* n, double* alpha, double* a, int* lda,
 			 const double* x, int* incx, double* beta, double* y, int* incy );
 /* C := alpha*op( A )*op( B ) + beta*C
  * op( A ) an m by k matrix, op( B ) a  k by n matrix and C an m by n matrix
  */
-extern "C" void   dgemm_(char* transA, char* transB, int* m, int* n, int* k,
+extern "C" void   DGEMM(char* transA, char* transB, int* m, int* n, int* k,
 			 double* alpha, double* a, int* lda,
 			 double* b, int* ldb,
 			 double* beta, double* C, int*ldc);
@@ -28,9 +46,9 @@ extern "C" void   dgemm_(char* transA, char* transB, int* m, int* n, int* k,
  * The matrix X is overwritten on B.
  */
 //!opt DTPTRS packed format triangular solve
-extern "C" void   dtrsm_(char* side, char* uplo, char* transA, char* diag, 
-			 int* M, int* N, 
-			 double* alpha, 
+extern "C" void   DTRSM(char* side, char* uplo, char* transA, char* diag,
+			 int* M, int* N,
+			 double* alpha,
 			 const double* a, int* lda,
 			 double* b, int* ldb);
 
@@ -39,15 +57,15 @@ extern "C" void   dtrsm_(char* side, char* uplo, char* transA, char* diag,
  *   A = U**T * U,  if UPLO = 'U', or  A = L  * L**T,  if UPLO = 'L',
  * where U is an upper triangular matrix and L is lower triangular.
  */
-extern "C" void   dpotrf_(char* uplo, int* N, double* A, int* lda, int* info);
+extern "C" void   DPOTRF(char* uplo, int* N, double* A, int* lda, int* info);
 
 /* solves a system of linear equations A*X = B with a symmetric
  * positive definite matrix A using the Cholesky factorization
  * A = U**T*U or A = L*L**T computed by DPOTRF
- * A contains  the triangular factor U or L 
+ * A contains  the triangular factor U or L
 */
-extern "C" void   dpotrs_(char* uplo, int* N, int* NRHS, 
-			  double*A, int* lda, 
+extern "C" void   DPOTRS(char* uplo, int* N, int* NRHS,
+			  double*A, int* lda,
 			  double* B, int* ldb,
 			  int* info);
 
@@ -61,7 +79,7 @@ extern "C" void   dpotrs_(char* uplo, int* N, int* NRHS,
  *
  *  This is the blocked version of the algorithm, calling Level 3 BLAS.
  */
-extern "C" void dsytrf_( char* UPLO, int* N, double* A, int* LDA, int* IPIV, double* WORK, int* LWORK, int* INFO );
+extern "C" void DSYTRF( char* UPLO, int* N, double* A, int* LDA, int* IPIV, double* WORK, int* LWORK, int* INFO );
 
 /* DSYTRS solves a system of linear equations A*X = B with a real
  *  symmetric matrix A using the factorization A = U*D*U**T or
@@ -69,13 +87,13 @@ extern "C" void dsytrf_( char* UPLO, int* N, double* A, int* LDA, int* IPIV, dou
  *
  * To improve the solution using LAPACK one needs to use DSYRFS.
  */
-extern "C" void dsytrs_( char* UPLO, int* N, int* NRHS, double* A, int* LDA, int* IPIV, double*B, int* LDB, int* INFO );
+extern "C" void DSYTRS( char* UPLO, int* N, int* NRHS, double* A, int* LDA, int* IPIV, double*B, int* LDB, int* INFO );
 
 /* returns the value of the one norm,  or the Frobenius norm, or
  *  the  infinity norm,  or the  element of  largest absolute value  of a
  *  real matrix A.
  */
-extern "C" double   dlange_(char* norm, int* M, int* N, double*A, int* lda, double* work);
+extern "C" double   DLANGE(char* norm, int* M, int* N, double*A, int* lda, double* work);
 
 /* DPOSVX uses the Cholesky factorization A = U**T*U or A = L*L**T to
  compute the solution to a real system of linear equations
@@ -86,16 +104,16 @@ extern "C" double   dlange_(char* norm, int* M, int* N, double*A, int* lda, doub
  Error bounds on the solution and a condition estimate are also
  provided.
 */
-extern "C" void dposvx_(char* FACT, char* UPLO, int* N, int* NRHS,
+extern "C" void DPOSVX(char* FACT, char* UPLO, int* N, int* NRHS,
 			double* A, int* LDA,
 			double*	AF, int* LDAF,
 			char* EQUED,
 			double*	S,
 			double* B, int* LDB,
 			double*	X, int* LDX,
-			double* RCOND, double* FERR, double* BERR, 
+			double* RCOND, double* FERR, double* BERR,
 			double* WORK, int* IWORK,
-			int* 	INFO); 
+			int* 	INFO);
 /* DPOSVXX uses the Cholesky factorization A = U**T*U or A = L*L**T
     to compute the solution to a double precision system of linear equations
     A * X = B, where A is an N-by-N symmetric positive definite matrix
@@ -116,7 +134,7 @@ extern "C" void dposvx_(char* FACT, char* UPLO, int* N, int* NRHS,
     user-provided factorizations and equilibration factors if they
     differ from what DPOSVXX would itself produce.
 */
-extern "C" void dposvxx_(char* FACT, char* UPLO, int* N, int* NRHS,
+extern "C" void DPOSVXX(char* FACT, char* UPLO, int* N, int* NRHS,
 			 double* A, int* LDA,
 			 double* AF, int* LDAF,
 			 char* EQUED,
@@ -127,7 +145,7 @@ extern "C" void dposvxx_(char* FACT, char* UPLO, int* N, int* NRHS,
 			 int* N_ERR_BNDS, double* ERR_BNDS_NORM, double* ERR_BNDS_COMP,
 			 int* NPARAMS, double* PARAMS,
 			 double* WORK, int* IWORK,
-			 int* INFO);	
+			 int* INFO);
 
 };
 #endif

--- a/src/LinAlg/hiopMatrix.cpp
+++ b/src/LinAlg/hiopMatrix.cpp
@@ -277,7 +277,7 @@ void hiopMatrixDense::setToConstant(double c)
   
   buf=M[0]; int inc=1;
   for(int i=1; i<m_local; i++)
-   dcopy_(&n_local, buf, &inc, M[i], &inc);
+   DCOPY(&n_local, buf, &inc, M[i], &inc);
   
   //memcpy(M[i], buf, sizeof(double)*n_local); 
   //memcpy has similar performance as dcopy_; both faster than a loop
@@ -347,7 +347,7 @@ void hiopMatrixDense::timesVec(double beta, hiopVector& y_,
   if( MM != 0 && NN != 0 ) {
     // the arguments seem reversed but so is trans='T' 
     // required since we keep the matrix row-wise, while the Fortran/BLAS expects them column-wise
-    dgemv_( &fortranTrans, &NN, &MM, &alpha, &M[0][0], &NN,
+    DGEMV( &fortranTrans, &NN, &MM, &alpha, &M[0][0], &NN,
 	    x.local_data_const(), &incx_y, &beta, y.local_data(), &incx_y );
   } else {
     if( MM != 0 ) y.scale( beta );
@@ -380,7 +380,7 @@ void hiopMatrixDense::transTimesVec(double beta, hiopVector& y_,
   if( MM!=0 && NN!=0 ) {
     // the arguments seem reversed but so is trans='T' 
     // required since we keep the matrix row-wise, while the Fortran/BLAS expects them column-wise
-    dgemv_( &fortranTrans, &NN, &MM, &alpha, &M[0][0], &NN,
+    DGEMV( &fortranTrans, &NN, &MM, &alpha, &M[0][0], &NN,
 	    x.local_data_const(), &incx_y, &beta, y.local_data(), &incx_y );
   } else {
     if( NN != 0 ) y.scale( beta );
@@ -432,7 +432,7 @@ void hiopMatrixDense::timesMat_local(double beta, hiopMatrix& W_, double alpha, 
   int ldx=X.n(), ldm=n_local, ldw=X.n();
 
   double** XM=X.local_data(); double** WM=W.local_data();
-  dgemm_(&trans,&trans, &M,&N,&K, &alpha,XM[0],&ldx, this->M[0],&ldm, &beta,WM[0],&ldw);
+  DGEMM(&trans,&trans, &M,&N,&K, &alpha,XM[0],&ldx, this->M[0],&ldm, &beta,WM[0],&ldw);
 
   /* C = alpha*op(A)*op(B) + beta*C in our case is
      Wt= alpha* Xt  *Mt    + beta*Wt */
@@ -441,7 +441,7 @@ void hiopMatrixDense::timesMat_local(double beta, hiopMatrix& W_, double alpha, 
   //int lda=X.m(), ldb=n_local, ldc=W.n();
   //int M=X.n(), N=this->m(), K=this->n_local;
 
-  //dgemm_(&trans,&trans, &M,&N,&K, &alpha,XM[0],&lda, this->M[0],&ldb, &beta,WM[0],&ldc);
+  //DGEMM(&trans,&trans, &M,&N,&K, &alpha,XM[0],&lda, this->M[0],&ldb, &beta,WM[0],&ldc);
   
 }
 
@@ -465,7 +465,7 @@ void hiopMatrixDense::transTimesMat(double beta, hiopMatrix& W_, double alpha, c
   int M=X.n(), N=n_local, K=X.m();
   double** XM=X.local_data(); double** WM=W.local_data();
   
-  dgemm_(&transX, &transM, &M,&N,&K, &alpha,XM[0],&ldx, this->M[0],&ldm, &beta,WM[0],&ldw);
+  DGEMM(&transX, &transM, &M,&N,&K, &alpha,XM[0],&ldx, this->M[0],&ldm, &beta,WM[0],&ldw);
 }
 
 /* W = beta*W + alpha*this*X^T
@@ -486,7 +486,7 @@ void hiopMatrixDense::timesMatTrans_local(double beta, hiopMatrix& W_, double al
   if(n_local==0) {
     if(beta!=1.0) {
       int one=1; int mn=W.m()*W.n();
-      dscal_(&mn, &beta, W.M[0], &one);
+      DSCAL(&mn, &beta, W.M[0], &one);
     }
     return;
   }
@@ -498,7 +498,7 @@ void hiopMatrixDense::timesMatTrans_local(double beta, hiopMatrix& W_, double al
   int M=X.m(), N=m_local, K=n_local;
   double** XM=X.local_data(); double** WM=W.local_data();
 
-  dgemm_(&transX, &transM, &M,&N,&K, &alpha,XM[0],&ldx, this->M[0],&ldm, &beta,WM[0],&ldw);
+  DGEMM(&transX, &transM, &M,&N,&K, &alpha,XM[0],&ldx, this->M[0],&ldm, &beta,WM[0],&ldw);
 }
 void hiopMatrixDense::timesMatTrans(double beta, hiopMatrix& W_, double alpha, const hiopMatrix& X_) const
 {
@@ -562,13 +562,13 @@ void hiopMatrixDense::addMatrix(double alpha, const hiopMatrix& X_)
 #endif
   //  extern "C" void   daxpy_(int* n, double* da, double* dx, int* incx, double* dy, int* incy );
   int N=m_local*n_local, inc=1;
-  daxpy_(&N, &alpha, X.M[0], &inc, M[0], &inc);
+  DAXPY(&N, &alpha, X.M[0], &inc, M[0], &inc);
 }
 
 double hiopMatrixDense::max_abs_value()
 {
   char norm='M';
-  double maxv = dlange_(&norm, &n_local, &m_local, M[0], &n_local, NULL);
+  double maxv = DLANGE(&norm, &n_local, &m_local, M[0], &n_local, NULL);
 #ifdef WITH_MPI
   double maxvg;
   int ierr=MPI_Allreduce(&maxv,&maxvg,1,MPI_DOUBLE,MPI_MAX,comm); assert(ierr==MPI_SUCCESS);

--- a/src/LinAlg/hiopVector.cpp
+++ b/src/LinAlg/hiopVector.cpp
@@ -172,7 +172,7 @@ void hiopVectorPar::copyTo(double* dest) const
 double hiopVectorPar::twonorm() const 
 {
   int one=1; int n=n_local;
-  double nrm = dnrm2_(&n,data,&one); 
+  double nrm = DNRM2(&n,data,&one); 
 
 #ifdef WITH_MPI
   nrm *= nrm;
@@ -189,7 +189,7 @@ double hiopVectorPar::dotProductWith( const hiopVector& v_ ) const
   int one=1; int n=n_local;
   assert(this->n_local==v.n_local);
 
-  double dotprod=ddot_(&n, this->data, &one, v.data, &one);
+  double dotprod=DDOT(&n, this->data, &one, v.data, &one);
 
 #ifdef WITH_MPI
   double dotprodG;
@@ -301,14 +301,14 @@ void hiopVectorPar::scale(double num)
 {
   if(1.0==num) return;
   int one=1; int n=n_local;
-  dscal_(&n, &num, data, &one);
+  DSCAL(&n, &num, data, &one);
 }
 
 void hiopVectorPar::axpy(double alpha, const hiopVector& x_)
 {
   const hiopVectorPar& x = dynamic_cast<const hiopVectorPar&>(x_);
   int one = 1; int n=n_local;
-  daxpy_( &n, &alpha, x.data, &one, data, &one );
+  DAXPY( &n, &alpha, x.data, &one, data, &one );
 }
 
 void hiopVectorPar::axzpy(double alpha, const hiopVector& x_, const hiopVector& z_)
@@ -473,7 +473,7 @@ void hiopVectorPar::min( double& m, int& index ) const
 void hiopVectorPar::negate()
 {
   double minusOne=-1.0; int one=1, n=n_local;
-  dscal_(&n, &minusOne, data, &one);
+  DSCAL(&n, &minusOne, data, &one);
 }
 
 void hiopVectorPar::invert()

--- a/src/Optimization/hiopDualsUpdater.cpp
+++ b/src/Optimization/hiopDualsUpdater.cpp
@@ -238,7 +238,7 @@ int hiopDualsLsqUpdate::factorizeMat(hiopMatrixDense& M)
 #endif
   if(M.m()==0) return 0;
   char uplo='L'; int N=M.n(), lda=N, info;
-  dpotrf_(&uplo, &N, M.local_buffer(), &lda, &info);
+  DPOTRF(&uplo, &N, M.local_buffer(), &lda, &info);
   if(info>0)
     _nlp->log->printf(hovError, "hiopKKTLinSysLowRank::factorizeMat: dpotrf (Chol fact) detected %d minor being indefinite.\n", info);
   else
@@ -256,7 +256,7 @@ int hiopDualsLsqUpdate::solveWithFactors(hiopMatrixDense& M, hiopVectorPar& r)
   if(M.m()==0) return 0;
   char uplo='L'; //we have upper triangular in C++, but this is lower in fortran
   int N=M.n(), lda=N, nrhs=1, info;
-  dpotrs_(&uplo,&N, &nrhs, M.local_buffer(), &lda, r.local_data(), &lda, &info);
+  DPOTRS(&uplo,&N, &nrhs, M.local_buffer(), &lda, r.local_data(), &lda, &info);
   if(info<0) 
     _nlp->log->printf(hovError, "hiopKKTLinSysLowRank::solveWithFactors: dpotrs returned error %d\n", info);
 #ifdef DEEP_CHECKING

--- a/src/Optimization/hiopHessianLowRank.cpp
+++ b/src/Optimization/hiopHessianLowRank.cpp
@@ -568,7 +568,7 @@ void hiopHessianLowRank::factorizeV()
 
   int lwork=-1;//inquire sizes
   double Vwork_tmp;
-  dsytrf_(&uplo, &N, V->local_buffer(), &lda, _V_ipiv_vec, &Vwork_tmp, &lwork, &info);
+  DSYTRF(&uplo, &N, V->local_buffer(), &lda, _V_ipiv_vec, &Vwork_tmp, &lwork, &info);
   assert(info==0);
 
   lwork=(int)Vwork_tmp;
@@ -577,7 +577,7 @@ void hiopHessianLowRank::factorizeV()
     _V_work_vec=new hiopVectorPar(lwork);
   } else assert(_V_work_vec);
 
-  dsytrf_(&uplo, &N, V->local_buffer(), &lda, _V_ipiv_vec, _V_work_vec->local_data(), &lwork, &info);
+  DSYTRF(&uplo, &N, V->local_buffer(), &lda, _V_ipiv_vec, _V_work_vec->local_data(), &lwork, &info);
   
   if(info<0)
     nlp->log->printf(hovError, "hiopHessianLowRank::factorizeV error: %d argument to dsytrf has an illegal value\n", -info);
@@ -614,7 +614,7 @@ void hiopHessianLowRank::solveWithV(hiopVectorPar& rhs_s, hiopVectorPar& rhs_y)
   rhs.copyFromStarting(rhs_s,0);
   rhs.copyFromStarting(rhs_y,l);
 
-  dsytrs_(&uplo, &N, &one, V->local_buffer(), &lda, _V_ipiv_vec, rhs.local_data(), &N, &info);
+  DSYTRS(&uplo, &N, &one, V->local_buffer(), &lda, _V_ipiv_vec, rhs.local_data(), &N, &info);
 
   if(info<0) nlp->log->printf(hovError, "hiopHessianLowRank::solveWithV error: %d argument to dsytrf has an illegal value\n", -info);
   assert(info==0);
@@ -657,7 +657,7 @@ void hiopHessianLowRank::solveWithV(hiopMatrixDense& rhs)
 #ifdef DEEP_CHECKING
   assert(N==rhs.n()); 
 #endif
-  dsytrs_(&uplo, &N, &nrhs, V->local_buffer(), &lda, _V_ipiv_vec, rhs.local_buffer(), &ldb, &info);
+  DSYTRS(&uplo, &N, &nrhs, V->local_buffer(), &lda, _V_ipiv_vec, rhs.local_buffer(), &ldb, &info);
 
   if(info<0) nlp->log->printf(hovError, "hiopHessianLowRank::solveWithV error: %d argument to dsytrf has an illegal value\n", -info);
   assert(info==0);
@@ -1433,12 +1433,12 @@ void hiopHessianInvLowRank_obsolette::triangularSolve(const hiopMatrixDense& R, 
   char transA='T'; //to solve with an upper triangular, we force fortran to solve a transpose lower (see above)
   char diag  ='N'; //not a unit triangular
   double one=1.0; int lda=l, ldb=l;
-  dtrsm_(&side,&uplo,&transA,&diag,
-	 &l, //rows of rhs
-	 &k, //columns of rhs
-	 &one,
-	 Rbuf,&lda,
-	 rhsbuf, &ldb);
+  DTRSM(&side,&uplo,&transA,&diag,
+	&l, //rows of rhs
+	&k, //columns of rhs
+	&one,
+	Rbuf,&lda,
+	rhsbuf, &ldb);
   
 }
 
@@ -1458,12 +1458,12 @@ void hiopHessianInvLowRank_obsolette::triangularSolve(const hiopMatrixDense& R, 
   char transA='T'; //to solve with an upper triangular, we ask fortran to solve a transpose lower (see above)
   char diag  ='N'; //not a unit triangular
   double one=1.0; int lda=l, ldb=l, k=1;
-  dtrsm_(&side,&uplo,&transA,&diag,
-	 &l, //rows of rhs
-	 &k, //columns of rhs
-	 &one,
-	 Rbuf,&lda,
-	 rhsbuf, &ldb);
+  DTRSM(&side,&uplo,&transA,&diag,
+	&l, //rows of rhs
+	&k, //columns of rhs
+	&one,
+	Rbuf,&lda,
+	rhsbuf, &ldb);
 }
 void hiopHessianInvLowRank_obsolette::triangularSolveTrans(const hiopMatrixDense& R, hiopVectorPar& rhs)
 {
@@ -1481,12 +1481,12 @@ void hiopHessianInvLowRank_obsolette::triangularSolveTrans(const hiopMatrixDense
   char transA='N'; //to transpose-solve with an upper triangular, we ask fortran to perform a simple lower triangular solve (see above)
   char diag  ='N'; //not a unit triangular
   double one=1.0; int lda=l, ldb=l, k=1;
-  dtrsm_(&side,&uplo,&transA,&diag,
-	 &l, //rows of rhs
-	 &k, //columns of rhs
-	 &one,
-	 Rbuf,&lda,
-	 rhsbuf, &ldb);
+  DTRSM(&side,&uplo,&transA,&diag,
+	&l, //rows of rhs
+	&k, //columns of rhs
+	&one,
+	Rbuf,&lda,
+	rhsbuf, &ldb);
 }
 void hiopHessianInvLowRank_obsolette::growR(const int& lmem_curr, const int& lmem_max, const hiopVectorPar& STy, const double& sTy)
 {

--- a/src/Optimization/hiopKKTLinSys.cpp
+++ b/src/Optimization/hiopKKTLinSys.cpp
@@ -569,16 +569,16 @@ int hiopKKTLinSysLowRank::solveWithRefin(hiopMatrixDense& M, hiopVectorPar& rhs)
   //
   // 1. solve
   //
-  dposvx_(&FACT, &UPLO, &N, &NRHS,
-	  A, &LDA,
-	  AF, &LDAF,
-	  &EQUED,
-	  S,
-	  B, &LDB,
-	  X, &LDX,
-	  &RCOND, &FERR, &BERR, 
-	  WORK, IWORK,
-	  &INFO); 
+  DPOSVX(&FACT, &UPLO, &N, &NRHS,
+	 A, &LDA,
+	 AF, &LDAF,
+	 &EQUED,
+	 S,
+	 B, &LDB,
+	 X, &LDX,
+	 &RCOND, &FERR, &BERR, 
+	 WORK, IWORK,
+	 &INFO); 
   //printf("INFO ===== %d  RCOND=%g  FERR=%g   BERR=%g  EQUED=%c\n", INFO, RCOND, FERR, BERR, EQUED);
   //
   // 2. check residual
@@ -615,21 +615,21 @@ int hiopKKTLinSysLowRank::solveWithRefin(hiopMatrixDense& M, hiopVectorPar& rhs)
 
       int _V_ipiv_vec[1000]; double _V_work_vec[1000]; int lwork=1000;
       M.copyFrom(*Aref);
-      dsytrf_(&UPLO, &N, M.local_buffer(), &LDA, _V_ipiv_vec, _V_work_vec, &lwork, &info);
+      DSYTRF(&UPLO, &N, M.local_buffer(), &LDA, _V_ipiv_vec, _V_work_vec, &lwork, &info);
       assert(info==0);
-      dsytrs_(&UPLO, &N, &NRHS, M.local_buffer(), &LDA, _V_ipiv_vec, resid.local_data(), &LDB, &info);
+      DSYTRS(&UPLO, &N, &NRHS, M.local_buffer(), &LDA, _V_ipiv_vec, resid.local_data(), &LDB, &info);
       assert(info==0);
     } else { //iter refin based on symmetric positive definite factorization+solve 
       M.copyFrom(*Aref);
       //for(int i=0; i<4; i++) M.local_data()[i][i] +=1e-8;
-      dpotrf_(&UPLO, &N, M.local_buffer(), &LDA, &info);
+      DPOTRF(&UPLO, &N, M.local_buffer(), &LDA, &info);
       if(info>0)
 	nlp->log->printf(hovError, "hiopKKTLinSysLowRank::factorizeMat: dpotrf (Chol fact) detected %d minor being indefinite.\n", info);
       else
 	if(info<0) 
 	  nlp->log->printf(hovError, "hiopKKTLinSysLowRank::factorizeMat: dpotrf returned error %d\n", info);
       
-      dpotrs_(&UPLO,&N, &NRHS, M.local_buffer(), &LDA, resid.local_data(), &LDA, &info);
+      DPOTRS(&UPLO,&N, &NRHS, M.local_buffer(), &LDA, resid.local_data(), &LDA, &info);
       if(info<0) 
 	nlp->log->printf(hovError, "hiopKKTLinSysLowRank::solveWithFactors: dpotrs returned error %d\n", info);
     }
@@ -709,16 +709,16 @@ int hiopKKTLinSysLowRank::solve(hiopMatrixDense& M, hiopVectorPar& rhs)
   int* IWORK = new int[N];
   int INFO; 
 
-  dposvx_(&FACT, &UPLO, &N, &NRHS,
-	  A, &LDA,
-	  AF, &LDAF,
-	  &EQUED,
-	  S,
-	  B, &LDB,
-	  X, &LDX,
-	  &RCOND, &FERR, &BERR, 
-	  WORK, IWORK,
-	  &INFO); 
+  DPOSVX(&FACT, &UPLO, &N, &NRHS,
+	 A, &LDA,
+	 AF, &LDAF,
+	 &EQUED,
+	 S,
+	 B, &LDB,
+	 X, &LDX,
+	 &RCOND, &FERR, &BERR, 
+	 WORK, IWORK,
+	 &INFO); 
 
   rhs.copyFrom(S);
   nlp->log->write("Scaling S", rhs, hovSummary);


### PR DESCRIPTION
This commit modifies the CMake build scripts to use the FortranCInterface module to figure out the Fortran name mangling pattern during configuration.  This commit modifies the corresponding source code to use the CMake generated macros.