### PR TITLE
Quick fix in dev/NewtonMDS cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ if(HIOP_USE_GPU)
 
 
   set(HIOP_CUDA_LIBRARIES "-lculibos -lcublas -lcublasLt -lnvblas -lcusparse -lcudart -lcudadevrt")
-  find_package(CUDA)
+  find_package(CUDA 10.1)
   
   if(HIOP_CUDA_LIB_DIR)
     set(HIOP_CUDA_LIBRARIES "-L${HIOP_CUDA_LIB_DIR} ${HIOP_CUDA_LIBRARIES}")
@@ -65,7 +65,7 @@ if(HIOP_USE_GPU)
   message("HiOp GPU libs: '${MAGMA_LIBRARIES} ${HIOP_CUDA_LIBRARIES}'") 
   message("HiOp GPU includes: '${MAGMA_INCLUDE} ${HIOP_CUDA_INCLUDE}'") 
   include_directories(${MAGMA_INCLUDE} ${HIOP_CUDA_INCLUDE})
-  set(HIOP_MATH_LIBRARIES "${MAGMA_LIBRARIES} ${HIOP_CUDA_LIBRARIES} ${HIOP_MATH_LIBRARIES}")
+  set(HIOP_MATH_LIBRARIES ${MAGMA_LIBRARIES} ${HIOP_CUDA_LIBRARIES} ${HIOP_MATH_LIBRARIES})
 endif(HIOP_USE_GPU)
 
 if(HIOP_USE_GPU)
@@ -88,7 +88,7 @@ find_package(OpenMP)
 if(NOT DEFINED LAPACK_LIBRARIES)
   # in case the toolchain defines them
   find_package(LAPACK REQUIRED)
-  set(HIOP_MATH_LIBRARIES "${LAPACK_LIBRARIES} ${HIOP_MATH_LIBRARIES}")
+  set(HIOP_MATH_LIBRARIES ${LAPACK_LIBRARIES} ${HIOP_MATH_LIBRARIES})
 endif(NOT DEFINED LAPACK_LIBRARIES)
 string(STRIP "${HIOP_MATH_LIBRARIES}" HIOP_MATH_LIBRARIES)
 


### PR DESCRIPTION
- Removed redundant `"` in library list that caused linking drivers to HiOp library to fail. This issue may be dependent on CMake version.
- Set minimum CUDA version to 10.1, since HiOp depends on cublasLt, which is available only as of that version.

Fixes issue #16 