### PR TITLE
primal-dual restart and support for outputing duals variables

### DIFF
--- a/src/Drivers/nlpMDSForm_ex4.hpp
+++ b/src/Drivers/nlpMDSForm_ex4.hpp
@@ -394,15 +394,19 @@ public:
   }
   bool get_starting_point(const long long& n, const long long& m,
 				  double* x0,
-				  bool duals_avail,
+				  bool& duals_avail,
 				  double* z_bndL0, double* z_bndU0,
 				  double* lambda0)
   {
     if(sol_x_ && sol_zl_ && sol_zu_ && sol_lambda_) {
+
+      duals_avail = true;
+	    
       memcpy(x0, sol_x_, n*sizeof(double));
       memcpy(z_bndL0, sol_zl_, n*sizeof(double));
       memcpy(z_bndU0, sol_zu_, n*sizeof(double));
       memcpy(lambda0, sol_lambda_, m*sizeof(double));
+
     } else {
       duals_avail = false;
       return false;

--- a/src/Drivers/nlpMDSForm_ex4.hpp
+++ b/src/Drivers/nlpMDSForm_ex4.hpp
@@ -85,6 +85,10 @@ public:
     delete[] _buf_y;
     delete Md;
     delete Q;
+    delete[] sol_lambda_;
+    delete[] sol_zu_;
+    delete[] sol_zl_;
+    delete[] sol_x_;
   }
   
   bool get_prob_sizes(long long& n, long long& m)

--- a/src/Drivers/nlpMDSForm_ex4.hpp
+++ b/src/Drivers/nlpMDSForm_ex4.hpp
@@ -38,6 +38,7 @@
  * Coding of the problem in MDS HiOp input: order of variables need to be [x,s,y] 
  * since [x,s] are the so-called sparse variables and y are the dense variables
  */
+
 class Ex4 : public hiop::hiopInterfaceMDS
 {
 public:
@@ -47,7 +48,7 @@ public:
   }
   
   Ex4(int ns_, int nd_)
-    : ns(ns_)
+    : ns(ns_), sol_x_(NULL), sol_zl_(NULL), sol_zu_(NULL), sol_lambda_(NULL)
   {
     if(ns<0) {
       ns = 0;
@@ -383,19 +384,76 @@ public:
     }
     return true;
   }
-  
+
+  /* Implementation of the primal starting point specification */
   bool get_starting_point(const long long& global_n, double* x0)
   {
     assert(global_n==2*ns+nd); 
     for(int i=0; i<global_n; i++) x0[i]=1.;
     return true;
   }
+  bool get_starting_point(const long long& n, const long long& m,
+				  double* x0,
+				  bool duals_avail,
+				  double* z_bndL0, double* z_bndU0,
+				  double* lambda0)
+  {
+    if(sol_x_ && sol_zl_ && sol_zu_ && sol_lambda_) {
+      memcpy(x0, sol_x_, n*sizeof(double));
+      memcpy(z_bndL0, sol_zl_, n*sizeof(double));
+      memcpy(z_bndU0, sol_zu_, n*sizeof(double));
+      memcpy(lambda0, sol_lambda_, m*sizeof(double));
+    } else {
+      duals_avail = false;
+      return false;
+    }
+    return true;
+  }
 
+  /* The public methods below are not part of hiopInterface. They are a proxy
+   * for user's (front end) code to set solutions from a previous solve. 
+   *
+   * Same behaviour can be achieved internally (in this class ) if desired by 
+   * overriding @solution_callback and @get_starting_point
+   */
+  void set_solution_primal(const double* x)
+  {
+    int n=2*ns+nd;
+    if(NULL == sol_x_) {
+      sol_x_ = new double[n];
+    }
+    memcpy(sol_x_, x, n*sizeof(double));
+  }
+  void set_solution_duals(const double* zl, const double* zu, const double* lambda)
+  {
+    int m=ns+3*haveIneq;
+    int n=2*ns+nd;
+    if(NULL == sol_zl_) {
+      sol_zl_ = new double[n];
+    }
+    memcpy(sol_zl_, zl, n*sizeof(double));
+    
+    if(NULL == sol_zu_) {
+      sol_zu_ = new double[n];
+    }
+    memcpy(sol_zu_, zu, n*sizeof(double));
+	
+    if(NULL == sol_lambda_) {
+      sol_lambda_ = new double[m];
+    }
+    memcpy(sol_lambda_, lambda, m*sizeof(double));
+  }
 protected:
   int ns, nd;
   hiop::hiopMatrixDense *Q, *Md;
   double* _buf_y;
   bool haveIneq;
+
+  /* Internal buffers to store primal-dual solution */
+  double* sol_x_;
+  double* sol_zl_;
+  double* sol_zu_;
+  double* sol_lambda_;
 };
 
 class Ex4OneCallCons : public Ex4

--- a/src/Drivers/nlpMDS_ex4_driver.cpp
+++ b/src/Drivers/nlpMDS_ex4_driver.cpp
@@ -104,14 +104,15 @@ int main(int argc, char **argv)
   double obj_value=-1e+20;
   hiopSolveStatus status;
 
-  hiopInterfaceMDS* nlp_interface;
+  //user's NLP -> implementation of hiop::hiopInterfaceMDS
+  Ex4* my_nlp;
   if(one_call_cons) {
-    nlp_interface = new Ex4OneCallCons(n_sp, n_de);
+    my_nlp = new Ex4OneCallCons(n_sp, n_de);
   } else {
-    nlp_interface = new Ex4(n_sp, n_de);
+    my_nlp = new Ex4(n_sp, n_de);
   }
 
-  hiopNlpMDS nlp(*nlp_interface);
+  hiopNlpMDS nlp(*my_nlp);
 
   nlp.options->SetStringValue("dualsUpdateType", "linear");
   nlp.options->SetStringValue("dualsInitialization", "zero");
@@ -122,11 +123,13 @@ int main(int argc, char **argv)
 
   nlp.options->SetIntegerValue("verbosity_level", 3);
   nlp.options->SetNumericValue("mu0", 1e-1);
+  nlp.options->SetNumericValue("tolerance", 1e-5);
+
+    nlp.options->SetIntegerValue("verbosity_level", 10);
+  
   hiopAlgFilterIPMNewton solver(&nlp);
   status = solver.run();
   obj_value = solver.getObjective();
-
-  delete nlp_interface;
   
   if(status<0) {
     if(rank==0)
@@ -139,6 +142,61 @@ int main(int argc, char **argv)
     if(fabs(obj_value-(-4.999509728895e+01))>1e-6) {
       printf("selfcheck: objective mismatch for Ex4 MDS problem with 400 sparse variables and 100 "
 	     "dense variables did. BTW, obj=%18.12e was returned by HiOp.\n", obj_value);
+      //return -1;
+    }
+  } else {
+    if(rank==0) {
+      printf("Optimal objective: %22.14e. Solver status: %d\n", obj_value, status);
+    }
+  }
+
+  ////////////////////////////////////////////////////////////////////////////////////////////////////
+  // Reoptimize
+  // -----------
+  // 1. get solution from previous solve
+  // 2. give it to the (user's) nlp, which will provide HiOp a full primal-dual restart via
+  // 'get_starting_point' callback
+  // Normally, the user would also change her nlp between steps 1 and 2 above, for example, different
+  // bounds on variables or on inequalities
+  ////////////////////////////////////////////////////////////////////////////////////////////////////
+
+  long long n_vars, n_cons;
+  my_nlp->get_prob_sizes(n_vars, n_cons);
+
+  double x[n_vars];
+  double zl[n_vars];
+  double zu[n_vars];
+  double lambdas[n_cons];
+
+  solver.getSolution(x);
+  solver.getDualSolutions(zl, zu, lambdas);
+
+  my_nlp->set_solution_primal(x);
+  my_nlp->set_solution_duals(zl, zu, lambdas);
+
+  //
+  // set options for solver re-optimization
+  //
+  
+  //less agressive log-barrier parameter is always a safe bet
+  nlp.options->SetNumericValue("mu0", 1e-6);
+  nlp.options->SetNumericValue("tolerance", 1e-8);
+  nlp.options->SetIntegerValue("verbosity_level", 10);
+
+  //solve
+  status = solver.run();
+  obj_value = solver.getObjective();
+  
+  if(status<0) {
+    if(rank==0)
+      printf("solver returned negative solve status: %d (with objective is %18.12e)\n", status, obj_value);
+    return -1;
+  }
+
+  if(selfCheck) {
+    if(fabs(obj_value-(-4.999509728895e+01))>1e-6) {
+      printf("selfcheck: objective mismatch for Ex4 MDS problem with 400 sparse variables and 100 "
+	     "dense variables did. BTW, obj=%18.12e was returned by HiOp.\n", obj_value);
       return -1;
     }
   } else {
@@ -146,6 +204,10 @@ int main(int argc, char **argv)
       printf("Optimal objective: %22.14e. Solver status: %d\n", obj_value, status);
     }
   }
+
+  
+  delete my_nlp;
+  
 #ifdef HIOP_USE_MAGMA
   magma_finalize();
 #endif

--- a/src/Drivers/nlpMDS_ex4_driver.cpp
+++ b/src/Drivers/nlpMDS_ex4_driver.cpp
@@ -125,8 +125,6 @@ int main(int argc, char **argv)
   nlp.options->SetNumericValue("mu0", 1e-1);
   nlp.options->SetNumericValue("tolerance", 1e-5);
 
-    nlp.options->SetIntegerValue("verbosity_level", 10);
-  
   hiopAlgFilterIPMNewton solver(&nlp);
   status = solver.run();
   obj_value = solver.getObjective();
@@ -181,8 +179,12 @@ int main(int argc, char **argv)
   //less agressive log-barrier parameter is always a safe bet
   nlp.options->SetNumericValue("mu0", 1e-6);
   nlp.options->SetNumericValue("tolerance", 1e-8);
-  nlp.options->SetIntegerValue("verbosity_level", 10);
 
+  //nlp.options->SetIntegerValue("verbosity_level", 7);
+
+  //nlp.options->SetNumericValue("kappa1", 1e-15);
+  //nlp.options->SetNumericValue("kappa2", 1e-15);
+  
   //solve
   status = solver.run();
   obj_value = solver.getObjective();

--- a/src/Drivers/nlpMDS_ex4_driver.cpp
+++ b/src/Drivers/nlpMDS_ex4_driver.cpp
@@ -135,19 +135,6 @@ int main(int argc, char **argv)
     return -1;
   }
 
-  // this is used for testing when the driver is in '-selfcheck' mode
-  if(selfCheck) {
-    if(fabs(obj_value-(-4.999509728895e+01))>1e-6) {
-      printf("selfcheck: objective mismatch for Ex4 MDS problem with 400 sparse variables and 100 "
-	     "dense variables did. BTW, obj=%18.12e was returned by HiOp.\n", obj_value);
-      //return -1;
-    }
-  } else {
-    if(rank==0) {
-      printf("Optimal objective: %22.14e. Solver status: %d\n", obj_value, status);
-    }
-  }
-
   ////////////////////////////////////////////////////////////////////////////////////////////////////
   // Reoptimize
   // -----------

--- a/src/Interface/hiopInterface.hpp
+++ b/src/Interface/hiopInterface.hpp
@@ -246,7 +246,7 @@ public:
    */
   virtual bool get_starting_point(const long long& n, const long long& m,
 				  double* x0,
-				  bool duals_avail,
+				  bool& duals_avail,
 				  double* z_bndL0, double* z_bndU0,
 				  double* lambda0)
   {

--- a/src/Interface/hiopInterface.hpp
+++ b/src/Interface/hiopInterface.hpp
@@ -190,7 +190,8 @@ public:
   /** pass the communicator, defaults to MPI_COMM_WORLD (dummy for non-MPI builds)  */
   virtual bool get_MPI_comm(MPI_Comm& comm_out) { comm_out=MPI_COMM_WORLD; return true;}
 
-  /**  column partitioning specification for distributed memory vectors 
+  /**  
+   * Column partitioning specification for distributed memory vectors 
   *  Process P owns cols[P], cols[P]+1, ..., cols[P+1]-1, P={0,1,...,NumRanks}.
   *  Example: for a vector x of 6 elements on 3 ranks, the col partitioning is cols=[0,2,4,6].
   *  The caller manages memory associated with 'cols', array of size NumRanks+1 
@@ -199,13 +200,26 @@ public:
     return false; //defaults to serial 
   }
 
-  /* Method providing a primal starting point. This point is subject to internal adjustments in hiOP.
-   * The method returns true (and populate x0) or return false, in which case hiOP will use set 
-   * x0 to all zero (still subject to internal adjustement).
+  /**
+   * Method providing a primal or primal-dual starting point. This point is subject to internal adjustments 
+   * in HiOp.
+   * The method returns true (and populates x0) or returns false, in which case HiOp will internally set 
+   * x0 to all zero (still subject to internal adjustements).
    *
-   * TODO: provide API for a full, primal-dual restart. 
+   * If the user (implementer of this method) has good estimates of the duals of bound constraints and 
+   * inequality and equality constraints, the 'duals_avail' should be set to true and the duals should
+   * be provided in 'zL0', 'zU0', and 'lambda', respectively. 
+   * 
+   * TODO: how to set/enable primal-dual restart ?
    */
-  virtual bool get_starting_point(const long long&n, double* x0) { return false; }
+  virtual bool get_starting_point(const long long& n, const long long& m,
+				  double* x0,
+				  bool duals_avail,
+				  double* zL0, double* zU0,
+				  bool lambdas_avail, double* lambda)
+  {
+    return false;
+  }
 
   /** callback for the optimal solution.
    *  Note that:
@@ -222,7 +236,8 @@ public:
 				 const double* lambda,
 				 double obj_value) { };
 
-  /** Callback for the iteration: at the end of each iteration. This is NOT called during the line-searches.
+  /** 
+   * Callback for the (end of) iteration. This is not called during the line-searches.
    * Note: all the notes for @solution_callback apply.
    */
   virtual bool iterate_callback(int iter, double obj_value,

--- a/src/Interface/hiopInterface.hpp
+++ b/src/Interface/hiopInterface.hpp
@@ -201,31 +201,66 @@ public:
   }
 
   /**
-   * Method providing a primal or primal-dual starting point. This point is subject to internal adjustments 
-   * in HiOp.
-   * The method returns true (and populates x0) or returns false, in which case HiOp will internally set 
-   * x0 to all zero (still subject to internal adjustements).
+   * Method provides a primal or starting point. This point is subject to internal adjustments.
    *
-   * If the user (implementer of this method) has good estimates of the duals of bound constraints and 
-   * inequality and equality constraints, the 'duals_avail' should be set to true and the duals should
-   * be provided in 'zL0', 'zU0', and 'lambda', respectively. 
+   * Note: Avoid using this method since it will removed in a future release and replaced with
+   * the same-name method below.
+   *
+   * The method returns true (and populates x0) or returns false, in which case HiOp will 
+   * internally set x0 to all zero (still subject to internal adjustements).
+   *
+   * By default, HiOp first calls the overloaded primal-dual starting point specification
+   * method 
+   * @get_starting_point(const long long&, const long long&, double*, 
+   *                     bool, double*, double*, double*)
+   * If the above returns 'false', HiOp will then call this method.
+   *
+   */
+  virtual bool get_starting_point(const long long&n, double* x0)
+  {
+    return false;
+  }
+  
+  /**
+   * Method provides a primal or a primal-dual primal-dual starting point This point is subject 
+   * to internal adjustments in HiOp.
+   *
+   * If the user (implementer of this method) has good estimates only of the primal variables,
+   * the method should populates 'x0' with these values and return true. The 'duals_avail' 
+   * should be set to false; internally, HiOp will not access 'z_bndL0', 'z_bndU0', and 
+   * 'lambda0'.
+   *
+   * If the user (implementer of this method) has good estimates of the duals of bound constraints 
+   * and of inequality and equality constraints, 'duals_avail' boolean argument should 
+   * be set to true and the respective duals should be provided (in 'z_bndL0' and 'z_bndU0' and 
+   * 'lambda0', respectively). In this case, the user should also set 'x0' to his/her estimate 
+   * of primal variables and return 'true'.
+   *
+   * If user does not have high-quality (primal or primal-dual) starting points, the method should 
+   * return false (see note below).
+   *
+   * Note: when this method returns false, HiOp will call the overload
+   * @get_starting_point(long long&, double*)
+   * This behaviour is for backward compatibility and will be removed in a future release.
    * 
-   * TODO: how to set/enable primal-dual restart ?
    */
   virtual bool get_starting_point(const long long& n, const long long& m,
 				  double* x0,
 				  bool duals_avail,
-				  double* zL0, double* zU0,
-				  bool lambdas_avail, double* lambda)
+				  double* z_bndL0, double* z_bndU0,
+				  double* lambda0)
   {
     return false;
   }
 
-  /** callback for the optimal solution.
-   *  Note that:
+  /** 
+   * Callback method called by HiOp when the optimal solution is reached. User should use it
+   * to retrieve primal-dual optimal solution. 
+   * 
    *   i. x, z_L, z_U contain only the array slice that is local to the calling process
-   *  ii. g, lambda are replicated across all processes, which means they can be used as-is, without reducing them.
-   * iii. all other scalar quantities are replicated across all processes, which means they can be used as-is, 
+   *  ii. g, lambda are replicated across all processes, which means they can be used as-is, 
+   * without reducing them.
+   * iii. all other scalars are replicated across all processes, thus, they can be used as-is, 
    * without reducing them.
    */
   virtual void solution_callback(hiopSolveStatus status,

--- a/src/LinAlg/hiopVector.cpp
+++ b/src/LinAlg/hiopVector.cpp
@@ -332,7 +332,7 @@ void hiopVectorPar::componentDiv ( const hiopVector& v_ )
   for(int i=0; i<n_local; i++) data[i] /= v.data[i];
 }
 
-void hiopVectorPar::componentDiv_p_selectPattern( const hiopVector& v_, const hiopVector& ix_)
+void hiopVectorPar::componentDiv_w_selectPattern( const hiopVector& v_, const hiopVector& ix_)
 {
   const hiopVectorPar& v = dynamic_cast<const hiopVectorPar&>(v_);
   const hiopVectorPar& ix= dynamic_cast<const hiopVectorPar&>(ix_);

--- a/src/LinAlg/hiopVector.hpp
+++ b/src/LinAlg/hiopVector.hpp
@@ -119,7 +119,7 @@ public:
   /* Elements of this that corespond to nonzeros in ix are divided by elements of v.
    * The rest of elements of this are set to zero.
    */
-  virtual void componentDiv_p_selectPattern( const hiopVector& v, const hiopVector& ix) = 0;
+  virtual void componentDiv_w_selectPattern( const hiopVector& v, const hiopVector& ix) = 0;
   /** Scale each element of this  by the constant alpha */
   virtual void scale( double alpha ) = 0;
   /** this += alpha * x */
@@ -160,7 +160,9 @@ public:
 				 double kappa1, double kappa2) = 0;
   /* max{a\in(0,1]| x+ad >=(1-tau)x} */
   virtual double fractionToTheBdry(const hiopVector& dx, const double& tau) const = 0;
-  virtual double fractionToTheBdry_w_pattern(const hiopVector& dx, const double& tau, const hiopVector& ix) const = 0;
+  virtual double fractionToTheBdry_w_pattern(const hiopVector& dx,
+					     const double& tau,
+					     const hiopVector& ix) const = 0;
   /** Entries corresponding to zeros in ix are set to zero */
   virtual void selectPattern(const hiopVector& ix) = 0;
   /** checks whether entries in this matches pattern in ix */
@@ -172,7 +174,8 @@ public:
   //virtual hiopVector* new_copy() const = 0;
 
   /* dual adjustment -> see hiopIterate::adjustDuals_primalLogHessian */
-  virtual void adjustDuals_plh(const hiopVector& x, const hiopVector& ix, const double& mu, const double& kappa)=0;
+  virtual void adjustDuals_plh(const hiopVector& x, const hiopVector& ix,
+			       const double& mu, const double& kappa)=0;
 
   /* check for nans in the local vector */
   virtual bool isnan() const = 0;
@@ -226,7 +229,7 @@ public:
   virtual double onenorm_local() const; 
   virtual void componentMult( const hiopVector& v );
   virtual void componentDiv ( const hiopVector& v );
-  virtual void componentDiv_p_selectPattern( const hiopVector& v, const hiopVector& ix);
+  virtual void componentDiv_w_selectPattern( const hiopVector& v, const hiopVector& ix);
   virtual void scale( double alpha );
   /** this += alpha * x */
   virtual void axpy  ( double alpha, const hiopVector& x );

--- a/src/Optimization/hiopAlgFilterIPM.cpp
+++ b/src/Optimization/hiopAlgFilterIPM.cpp
@@ -558,31 +558,58 @@ bool hiopAlgFilterIPMBase::evalNlp_derivOnly(hiopIterate& iter,
 /* returns the objective value; valid only after 'run' method has been called */
 double hiopAlgFilterIPMBase::getObjective() const
 {
-  if(solver_status_==NlpSolve_IncompleteInit || solver_status_ == NlpSolve_SolveNotCalled)
-    nlp->log->printf(hovError, "getObjective: hiOp did not initialize entirely or the 'run' function was not called.");
-  if(solver_status_==NlpSolve_Pending)
-    nlp->log->printf(hovWarning, "getObjective: hiOp does not seem to have completed yet. The objective value returned may not be optimal.");
+  if(solver_status_==NlpSolve_IncompleteInit || solver_status_ == NlpSolve_SolveNotCalled) {
+    nlp->log->
+      printf(hovError, "getObjective: HiOp did not initialize entirely or the 'run' function was not called.");
+  }
+  if(solver_status_==NlpSolve_Pending) {
+    nlp->log->
+      printf(hovWarning, "getObjective: HiOp has not completed and objective value may not be optimal.");
+  }
   return nlp->user_obj(_f_nlp);
 }
 /* returns the primal vector x; valid only after 'run' method has been called */
 void hiopAlgFilterIPMBase::getSolution(double* x) const
 {
-  if(solver_status_==NlpSolve_IncompleteInit || solver_status_ == NlpSolve_SolveNotCalled)
-    nlp->log->printf(hovError, "getSolution: hiOp did not initialize entirely or the 'run' function was not called.");
-  if(solver_status_==NlpSolve_Pending)
-    nlp->log->printf(hovWarning, "getSolution: hiOp have not completed yet. The primal vector returned may not be optimal.");
-
+  if(solver_status_==NlpSolve_IncompleteInit || solver_status_ == NlpSolve_SolveNotCalled) {
+    nlp->log->
+      printf(hovError, "getSolution: HiOp did not initialize entirely or the 'run' function was not called.");
+  }
+  if(solver_status_==NlpSolve_Pending) {
+    nlp->log->
+      printf(hovWarning, "getSolution: HiOp has not completed yet and solution returned may not be optimal.");
+  }
   hiopVectorPar& it_x = dynamic_cast<hiopVectorPar&>(*it_curr->get_x());
   //it_curr->get_x()->copyTo(x);
   nlp->user_x(it_x, x);
 }
 
+void hiopAlgFilterIPMBase::getDualSolutions(double* zl_a, double* zu_a, double* lambda_a)
+{
+  if(solver_status_==NlpSolve_IncompleteInit || solver_status_ == NlpSolve_SolveNotCalled) {
+    nlp->log->
+      printf(hovError,
+	     "getDualSolutions: HiOp did not initialize entirely or the 'run' function was not called.");
+  }
+  if(solver_status_==NlpSolve_Pending) {
+    nlp->log->
+      printf(hovWarning,
+	     "getSolution: HiOp has not completed yet and solution returned may not be optimal.");
+  }
+  hiopVectorPar& zl = dynamic_cast<hiopVectorPar&>(*it_curr->get_zl());
+  hiopVectorPar& zu = dynamic_cast<hiopVectorPar&>(*it_curr->get_zu());
+
+  nlp->get_dual_solutions(*it_curr, zl_a, zu_a, lambda_a);  
+}
+  
 int hiopAlgFilterIPMBase::getNumIterations() const
 {
   if(solver_status_==NlpSolve_IncompleteInit || solver_status_ == NlpSolve_SolveNotCalled)
-    nlp->log->printf(hovError, "getNumIterations: hiOp did not initialize entirely or the 'run' function was not called.");
+    nlp->log->
+      printf(hovError, "getNumIterations: HiOp did not initialize or the 'run' function was not called.");
   if(solver_status_==NlpSolve_Pending)
-    nlp->log->printf(hovWarning, "getNumIterations: hiOp does not seem to have completed yet. The objective value returned may not be optimal.");
+    nlp->log->
+      printf(hovWarning, "getNumIterations: HiOp has not completed upon this call of 'getNumIterations'");
   return nlp->runStats.nIter;
 }
 

--- a/src/Optimization/hiopAlgFilterIPM.cpp
+++ b/src/Optimization/hiopAlgFilterIPM.cpp
@@ -201,7 +201,8 @@ void hiopAlgFilterIPMBase::reInitializeNlpObjects()
     if(NULL==nlpd) {
       dualsUpdateType = 1;
       dualsInitializ = 1;
-      nlp->log->printf(hovWarning, "Option dualsUpdateType=lsq not compatible with the requested NLP formulation and will "
+      nlp->log->printf(hovWarning,
+		       "Option dualsUpdateType=lsq not compatible with the requested NLP formulation and will "
 		       "be set to dualsUpdateType=linear together with dualsInitialization=zero\n");
     }
   }
@@ -276,10 +277,16 @@ startingProcedure(hiopIterate& it_ini,
 		  double &f, hiopVector& c, hiopVector& d, 
 		  hiopVector& gradf,  hiopMatrix& Jac_c,  hiopMatrix& Jac_d)
 {
-  if(!nlp->get_starting_point(*it_ini.get_x())) {
+  bool duals_avail = false;  
+  if(!nlp->get_starting_point(*it_ini.get_x(),
+			      duals_avail,
+			      *it_ini.get_zl(), *it_ini.get_zu(),
+			      *it_ini.get_yc(), *it_ini.get_yd())) {
+
     nlp->log->printf(hovWarning, "user did not provide a starting point; will be set to all zeros\n");
     it_ini.get_x()->setToZero();
-    //assert(false); return false;
+    //in case user wrongly set this to true when he/she returned false
+    duals_avail = false;
   }
   
   nlp->runStats.tmSolverInternal.start();
@@ -292,12 +299,16 @@ startingProcedure(hiopIterate& it_ini,
 
   // before evaluating the NLP, make sure that iterate, including dual variables are initialized
   // to zero; many of these will be updated later in this method, but we want to make sure
-  // the user's NLP evaluator functions, in particular Hessian of the Lagrangian, receives
-  // initialized arrays
-  // initialization for zl, zu, vl, vu
-  it_ini.setBoundsDualsToConstant(1.);
-  // initialization for yc and yd
-  it_ini.setEqualityDualsToConstant(0.);
+  // that the user's NLP evaluator functions, in particular the Hessian of the Lagrangian,
+  // receives initialized arrays
+
+  
+  if(!duals_avail) {
+    // initialization for yc and yd
+    it_ini.setEqualityDualsToConstant(0.);
+  } else {
+    // yc and yd were provided by the user
+  }
   
   if(!this->evalNlp(it_ini, f, c, d, gradf, Jac_c, Jac_d, *_Hess_Lagr)) {
     nlp->log->printf(hovError, "Failure in evaluating user provided NLP functions.");
@@ -314,9 +325,20 @@ startingProcedure(hiopIterate& it_ini,
 
   it_ini.determineSlacks();
 
-  it_ini.setBoundsDualsToConstant(1.);
+  if(!duals_avail) {
+    // initialization for zl, zu, vl, vu
+    it_ini.setBoundsDualsToConstant(1.);
+  } else {
+    // zl and zu were provided by the user
 
-  if(0==dualsInitializ) {
+    // compute vl and vu from vl = mu e ./ sdl and vu = mu e ./ sdu
+    // sdl and sdu were initialized above in 'determineSlacks'
+    
+    it_ini.determineDualsBounds_d(mu0);
+  }
+
+  if(!duals_avail) {
+    if(0==dualsInitializ) {
     //LSQ-based initialization of yc and yd
 
     //is the dualsUpdate already the LSQ-based updater?
@@ -331,10 +353,14 @@ startingProcedure(hiopIterate& it_ini,
     updater->computeInitialDualsEq(it_ini, gradf, Jac_c, Jac_d);
 
     if(deleteUpdater) delete updater;
-  } else {
-    it_ini.setEqualityDualsToConstant(0.);
+    } else {
+      it_ini.setEqualityDualsToConstant(0.);
+    }
+  } // end of if(!duals_avail)
+  else {
+    // duals eq ('yc' and 'yd') were provided by the user 
   }
-
+  
   nlp->log->write("Using initial point:", it_ini, hovIteration);
   nlp->runStats.tmStartingPoint.stop();
   nlp->runStats.tmSolverInternal.stop();

--- a/src/Optimization/hiopAlgFilterIPM.cpp
+++ b/src/Optimization/hiopAlgFilterIPM.cpp
@@ -401,8 +401,8 @@ evalNlp(hiopIterate& iter,
     return false;
   }
 
-  nlp->log->write("Eq   body c:", c, hovFcnEval);
-  nlp->log->write("Ineq body d:", d, hovFcnEval);
+  //nlp->log->write("Eq   body c:", c, hovFcnEval);
+  //nlp->log->write("Ineq body d:", d, hovFcnEval);
   
   //bret = nlp->eval_Jac_c    (x, new_x, Jac_c);           assert(bret);
   //bret = nlp->eval_Jac_d    (x, new_x, Jac_d);           assert(bret);

--- a/src/Optimization/hiopAlgFilterIPM.hpp
+++ b/src/Optimization/hiopAlgFilterIPM.hpp
@@ -80,7 +80,8 @@ public:
   double getObjective() const;
   /* returns the primal vector x; valid only after 'run' method has been called */
   void getSolution(double* x) const;
-  /* returns the status of the solver */
+  /* returns dual solutions; valid only after 'run' method has been called */
+  void getDualSolutions(double* zl, double* zu, double* lambda);
   /* returns the status of the solver */
   inline hiopSolveStatus getSolveStatus() const { return solver_status_; }
   /* returns the number of iterations */
@@ -162,7 +163,8 @@ protected:
 
   /** Algorithms's working quantities */  
   double _mu, _tau, _alpha_primal, _alpha_dual;
-  //initialized to 1e4*max{1,\theta(x_0)} and used in the filter as an upper acceptability limit for infeasibility
+  //initialized to 1e4*max{1,\theta(x_0)} and used in the filter as an upper acceptability
+  //limit for infeasibility
   double theta_max; 
   //1e-4*max{1,\theta(x_0)} used in the switching condition during the line search
   double theta_min;

--- a/src/Optimization/hiopIterate.hpp
+++ b/src/Optimization/hiopIterate.hpp
@@ -61,26 +61,36 @@ public:
   hiopIterate(const hiopNlpFormulation* nlp);
   virtual ~hiopIterate();
 
-  //virtual void projectPrimalsIntoBounds(double kappa1, double kappa2);
   virtual void projectPrimalsXIntoBounds(double kappa1, double kappa2);
   virtual void projectPrimalsDIntoBounds(double kappa1, double kappa2);
   virtual void setBoundsDualsToConstant(const double& v);
   virtual void setEqualityDualsToConstant(const double& v);
-  /** computes the slacks given the primals: sxl=x-xl, sxu=xu-x, and similar 
-   *  for sdl and sdu  */
+  /** 
+   * Computes the slacks given the primals: sxl=x-xl, sxu=xu-x, and similar 
+   *  for sdl and sdu.
+   */
   virtual void determineSlacks();
 
+  /** 
+   * Computes duals for bounds on d, namely vl and vu from vl=mu e/sdl and vu = mu e/sdu. 
+   * Assumes sdl and sdu are available/computed previously.
+   */
+  virtual void determineDualsBounds_d(const double& mu);
+  
   /* max{a\in(0,1]| x+ad >=(1-tau)x} */
-  bool fractionToTheBdry(const hiopIterate& dir, const double& tau, double& alphaprimal, double& alphadual) const;
+  bool fractionToTheBdry(const hiopIterate& dir, const double& tau,
+			 double& alphaprimal, double& alphadual) const;
   
   /* take the step: this = iter+alpha*dir */
-  virtual bool takeStep_primals(const hiopIterate& iter, const hiopIterate& dir, const double& alphaprimal, const double& alphadual);
-  virtual bool takeStep_duals(const hiopIterate& iter, const hiopIterate& dir, const double& alphaprimal, const double& alphadual);
-  //virtual bool updateDualsEq(const hiopIterate& iter, const hiopIterate& dir, double& alphaprimal, double& alphadual);
-  //virtual bool updateDualsIneq(const hiopIterate& iter, const hiopIterate& dir, double& alphaprimal, double& alphadual);
+  virtual bool takeStep_primals(const hiopIterate& iter, const hiopIterate& dir,
+				const double& alphaprimal, const double& alphadual);
+  virtual bool takeStep_duals(const hiopIterate& iter, const hiopIterate& dir,
+			      const double& alphaprimal, const double& alphadual);
   
-  /* Adjusts the signed duals to ensure the the logbar primal-dual Hessian is not arbitrarily 
-   * far away from the primal counterpart. This is eq. 16 in the filter IPM paper */
+  /**
+   * Adjusts the signed duals to ensure the the logbar primal-dual Hessian is not arbitrarily 
+   * far away from the primal counterpart. This is eq. 16 in the filter IPM paper 
+   */
   virtual bool adjustDuals_primalLogHessian(const double& mu, const double& kappa_Sigma);
   /* compute the log-barrier term for the primal signed variables */
   virtual double evalLogBarrier() const;
@@ -88,11 +98,15 @@ public:
   virtual void addLogBarGrad_x(const double& mu, hiopVector& gradx) const;
   virtual void addLogBarGrad_d(const double& mu, hiopVector& gradd) const;
 
-  /* computes the log barrier's linear damping term of the Filter-IPM method of WaectherBiegler (section 3.7) */
+  /**
+   * Computes the log barrier's linear damping term of the Filter-IPM method of WaectherBiegler (section 3.7) 
+   */
   virtual double linearDampingTerm(const double& mu, const double& kappa_d) const;
   /* adds the damping term to the gradient */
-  virtual void addLinearDampingTermToGrad_x(const double& mu, const double& kappa_d, const double& beta, hiopVector& grad_x) const;
-  virtual void addLinearDampingTermToGrad_d(const double& mu, const double& kappa_d, const double& beta, hiopVector& grad_d) const;
+  virtual void addLinearDampingTermToGrad_x(const double& mu, const double& kappa_d, const double& beta,
+					    hiopVector& grad_x) const;
+  virtual void addLinearDampingTermToGrad_d(const double& mu, const double& kappa_d, const double& beta,
+					    hiopVector& grad_d) const;
 
   /** norms for individual parts of the iterate (on demand computation) */
   virtual double normOneOfBoundDuals() const;

--- a/src/Optimization/hiopKKTLinSys.cpp
+++ b/src/Optimization/hiopKKTLinSys.cpp
@@ -309,7 +309,7 @@ bool hiopKKTLinSysCompressedXYcYd::computeDirections(const hiopResidual* resid,
     dir->sxl->copyFrom(*r.rxl); dir->sxl->axpy( 1.0,*dir->x); dir->sxl->selectPattern(nlp_->get_ixl()); 
 
     dir->zl->copyFrom(*r.rszl); dir->zl->axzpy(-1.0,*iter_->zl,*dir->sxl); 
-    dir->zl->componentDiv_p_selectPattern(*iter_->sxl, nlp_->get_ixl());
+    dir->zl->componentDiv_w_selectPattern(*iter_->sxl, nlp_->get_ixl());
   } else {
     dir->sxl->setToZero(); dir->zl->setToZero();
   }
@@ -323,7 +323,7 @@ bool hiopKKTLinSysCompressedXYcYd::computeDirections(const hiopResidual* resid,
 
     dir->zu->copyFrom(*r.rszu); dir->zu->axzpy(-1.0,*iter_->zu,*dir->sxu);
     dir->zu->selectPattern(nlp_->get_ixu());
-    dir->zu->componentDiv_p_selectPattern(*iter_->sxu, nlp_->get_ixu());
+    dir->zu->componentDiv_w_selectPattern(*iter_->sxu, nlp_->get_ixu());
   } else {
     dir->sxu->setToZero(); dir->zu->setToZero();
   }
@@ -337,7 +337,7 @@ bool hiopKKTLinSysCompressedXYcYd::computeDirections(const hiopResidual* resid,
 
     dir->vl->copyFrom(*r.rsvl); dir->vl->axzpy(-1.0,*iter_->vl,*dir->sdl);
     dir->vl->selectPattern(nlp_->get_idl());
-    dir->vl->componentDiv_p_selectPattern(*iter_->sdl, nlp_->get_idl());
+    dir->vl->componentDiv_w_selectPattern(*iter_->sdl, nlp_->get_idl());
   } else {
     dir->sdl->setToZero(); dir->vl->setToZero();
   }
@@ -351,7 +351,7 @@ bool hiopKKTLinSysCompressedXYcYd::computeDirections(const hiopResidual* resid,
     
     dir->vu->copyFrom(*r.rsvu); dir->vu->axzpy(-1.0,*iter_->vu,*dir->sdu);
     dir->vu->selectPattern(nlp_->get_idu());
-    dir->vu->componentDiv_p_selectPattern(*iter_->sdu, nlp_->get_idu());
+    dir->vu->componentDiv_w_selectPattern(*iter_->sdu, nlp_->get_idu());
   } else {
     dir->sdu->setToZero(); dir->vu->setToZero();
   }
@@ -544,7 +544,7 @@ bool hiopKKTLinSysCompressedXDYcYd::computeDirections(const hiopResidual* resid,
     dir->sxl->copyFrom(*r.rxl); dir->sxl->axpy( 1.0,*dir->x); dir->sxl->selectPattern(nlp_->get_ixl()); 
 
     dir->zl->copyFrom(*r.rszl); dir->zl->axzpy(-1.0,*iter_->zl,*dir->sxl); 
-    dir->zl->componentDiv_p_selectPattern(*iter_->sxl, nlp_->get_ixl());
+    dir->zl->componentDiv_w_selectPattern(*iter_->sxl, nlp_->get_ixl());
   } else {
     dir->sxl->setToZero(); dir->zl->setToZero();
   }
@@ -553,10 +553,14 @@ bool hiopKKTLinSysCompressedXDYcYd::computeDirections(const hiopResidual* resid,
   //dir->zl->print();
   //dsxu = rxu - dx and dzu = [Sxu]^{-1} ( - Zu*dsxu + rszu)
   if(nlp_->n_upp_local()) { 
-    dir->sxu->copyFrom(*r.rxu); dir->sxu->axpy(-1.0,*dir->x); dir->sxu->selectPattern(nlp_->get_ixu()); 
+    dir->sxu->copyFrom(*r.rxu);
+    dir->sxu->axpy(-1.0,*dir->x);
+    dir->sxu->selectPattern(nlp_->get_ixu()); 
 
-    dir->zu->copyFrom(*r.rszu); dir->zu->axzpy(-1.0,*iter_->zu,*dir->sxu); dir->zu->selectPattern(nlp_->get_ixu());
-    dir->zu->componentDiv_p_selectPattern(*iter_->sxu, nlp_->get_ixu());
+    dir->zu->copyFrom(*r.rszu);
+    dir->zu->axzpy(-1.0,*iter_->zu,*dir->sxu);
+    dir->zu->selectPattern(nlp_->get_ixu());
+    dir->zu->componentDiv_w_selectPattern(*iter_->sxu, nlp_->get_ixu());
   } else {
     dir->sxu->setToZero(); dir->zu->setToZero();
   }
@@ -565,20 +569,28 @@ bool hiopKKTLinSysCompressedXDYcYd::computeDirections(const hiopResidual* resid,
   //dir->zu->print();
   //dsdl = rdl + dd and dvl = [Sdl]^{-1} ( - Vl*dsdl + rsvl)
   if(nlp_->m_ineq_low()) {
-    dir->sdl->copyFrom(*r.rdl); dir->sdl->axpy( 1.0,*dir->d); dir->sdl->selectPattern(nlp_->get_idl());
+    dir->sdl->copyFrom(*r.rdl);
+    dir->sdl->axpy( 1.0,*dir->d);
+    dir->sdl->selectPattern(nlp_->get_idl());
 
-    dir->vl->copyFrom(*r.rsvl); dir->vl->axzpy(-1.0,*iter_->vl,*dir->sdl); dir->vl->selectPattern(nlp_->get_idl());
-    dir->vl->componentDiv_p_selectPattern(*iter_->sdl, nlp_->get_idl());
+    dir->vl->copyFrom(*r.rsvl);
+    dir->vl->axzpy(-1.0,*iter_->vl,*dir->sdl);
+    dir->vl->selectPattern(nlp_->get_idl());
+    dir->vl->componentDiv_w_selectPattern(*iter_->sdl, nlp_->get_idl());
   } else {
     dir->sdl->setToZero(); dir->vl->setToZero();
   }
 
   //dsdu = rdu - dd and dvu = [Sdu]^{-1} ( - Vu*dsdu + rsvu )
   if(nlp_->m_ineq_upp()>0) {
-    dir->sdu->copyFrom(*r.rdu); dir->sdu->axpy(-1.0,*dir->d); dir->sdu->selectPattern(nlp_->get_idu());
+    dir->sdu->copyFrom(*r.rdu);
+    dir->sdu->axpy(-1.0,*dir->d);
+    dir->sdu->selectPattern(nlp_->get_idu());
     
-    dir->vu->copyFrom(*r.rsvu); dir->vu->axzpy(-1.0,*iter_->vu,*dir->sdu); dir->vu->selectPattern(nlp_->get_idu());
-    dir->vu->componentDiv_p_selectPattern(*iter_->sdu, nlp_->get_idu());
+    dir->vu->copyFrom(*r.rsvu);
+    dir->vu->axzpy(-1.0,*iter_->vu,*dir->sdu);
+    dir->vu->selectPattern(nlp_->get_idu());
+    dir->vu->componentDiv_w_selectPattern(*iter_->sdu, nlp_->get_idu());
   } else {
     dir->sdu->setToZero(); dir->vu->setToZero();
   }

--- a/src/Optimization/hiopNlpFormulation.cpp
+++ b/src/Optimization/hiopNlpFormulation.cpp
@@ -114,8 +114,8 @@ hiopNlpFormulation::hiopNlpFormulation(hiopInterfaceBase& interface_)
   dl=NULL;
   du=NULL;
   cons_ineq_type=NULL;
-  cons_eq_mapping=NULL;
-  cons_ineq_mapping=NULL;
+  cons_eq_mapping_=NULL;
+  cons_ineq_mapping_=NULL;
   idl=NULL;
   idu=NULL;
 #ifdef HIOP_USE_MPI
@@ -124,6 +124,7 @@ hiopNlpFormulation::hiopNlpFormulation(hiopInterfaceBase& interface_)
   cons_eval_type_ = -1;
   cons_body_ = NULL;
   cons_Jac_ = NULL;
+  cons_lambdas_ = NULL;
 }
 
 hiopNlpFormulation::~hiopNlpFormulation()
@@ -142,8 +143,8 @@ hiopNlpFormulation::~hiopNlpFormulation()
   if(cons_ineq_type) delete[] cons_ineq_type;
   if(cons_eq_type)   delete[] cons_eq_type;
 
-  if(cons_eq_mapping)   delete[] cons_eq_mapping;
-  if(cons_ineq_mapping) delete[] cons_ineq_mapping;
+  if(cons_eq_mapping_)   delete[] cons_eq_mapping_;
+  if(cons_ineq_mapping_) delete[] cons_ineq_mapping_;
 #ifdef HIOP_USE_MPI
   if(vec_distrib) delete[] vec_distrib;
 #endif
@@ -159,6 +160,7 @@ hiopNlpFormulation::~hiopNlpFormulation()
 #endif
   delete[] cons_body_;
   delete cons_Jac_;
+  delete[] cons_lambdas_;
 }
 
 bool hiopNlpFormulation::finalizeInitialization()
@@ -326,9 +328,11 @@ bool hiopNlpFormulation::finalizeInitialization()
     } else {
       if(options->GetString("fixed_var")=="relax") {
 	log->printf(hovWarning, "Fixed variables will be relaxed internally.\n");
-	hiopFixedVarsRelaxer* fixedVarsRelaxer = new hiopFixedVarsRelaxer(*xl, *xu, nfixed_vars, nfixed_vars_local);
+	auto* fixedVarsRelaxer = new hiopFixedVarsRelaxer(*xl, *xu,
+							  nfixed_vars, nfixed_vars_local);
 	fixedVarsRelaxer->setup();
-	fixedVarsRelaxer->relax(options->GetNumeric("fixed_var_tolerance"), options->GetNumeric("fixed_var_perturb"), *xl, *xu);
+	fixedVarsRelaxer->relax(options->GetNumeric("fixed_var_tolerance"),
+				options->GetNumeric("fixed_var_perturb"), *xl, *xu);
 
 	nlp_transformations.append(fixedVarsRelaxer);
 
@@ -355,20 +359,28 @@ bool hiopNlpFormulation::finalizeInitialization()
     else                     n_cons_ineq++;
   }
 
-  if(c_rhs) delete c_rhs; 
-  if(cons_eq_type) delete[] cons_eq_type;
-  if(dl) delete dl; if(du) delete du;
-  if(cons_ineq_type) delete[] cons_ineq_type;
-  if(cons_eq_mapping) delete[] cons_eq_mapping;
-  if(cons_ineq_mapping) delete[] cons_ineq_mapping;
+  if(c_rhs)
+    delete c_rhs; 
+  if(cons_eq_type)
+    delete[] cons_eq_type;
+  if(dl)
+    delete dl;
+  if(du) delete du;
+  if(cons_ineq_type)
+    delete[] cons_ineq_type;
+  if(cons_eq_mapping_)
+    delete[] cons_eq_mapping_;
+  if(cons_ineq_mapping_)
+    delete[] cons_ineq_mapping_;
+  
   /* allocate c_rhs, dl, and du (all serial in this formulation) */
   c_rhs = new hiopVectorPar(n_cons_eq);
   cons_eq_type = new  hiopInterfaceBase::NonlinearityType[n_cons_eq];
   dl    = new hiopVectorPar(n_cons_ineq);
   du    = new hiopVectorPar(n_cons_ineq);
   cons_ineq_type = new  hiopInterfaceBase::NonlinearityType[n_cons_ineq];
-  cons_eq_mapping   = new long long[n_cons_eq];
-  cons_ineq_mapping = new long long[n_cons_ineq];
+  cons_eq_mapping_   = new long long[n_cons_eq];
+  cons_ineq_mapping_ = new long long[n_cons_ineq];
 
   /* copy lower and upper bounds - constraints */
   double *dlvec=dl->local_data(), *duvec=du->local_data(), *c_rhsvec=c_rhs->local_data();
@@ -377,19 +389,21 @@ bool hiopNlpFormulation::finalizeInitialization()
     if(gl_vec[i]==gu_vec[i]) {
       cons_eq_type[it_eq]=cons_type[i]; 
       c_rhsvec[it_eq] = gl_vec[i]; 
-      cons_eq_mapping[it_eq]=i;
+      cons_eq_mapping_[it_eq]=i;
       it_eq++;
     } else {
 #ifdef HIOP_DEEPCHECKS
-    assert(gl_vec[i] <= gu_vec[i] && "please fix the inconsistent inequality constraints, otherwise the problem is infeasible");
+    assert(gl_vec[i] <= gu_vec[i] &&
+	   "please fix the inconsistent inequality constraints, otherwise the problem is infeasible");
 #endif
       cons_ineq_type[it_ineq]=cons_type[i];
       dlvec[it_ineq]=gl_vec[i]; duvec[it_ineq]=gu_vec[i]; 
-      cons_ineq_mapping[it_ineq]=i;
+      cons_ineq_mapping_[it_ineq]=i;
       it_ineq++;
     }
   }
   assert(it_eq==n_cons_eq); assert(it_ineq==n_cons_ineq);
+  
   /* delete the temporary buffers */
   delete gl; delete gu; delete[] cons_type;
 
@@ -429,10 +443,15 @@ bool hiopNlpFormulation::finalizeInitialization()
 
   //reset/release info and data related to one-call constraints evaluation
   cons_eval_type_ = -1;
+  
   delete[] cons_body_;
   cons_body_ = NULL;
+  
   delete cons_Jac_;
   cons_Jac_ = NULL;
+
+  delete[] cons_lambdas_;
+  cons_lambdas_ = NULL;
   return bret;
 }
 
@@ -521,10 +540,10 @@ bool hiopNlpFormulation::get_starting_point(hiopVector& x0,
     
     //copy back 
     for(int i=0; i<n_cons_eq; ++i) {
-      yc0d[i] = lambda_for_user[cons_eq_mapping[i]];
+      yc0d[i] = lambda_for_user[cons_eq_mapping_[i]];
     }
     for(int i=0; i<n_cons_ineq; ++i) {
-      yd0d[i] = lambda_for_user[cons_ineq_mapping[i]];
+      yd0d[i] = lambda_for_user[cons_ineq_mapping_[i]];
     }
   }
   
@@ -547,7 +566,7 @@ bool hiopNlpFormulation::eval_c(double*x, bool new_x, double* c)
   runStats.tmEvalCons.start();
   bool bret = interface_base.eval_cons(nlp_transformations.n_post(),
 				       n_cons,n_cons_eq,
-				       cons_eq_mapping,
+				       cons_eq_mapping_,
 				       xx,new_x,
 				       cc);
   runStats.tmEvalCons.stop(); runStats.nEvalCons_eq++;
@@ -562,7 +581,7 @@ bool hiopNlpFormulation::eval_d(double*x, bool new_x, double* d)
 
   runStats.tmEvalCons.start();
   bool bret = interface_base.eval_cons(nlp_transformations.n_post(),
-				       n_cons, n_cons_ineq, cons_ineq_mapping,
+				       n_cons, n_cons_ineq, cons_ineq_mapping_,
 				       xx, new_x, dd);
   runStats.tmEvalCons.stop(); runStats.nEvalCons_ineq++;
 
@@ -593,8 +612,12 @@ bool hiopNlpFormulation::eval_c_d(double*x, bool new_x, double* c, double* d)
   }
 
   if(0 == cons_eval_type_) {
-    if(do_eval_c) if(!eval_c(x, new_x, c)) { return false; }
-    if(!eval_d(x, new_x, d)) { return false; }
+    if(do_eval_c) if(!eval_c(x, new_x, c)) {
+	return false;
+      }
+    if(!eval_d(x, new_x, d)) {
+      return false;
+    }
     return true;
   } else {
     assert(1 == cons_eval_type_);
@@ -609,10 +632,10 @@ bool hiopNlpFormulation::eval_c_d(double*x, bool new_x, double* c, double* d)
 					 xx, new_x, body);
     //copy back to c and d
     for(int i=0; i<n_cons_eq; ++i) {
-      c[i] = body[cons_eq_mapping[i]];
+      c[i] = body[cons_eq_mapping_[i]];
     }
     for(int i=0; i<n_cons_ineq; ++i) {
-      d[i] = body[cons_ineq_mapping[i]];
+      d[i] = body[cons_ineq_mapping_[i]];
     }
     
     runStats.tmEvalCons.stop();
@@ -662,28 +685,73 @@ bool hiopNlpFormulation::eval_Jac_c_d(double* x, bool new_x, hiopMatrix& Jac_c, 
   return true;
 }
 
+void hiopNlpFormulation::
+get_dual_solutions(const hiopIterate& it, double* zl_a, double* zu_a, double* lambda_a)
+{
+  const hiopVectorPar& zl = dynamic_cast<hiopVectorPar&>(*it.get_zl());
+  const hiopVectorPar& zu = dynamic_cast<hiopVectorPar&>(*it.get_zu());
+  zl.copyTo(zl_a);
+  zu.copyTo(zu_a);
+
+  copy_EqIneq_to_cons(*it.get_yc(), *it.get_yd(), n_cons, lambda_a);
+}
+
+void hiopNlpFormulation::copy_EqIneq_to_cons(const hiopVector& yc_in,
+					     const hiopVector& yd_in,
+					     int num_cons, //size of 'cons'
+					     double* cons)
+{
+  const double* yc_arr = dynamic_cast<const hiopVectorPar&>(yc_in).local_data_const();
+  const double* yd_arr = dynamic_cast<const hiopVectorPar&>(yd_in).local_data_const();
+  assert(num_cons == n_cons);
+  assert(yc_in.get_size() + yd_in.get_size() == n_cons);
+    //concatanate multipliers -> copy into whole lambda array 
+  for(int i=0; i<n_cons_eq; ++i) {
+    cons[cons_eq_mapping_[i]] = yc_arr[i];
+  }
+  for(int i=0; i<n_cons_ineq; ++i) {
+    cons[cons_ineq_mapping_[i]] = yd_arr[i];
+  }
+}
+
 void hiopNlpFormulation::user_callback_solution(hiopSolveStatus status,
 						const hiopVector& x,
 						const hiopVector& z_L,
 						const hiopVector& z_U,
 						const hiopVector& c,
 						const hiopVector& d,
-						const hiopVector& yc,
-						const hiopVector& yd,
+						const hiopVector& y_c,
+						const hiopVector& y_d,
 						double obj_value) 
 {
   const hiopVectorPar& xp = dynamic_cast<const hiopVectorPar&>(x);
   const hiopVectorPar& zl = dynamic_cast<const hiopVectorPar&>(z_L);
   const hiopVectorPar& zu = dynamic_cast<const hiopVectorPar&>(z_U);
+
   assert(xp.get_size()==n_vars);
-  assert(c.get_size()+d.get_size()==n_cons);
-  //!petra: to do: assemble (c,d) into cons and (yc,yd) into lambda based on cons_eq_mapping
-  // and cons_ineq_mapping
+  assert(y_c.get_size() == n_cons_eq);
+  assert(y_d.get_size() == n_cons_ineq);
+
+  if(cons_lambdas_ == NULL) {
+    cons_lambdas_ = new double[n_cons];
+  }
+  copy_EqIneq_to_cons(y_c, y_d, n_cons, cons_lambdas_);
+  
+  
+  //concatenate 'c' and 'd' into user's constrainty body
+  if(cons_body_ == NULL) {
+    cons_body_ = new double[n_cons];
+  }
+  copy_EqIneq_to_cons(c, d, n_cons, cons_body_);
+  
+  //! todo -> test this when fixed variables are removed -> the internal
+  //! zl and zu may have different sizes than what user expects since HiOp removes
+  //! variables internally
   interface_base.solution_callback(status, 
 				   (int)n_vars, xp.local_data_const(),
 				   zl.local_data_const(), zu.local_data_const(),
-				   (int)n_cons, NULL, //cons, 
-				   NULL, //lambda,
+				   (int)n_cons, cons_body_,
+				   cons_lambdas_,
 				   obj_value);
 }
 
@@ -694,8 +762,8 @@ bool hiopNlpFormulation::user_callback_iterate(int iter,
 					       const hiopVector& z_U,
 					       const hiopVector& c,
 					       const hiopVector& d,
-					       const hiopVector& yc,
-					       const hiopVector& yd,
+					       const hiopVector& y_c,
+					       const hiopVector& y_d,
 					       double inf_pr,
 					       double inf_du,
 					       double mu,
@@ -708,13 +776,31 @@ bool hiopNlpFormulation::user_callback_iterate(int iter,
   const hiopVectorPar& zu = dynamic_cast<const hiopVectorPar&>(z_U);
   assert(xp.get_size()==n_vars);
   assert(c.get_size()+d.get_size()==n_cons);
-  //!petra: to do: assemble (c,d) into cons and (yc,yd) into lambda based on cons_eq_mapping
-  //and cons_ineq_mapping
+
+  assert(y_c.get_size() == n_cons_eq);
+  assert(y_d.get_size() == n_cons_ineq);
+
+  if(cons_lambdas_ == NULL) {
+    cons_lambdas_ = new double[n_cons];
+  }
+  copy_EqIneq_to_cons(y_c, y_d, n_cons, cons_lambdas_);
+  
+  
+  //concatenate 'c' and 'd' into user's constrainty body
+  if(cons_body_ == NULL) {
+    cons_body_ = new double[n_cons];
+  }
+  copy_EqIneq_to_cons(c, d, n_cons, cons_body_);
+  
+  //! todo -> test this when fixed variables are removed -> the internal
+  //! zl and zu may have different sizes than what user expects since HiOp removes
+  //! variables internally
+  
   return interface_base.iterate_callback(iter, obj_value, 
 					 (int)n_vars, xp.local_data_const(),
 					 zl.local_data_const(), zu.local_data_const(),
-					 (int)n_cons, NULL, //cons, 
-					 NULL, //lambda,
+					 (int)n_cons, cons_body_, 
+					 cons_lambdas_,
 					 inf_pr, inf_du, mu, alpha_du, alpha_pr,  ls_trials);
 }
 
@@ -769,7 +855,7 @@ bool hiopNlpDenseConstraints::eval_Jac_c(double* x, bool new_x, double** Jac_c)
   double** Jac_c_user = nlp_transformations.applyToJacobEq(Jac_c, n_cons_eq);
 
   runStats.tmEvalJac_con.start();
-  bool bret = interface.eval_Jac_cons(nlp_transformations.n_post(),n_cons,n_cons_eq,cons_eq_mapping,
+  bool bret = interface.eval_Jac_cons(nlp_transformations.n_post(),n_cons,n_cons_eq,cons_eq_mapping_,
 				      x_user,new_x,Jac_c_user);
   runStats.tmEvalJac_con.stop(); runStats.nEvalJac_con_eq++;
 
@@ -782,7 +868,7 @@ bool hiopNlpDenseConstraints::eval_Jac_d(double* x, bool new_x, double** Jac_d)
   double** Jac_d_user = nlp_transformations.applyToJacobIneq(Jac_d, n_cons_ineq);
  
   runStats.tmEvalJac_con.start();
-  bool bret = interface.eval_Jac_cons(nlp_transformations.n_post(),n_cons,n_cons_ineq,cons_ineq_mapping,
+  bool bret = interface.eval_Jac_cons(nlp_transformations.n_post(),n_cons,n_cons_ineq,cons_ineq_mapping_,
 				      x_user,new_x,Jac_d_user);
   runStats.tmEvalJac_con.stop(); runStats.nEvalJac_con_ineq++;
 
@@ -819,8 +905,8 @@ bool hiopNlpDenseConstraints::eval_Jac_c_d_interface_impl(double* x, bool new_x,
   assert(cons_Jac_de->local_data() == Jac_consde &&
 	 "mismatch between Jacobian mem adress pre- and post-transformations should not happen");
 
-  Jac_cde->copyRowsFrom(*cons_Jac_, cons_eq_mapping, n_cons_eq);
-  Jac_dde->copyRowsFrom(*cons_Jac_, cons_ineq_mapping, n_cons_ineq);
+  Jac_cde->copyRowsFrom(*cons_Jac_, cons_eq_mapping_, n_cons_eq);
+  Jac_dde->copyRowsFrom(*cons_Jac_, cons_ineq_mapping_, n_cons_ineq);
   
   runStats.tmEvalJac_con.stop();
   runStats.nEvalJac_con_eq++;
@@ -914,7 +1000,7 @@ bool hiopNlpMDS::eval_Jac_c(double* x, bool new_x, hiopMatrix& Jac_c)
     
     int nnz = pJac_c->sp_nnz();
     bool bret = interface.eval_Jac_cons(n_vars, n_cons, 
-					n_cons_eq, cons_eq_mapping, 
+					n_cons_eq, cons_eq_mapping_, 
 					x_user, new_x,
 					pJac_c->n_sp(), pJac_c->n_de(), 
 					nnz, pJac_c->sp_irow(), pJac_c->sp_jcol(), pJac_c->sp_M(),
@@ -942,7 +1028,7 @@ bool hiopNlpMDS::eval_Jac_d(double* x, bool new_x, hiopMatrix& Jac_d)
   
     int nnz = pJac_d->sp_nnz();
     bool bret =  interface.eval_Jac_cons(n_vars, n_cons, 
-					 n_cons_ineq, cons_ineq_mapping, 
+					 n_cons_ineq, cons_ineq_mapping_, 
 					 x_user, new_x,
 					 pJac_d->n_sp(), pJac_d->n_de(), 
 					 nnz, pJac_d->sp_irow(), pJac_d->sp_jcol(), pJac_d->sp_M(),
@@ -990,8 +1076,8 @@ bool hiopNlpMDS::eval_Jac_c_d_interface_impl(double* x,
     //Jac_d = nlp_transformations.applyInvToJacobIneq(Jac_d_user, n_cons_ineq);
     
     //copy back to Jac_c and Jac_d
-    pJac_c->copyRowsFrom(*cons_Jac, cons_eq_mapping, n_cons_eq);
-    pJac_d->copyRowsFrom(*cons_Jac, cons_ineq_mapping, n_cons_ineq);
+    pJac_c->copyRowsFrom(*cons_Jac, cons_eq_mapping_, n_cons_eq);
+    pJac_d->copyRowsFrom(*cons_Jac, cons_ineq_mapping_, n_cons_ineq);
     
     runStats.tmEvalJac_con.stop();
     runStats.nEvalJac_con_eq++;

--- a/src/Optimization/hiopNlpFormulation.hpp
+++ b/src/Optimization/hiopNlpFormulation.hpp
@@ -114,7 +114,10 @@ public:
 			      bool new_lambdas, 
 			      hiopMatrix& Hess_L)=0;
   /* starting point */
-  virtual bool get_starting_point(hiopVector& x0);
+  virtual bool get_starting_point(hiopVector& x0,
+				  bool& duals_avail,
+				  hiopVector& zL0, hiopVector& zU0,
+				  hiopVector& yc0, hiopVector& yd0);
 
   /** linear algebra factory */
   virtual hiopVector* alloc_primal_vec() const;

--- a/src/Optimization/hiopNlpFormulation.hpp
+++ b/src/Optimization/hiopNlpFormulation.hpp
@@ -90,8 +90,9 @@ public:
 
   virtual bool finalizeInitialization();
 
-  /* wrappers for the interface calls. Can be overridden for specialized formulations required 
-   * by the algorithm 
+  /**
+   * Wrappers for the interface calls. 
+   * Can be overridden for specialized formulations required by the algorithm.
    */
   virtual bool eval_f(double* x, bool new_x, double& f);
   virtual bool eval_grad_f(double* x, bool new_x, double* gradf);
@@ -132,7 +133,8 @@ public:
 
   virtual
   void user_callback_solution(hiopSolveStatus status,
-			      const hiopVector& x, const hiopVector& z_L, const hiopVector& z_U,
+			      const hiopVector& x,
+			      const hiopVector& z_L, const hiopVector& z_U,
 			      const hiopVector& c, const hiopVector& d,
 			      const hiopVector& yc, const hiopVector& yd,
 			      double obj_value);
@@ -140,7 +142,8 @@ public:
   virtual
   bool user_callback_iterate(int iter,
 			     double obj_value,
-			     const hiopVector& x, const hiopVector& z_L, const hiopVector& z_U,
+			     const hiopVector& x,
+			     const hiopVector& z_L, const hiopVector& z_U,
 			     const hiopVector& c, const hiopVector& d,
 			     const hiopVector& yc, const hiopVector& yd,
 			     double inf_pr, double inf_du, double mu,
@@ -182,6 +185,19 @@ public:
     memcpy(user_x, user_xa, nlp_transformations.n_post_local()*sizeof(double));
   }
 
+  /* copies/unpacks duals of the bounds and of constraints from 'it' to the three arrays */
+  void get_dual_solutions(const hiopIterate& it,
+			  double* zl_a,
+			  double* zu_a,
+			  double* lambda_a);
+  
+  /* packs constraint rhs or constraint multipliers into one array based on the internal mappings 
+   * 'cons_eq_mapping_'and 'cons_ineq_mapping_ */
+  void copy_EqIneq_to_cons(const hiopVector& yc,
+			   const hiopVector& yd,
+			   int num_cons, //size of 'cons'
+			   double* cons);
+  
   /* outputing and debug-related functionality*/
   hiopLogger* log;
   hiopRunStats runStats;
@@ -213,8 +229,9 @@ protected:
 
   hiopVectorPar *dl, *du,  *idl, *idu; //these will be local
   hiopInterfaceBase::NonlinearityType* cons_ineq_type;
+  
   // keep track of the constraints indexes in the original, user's formulation
-  long long *cons_eq_mapping, *cons_ineq_mapping; 
+  long long *cons_eq_mapping_, *cons_ineq_mapping_; 
 
   //options for which this class was setup
   std::string strFixedVars; //"none", "fixed", "relax"
@@ -228,18 +245,35 @@ protected:
   long long* vec_distrib;
 #endif
 
+  /* User provided interface */
   hiopInterfaceBase& interface_base;
 
-  /* Flag to indicate whether to use evaluate all constraints once or separately for equalities
+  /**
+   * Flag to indicate whether to use evaluate all constraints once or separately for equalities
    * or inequalities. Possible values
    * -1 : not initialized/not decided
    *  0 : separately
    *  1 : at once
    */
   int cons_eval_type_;
-  /* used only when constraints and Jacobian are evaluated at once (cons_eval_type_==1) */
+  
+  /** 
+   * Internal buffer for constraints. Used only when constraints and Jacobian are evaluated at 
+   * once (cons_eval_type_==1), otherwise NULL.
+   */
   double* cons_body_;
+  
+  /** 
+   * Internal buffer for the Jacobian. Used only when constraints and Jacobian are evaluated at 
+   * once (cons_eval_type_==1), otherwise NULL.
+   */
   hiopMatrix* cons_Jac_;
+
+  /** 
+   * Internal buffer for the multipliers of the constraints use to copy the multipliers of eq. and
+   * ineq. into and to return it to the user via @user_callback_solution and @user_callback_iterate
+   */
+  double* cons_lambdas_;
 private:
   hiopNlpFormulation(const hiopNlpFormulation& s) : interface_base(s.interface_base) {};
 };

--- a/src/Utils/hiopOptions.cpp
+++ b/src/Utils/hiopOptions.cpp
@@ -108,7 +108,9 @@ string hiopOptions::GetString (const char* name) const
 
 void hiopOptions::registerOptions()
 {
-  registerNumOption("mu0", 1., 1e-6, 1000., "Initial log-barrier parameter mu (default 1.)");
+  // TODO: add option for mu_target
+  registerNumOption("mu0", 1., 1e-16, 1000.,
+		    "Initial log-barrier parameter mu (default 1.)");
   registerNumOption("kappa_mu", 0.2, 1e-8, 0.999, 
 		    "Linear reduction coefficient for mu (default 0.2) (eqn (7) in Filt-IPM paper)");
   registerNumOption("theta_mu", 1.5,  1.0,   2.0, 

--- a/tests/LinAlg/vectorTests.hpp
+++ b/tests/LinAlg/vectorTests.hpp
@@ -461,7 +461,7 @@ public:
     if (rank== 0)
       setLocalElement(&pattern, N - 1, zero);
 
-    v.componentDiv_p_selectPattern(x, pattern);
+    v.componentDiv_w_selectPattern(x, pattern);
 
     const int fail = verifyAnswer(&v,
       [=] (local_ordinal_type i) -> real_type


### PR DESCRIPTION
Two main capabilities are provided by this PR.

i. solution and iterate callbacks from hiopInterface returns duals multipliers
ii. primal-dual starting point can be now specified via hiopInterface

NLP MDS Example 4 has been updated with an example of a primal-dual warm/hot start.

This also addresses Issue #30 