### PR TITLE
Minimized logBarrier numerical error with Kahan summation

### DIFF
--- a/tests/LinAlg/vectorTests.hpp
+++ b/tests/LinAlg/vectorTests.hpp
@@ -714,9 +714,6 @@ public:
       hiop::hiopVector& pattern,
       const int rank)
   {
-    printMessage(SKIP_TEST, __func__, rank);
-    return 0;
-    
     const local_ordinal_type N = getLocalSize(&x);
     assert(N == getLocalSize(&pattern));
 


### PR DESCRIPTION
Reimplemented `hiopVectorPar::logBarrier` method with Kahan sum to prevent numerical error accumulation (see #67). Tested that precision is preserved with `-O2` and `-O3` with GCC 7.4.  