### PR TITLE
Small changes to conform to style guide in hiopMatrixSparse*

### DIFF
--- a/src/LinAlg/hiopMatrixSparse.hpp
+++ b/src/LinAlg/hiopMatrixSparse.hpp
@@ -17,9 +17,9 @@ class hiopMatrixSparse : public hiopMatrix
 {
 public:
   hiopMatrixSparse(int rows, int cols, int nnz)
-      : nrows(rows)
-      , ncols(cols)
-      , nnz(nnz)
+      : nrows_(rows)
+      , ncols_(cols)
+      , nnz_(nnz)
   {
   }
   virtual ~hiopMatrixSparse()
@@ -106,15 +106,15 @@ public:
 
   inline long long m() const
   {
-    return nrows;
+    return nrows_;
   }
   inline long long n() const
   {
-    return ncols;
+    return ncols_;
   }
   inline long long numberOfNonzeros() const
   {
-    return nnz;
+    return nnz_;
   }
 
 #ifdef HIOP_DEEPCHECKS
@@ -125,9 +125,9 @@ public:
   virtual bool checkIndexesAreOrdered() const = 0;
 #endif
 protected:
-  int nrows;   ///< number of rows
-  int ncols;   ///< number of columns
-  int nnz;     ///< number of nonzero entries
+  int nrows_;   ///< number of rows
+  int ncols_;   ///< number of columns
+  int nnz_;     ///< number of nonzero entries
 };
 
 }   // namespace hiop

--- a/src/LinAlg/hiopMatrixSparseTriplet.hpp
+++ b/src/LinAlg/hiopMatrixSparseTriplet.hpp
@@ -102,48 +102,48 @@ public:
   virtual hiopMatrix* alloc_clone() const;
   virtual hiopMatrix* new_copy() const;
 
-  inline int* i_row() { return iRow; }
-  inline int* j_col() { return jCol; }
-  inline double* M() { return values; }
+  inline int* i_row() { return iRow_; }
+  inline int* j_col() { return jCol_; }
+  inline double* M() { return values_; }
 
-  inline const int* i_row() const { return iRow; }
-  inline const int* j_col() const { return jCol; }
-  inline const double* M() const { return values; }
+  inline const int* i_row() const { return iRow_; }
+  inline const int* j_col() const { return jCol_; }
+  inline const double* M() const { return values_; }
 #ifdef HIOP_DEEPCHECKS
   virtual bool assertSymmetry(double tol=1e-16) const { return false; }
   virtual bool checkIndexesAreOrdered() const;
 #endif
 protected:
-  int* iRow; ///< row indices of the nonzero entries
-  int* jCol; ///< column indices of the nonzero entries
-  double* values; ///< values of the nonzero entries
+  int* iRow_; ///< row indices of the nonzero entries
+  int* jCol_; ///< column indices of the nonzero entries
+  double* values_; ///< values_ of the nonzero entries
 
 protected:
   struct RowStartsInfo
   {
-    int *idx_start; //size num_rows+1
-    int num_rows;
+    int *idx_start_; //size num_rows+1
+    int num_rows_;
     RowStartsInfo()
-      : idx_start(NULL), num_rows(0)
+      : idx_start_(NULL), num_rows_(0)
     {}
     RowStartsInfo(int n_rows)
-      : idx_start(new int[n_rows+1]), num_rows(n_rows)
+      : idx_start_(new int[n_rows+1]), num_rows_(n_rows)
     {}
     virtual ~RowStartsInfo()
     {
-      delete[] idx_start;
+      delete[] idx_start_;
     }
   };
-  mutable RowStartsInfo* row_starts;
+  mutable RowStartsInfo* row_starts_;
 private:
   RowStartsInfo* allocAndBuildRowStarts() const; 
 private:
   hiopMatrixSparseTriplet() 
-    : hiopMatrixSparse(0, 0, 0), iRow(NULL), jCol(NULL), values(NULL)
+    : hiopMatrixSparse(0, 0, 0), iRow_(NULL), jCol_(NULL), values_(NULL)
   {
   }
   hiopMatrixSparseTriplet(const hiopMatrixSparseTriplet&) 
-    : hiopMatrixSparse(0, 0, 0), iRow(NULL), jCol(NULL), values(NULL)
+    : hiopMatrixSparse(0, 0, 0), iRow_(NULL), jCol_(NULL), values_(NULL)
   {
     assert(false);
   }
@@ -205,7 +205,7 @@ public:
 #endif
   virtual bool isDiagonal() const 
   {
-    for(int itnnz=0; itnnz<nnz; itnnz++) if(iRow[itnnz]!=jCol[itnnz]) return false;
+    for(int itnnz=0; itnnz<nnz_; itnnz++) if(iRow_[itnnz]!=jCol_[itnnz]) return false;
     return true;
   }
 };


### PR DESCRIPTION
Title is self-explanatory. Passes all tests, except for the case described in #71. Mostly just adding trailing underscore to member variables for sparse matrix classes.