### PR TITLE
update documentation for sparse linear algebra

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,15 @@ or, if you are using C-shell, as
 $ setenv NVBLAS_CONFIG_FILE <hiop install dir>/lib/nvblas.conf
 ```
 
+## Existing issues
+Users are highly encouraged to report any issues they found from using Hiop.
+One known issue is that there is some minor inconsistence between Hiop and linear package STRUMPACK.
+When STRUMPACK is compiled with MPI (and Scalapack), user must set flag `HIOP_USE_MPI` to `ON` when compiling Hiop.
+Otherwise Hiop won't load MPI module and will return an error when links to STRUMPACK, since the later one reuires a valid MPI module. 
+Similary, if both Magma and STRUMPACK are linked to Hiop, user must guarentee the all the packages are compiled by the same CUDA compiler.
+User can check other issues and their existing status from https://github.com/LLNL/hiop 
+
+
 ## Acknowledgments
 
 HiOp has been developed under the financial support of: 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $> cmake -DCMAKE_INSTALL_PREFIX=/usr/lib/hiop ..'
 * GPU support: *-DHIOP_USE_GPU=ON*. MPI can be either off or on. For more build system options related to GPUs, see "Dependencies" section below.
 * Use RAJA portability layer to allow running linear algebra in either host (CPU) or device (GPU): *-DHIOP_USE_RAJA=ON* and *-DHIOP_USE_UMPIRE=ON*. These build options are off by default. Currently, HiOp only supports unified memory space.
 * Enable/disable "developer mode" build that enforces more restrictive compiler rules and guidelines: *-DHIOP_DEVELOPER_MODE=ON*. This option is by default off.
-* Additional checks and self-diagnostics inside HiOp meant to detect anormalities and help to detect bugs and/or troubleshoot problematic instances: *-DHIOP_DEEPCHECKS=[ON/OFF]* (by default ON). Disabling HIOP_DEEPCHECKS usually provides 30-40% execution speedup in HiOp. For full strength, it is recomended to use HIOP_DEEPCHECKS with debug builds. With non-debug builds, in particular the ones that disable the assert macro, HIOP_DEEPCHECKS does not perform all checks and, thus, may overlook potential issues.
+* Additional checks and self-diagnostics inside HiOp meant to detect abnormalities and help to detect bugs and/or troubleshoot problematic instances: *-DHIOP_DEEPCHECKS=[ON/OFF]* (by default ON). Disabling HIOP_DEEPCHECKS usually provides 30-40% execution speedup in HiOp. For full strength, it is recommended to use HIOP_DEEPCHECKS with debug builds. With non-debug builds, in particular the ones that disable the assert macro, HIOP_DEEPCHECKS does not perform all checks and, thus, may overlook potential issues.
 
 For example:
 ```shell 
@@ -49,7 +49,7 @@ $> make install
 ### Dependencies
 HiOp requires LAPACK and BLAS. These dependencies are automatically detected by the build system. MPI is optional and by default enabled. To disable use cmake option '-DHIOP_USE_MPI=OFF'.
 
-HiOp has some support for NVIDIA **GPU-based computations** via CUDA and Magma. To enable the use of GPUs,  use cmake with '-DHIOP_USE_GPU=ON'. The build system will automatically search for CUDA Toolkit. For non-standard CUDA Toolkit installations, use '-DHIOP_CUDA_LIB_DIR=/path' and '-DHIOP_CUDA_INCLUDE_DIR=/path'. For "very" non-standard CUDA Toolkit installations, one can specify the directory of cuBlas libraries as well with '-DHIOP_CUBLAS_LIB_DIR=/path'.
+HiOp has some support for NVIDIA **GPU-based computations** via CUDA and Magma. To enable the use of GPUs, use cmake with '-DHIOP_USE_GPU=ON'. The build system will automatically search for CUDA Toolkit. For non-standard CUDA Toolkit installations, use '-DHIOP_CUDA_LIB_DIR=/path' and '-DHIOP_CUDA_INCLUDE_DIR=/path'. For "very" non-standard CUDA Toolkit installations, one can specify the directory of cuBlas libraries as well with '-DHIOP_CUBLAS_LIB_DIR=/path'.
 
 When RAJA-based portability abstraction layer is enabled, HiOp requires RAJA and UMPIRE libraries 
 
@@ -118,11 +118,11 @@ $ setenv NVBLAS_CONFIG_FILE <hiop install dir>/lib/nvblas.conf
 ```
 
 ## Existing issues
-Users are highly encouraged to report any issues they found from using Hiop.
-One known issue is that there is some minor inconsistence between Hiop and linear package STRUMPACK.
-When STRUMPACK is compiled with MPI (and Scalapack), user must set flag `HIOP_USE_MPI` to `ON` when compiling Hiop.
-Otherwise Hiop won't load MPI module and will return an error when links to STRUMPACK, since the later one reuires a valid MPI module. 
-Similary, if both Magma and STRUMPACK are linked to Hiop, user must guarentee the all the packages are compiled by the same CUDA compiler.
+Users are highly encouraged to report any issues they found from using HiOp.
+One known issue is that there is some minor inconsistence between HiOp and linear package STRUMPACK.
+When STRUMPACK is compiled with MPI (and Scalapack), user must set flag `HIOP_USE_MPI` to `ON` when compiling HiOp.
+Otherwise HiOp won't load MPI module and will return an error when links to STRUMPACK, since the later one requires a valid MPI module. 
+Similarly, if both Magma and STRUMPACK are linked to HiOp, user must guarantee the all the packages are compiled by the same CUDA compiler.
 User can check other issues and their existing status from https://github.com/LLNL/hiop 
 
 

--- a/src/Interface/README.md
+++ b/src/Interface/README.md
@@ -1,7 +1,16 @@
-HiOp supports two input formats: `hiopInterfaceDenseConstraints`,`hiopInterfaceSparse` and `hiopInterfaceMDS`.
-Both formats are in the form of C++ interfaces (e.g., abstract classes), see [hiopInterface.hpp](hiopInterface.hpp) file, that the user must instantiate/implement and provide to HiOp.
+HiOp supports three input formats: `hiopInterfaceDenseConstraints`,`hiopInterfaceSparse` and `hiopInterfaceMDS`.
+All formats are in the form of C++ interfaces (e.g., abstract classes), see [hiopInterface.hpp](hiopInterface.hpp) file, that the user must instantiate/implement and provide to HiOp.
 
-Please read carefully the (software) documentation provided in [hiopInterface.hpp](hiopInterface.hpp) and the (math) documentation provided in the [user manual](../../doc/hiop_usermanual.pdf). In addition, please be aware of the following notes in the case of `hiopInterfaceMDS`.
+Please read carefully the (software) documentation provided in [hiopInterface.hpp](hiopInterface.hpp) and the (math) documentation provided in the [user manual](../../doc/hiop_usermanual.pdf). In addition, please be aware of the following notes in the case of `hiopInterfaceSpare` or `hiopInterfaceMDS`.
+
+## Key points/conventions for `hiopInterfaceSparse`
+
+### Jacobian and Hessian
+* both Jacobian and Hessian are sparse, and their triplet forms are user inputs via the interface.
+* Jacobian is implemented as a geranal sparse matrix and hecne user need to provid all the nonzeros of it.
+* Hessian is implemented as a symmetric sparse matrix and hecne user only need to provid a triangular part of it.
+* for conventions on symmetric matrices and sparse matrices see [this](../LinAlg/readme.md)
+
 
 ## Key points/conventions for `hiopInterfaceMDS`
 

--- a/src/Interface/README.md
+++ b/src/Interface/README.md
@@ -7,8 +7,8 @@ Please read carefully the (software) documentation provided in [hiopInterface.hp
 
 ### Jacobian and Hessian
 * both Jacobian and Hessian are sparse, and their triplet forms are user inputs via the interface.
-* Jacobian is implemented as a geranal sparse matrix and hecne user need to provid all the nonzeros of it.
-* Hessian is implemented as a symmetric sparse matrix and hecne user only need to provid a triangular part of it.
+* Jacobian is implemented as a general sparse matrix and hence user need to provide all the nonzeros of it.
+* Hessian is implemented as a symmetric sparse matrix and hence user only need to provide a triangular part of it.
 * for conventions on symmetric matrices and sparse matrices see [this](../LinAlg/readme.md)
 
 
@@ -21,7 +21,7 @@ MDS stands for mixed dense-sparse, meaning that the derivatives (Jacobian and He
 
 * the (vector of) optimization variables are supposed to be split in *dense* and *sparse* variables
 * HiOp expects the optimization variables in a certain order: sparse variables first, followed by dense variables
-  * the implementer/user (inconviniently) has to keep an map between his internal variables indexes and the indexes HiOp expects in order to avoid expensive memory moves inside HiOp
+  * the implementer/user (inconveniently) has to keep an map between his internal variables indexes and the indexes HiOp expects in order to avoid expensive memory moves inside HiOp
   
 ### Jacobian
 
@@ -30,10 +30,10 @@ MDS stands for mixed dense-sparse, meaning that the derivatives (Jacobian and He
 * as indicated at the previous bullet, the user needs to map the column/variable index in the true Jacobian to the column index in the sparse or dense Jacobian block. The indexes inside the sparse and dense Jacobian blocks is zero-based
 
 ### Hessian
-* the Hessian's structure is slightly different that that of the Jacobian. The Hessian has three relevant blocks
+* the Hessian's structure is slightly different that of the Jacobian. The Hessian has three relevant blocks
   * Hessian with respect to (sparse,sparse) variables
   * Hessian with respect to (dense,dense) variables	
-  * Hessian with respect to (sparse,dense) variables, which is the transpose of (dense,sparse) Hessian. This blocks are ignored currentlty by HiOp (subject to change)
+  * Hessian with respect to (sparse,dense) variables, which is the transpose of (dense,sparse) Hessian. This blocks are ignored currently by HiOp (subject to change)
 * all the above indexing rules for the Jacobian blocks apply to the Hessian blocks
 * for conventions on symmetric matrices and sparse matrices see [this](../LinAlg/readme.md)
   

--- a/src/LinAlg/load_kkt_mat.m
+++ b/src/LinAlg/load_kkt_mat.m
@@ -22,7 +22,6 @@ for ii=2:m+1
         rowidx(jj) = ii-1;
     end
 end
-colidx = colidx + 1; % increase column indexes by one
 
 %% form the matrix and fill lower triangle
 M = sparse(rowidx, colidx, vals, m, m);

--- a/src/LinAlg/readme.md
+++ b/src/LinAlg/readme.md
@@ -56,9 +56,16 @@ virtual void addUpperTriangleToSymDenseMatrixUpperTriangle(int diag_start, doubl
 
 ## Sparse matrices 
 Triplet format is momentarily used for sparse matrices. 
+HSL linear solvers, e.g., MA57, use triplet format as an input.
+To use other linear solvers that require different format, e.g., STRUMPACK uses compressed sparse row (CSR) format, hiop will make the conversion internally. After converting the matrix from triplet to CSR format, Hiop will sort the 
+nonzeros to prevent unexpected behaviors happened in the 3rd party linear solver.
 
 ### *Symmetric* sparse matrices 
 Only upper triangular nonzero entries should be specified, accessed, and maintained.
+In the current code, only Hessian and the symmetic KKT systems are implelemented as symmetric matrices. Users only need to provide the triangular nonzero entries to Hessian.
+For the symmetic KKT, some linear algebra package, e.g., MA57 from HSL, can read entries from both the upper and lower triangular part. For example, only one entry from KKT[i,j] and KKT[j,i] is requied to be presented in MA57.
+If both constraint Jacobian and Lagrangian Hessian are sorted by row in the triplet format, it is easier to copy the entries from Jac/Hes to the lower triangular part and keep the elements sorted by row.
+
 
 ## Obtaining matrices from HiOp
 

--- a/src/LinAlg/readme.md
+++ b/src/LinAlg/readme.md
@@ -57,13 +57,13 @@ virtual void addUpperTriangleToSymDenseMatrixUpperTriangle(int diag_start, doubl
 ## Sparse matrices 
 Triplet format is momentarily used for sparse matrices. 
 HSL linear solvers, e.g., MA57, use triplet format as an input.
-To use other linear solvers that require different format, e.g., STRUMPACK uses compressed sparse row (CSR) format, hiop will make the conversion internally. After converting the matrix from triplet to CSR format, Hiop will sort the 
+To use other linear solvers that require different format, e.g., STRUMPACK uses compressed sparse row (CSR) format, HiOp will make the conversion internally. After converting the matrix from triplet to CSR format, HiOp will sort the 
 nonzeros to prevent unexpected behaviors happened in the 3rd party linear solver.
 
 ### *Symmetric* sparse matrices 
 Only upper triangular nonzero entries should be specified, accessed, and maintained.
-In the current code, only Hessian and the symmetic KKT systems are implelemented as symmetric matrices. Users only need to provide the triangular nonzero entries to Hessian.
-For the symmetic KKT, some linear algebra package, e.g., MA57 from HSL, can read entries from both the upper and lower triangular part. For example, only one entry from KKT[i,j] and KKT[j,i] is requied to be presented in MA57.
+In the current code, only Hessian and the symmetric KKT systems are implelemented as symmetric matrices. Users only need to provide the triangular nonzero entries to Hessian.
+For the symmetric KKT, some linear algebra package, e.g., MA57 from HSL, can read entries from both the upper and lower triangular part. For example, only one entry from KKT[i,j] and KKT[j,i] is required to be presented in MA57.
 If both constraint Jacobian and Lagrangian Hessian are sorted by row in the triplet format, it is easier to copy the entries from Jac/Hes to the lower triangular part and keep the elements sorted by row.
 
 

--- a/src/LinAlg/readme.md
+++ b/src/LinAlg/readme.md
@@ -55,16 +55,19 @@ virtual void addUpperTriangleToSymDenseMatrixUpperTriangle(int diag_start, doubl
 ```
 
 ## Sparse matrices 
-Triplet format is momentarily used for sparse matrices. 
-HSL linear solvers, e.g., MA57, use triplet format as an input.
-To use other linear solvers that require different format, e.g., STRUMPACK uses compressed sparse row (CSR) format, HiOp will make the conversion internally. After converting the matrix from triplet to CSR format, HiOp will sort the 
-nonzeros to prevent unexpected behaviors happened in the 3rd party linear solver.
+Triplet format is momentarily used for sparse matrices. The index arrays `i` and `j` used to store sparse matrices in triplet format need to be kept sorted by the following comparison rules: 
+ - row indexes `i` in increasing order
+ - column indexes `j` for the same row index `i` in strictly increasing order.
+ 
+ Please remark that this does not allow duplicated entries. In a couple of places, HiOp may internally relax this requirement; however, this is  documented at the method level; otherwise, the precondition of sorted (i,j) entries holds for all other methods related to sparse matrices.
+ 
+HiOp offers support for converting sparse triplet format to  compressed sparse row (CSR) format, which, for example, is used with STRUMPACK linear solver. It is worth mentioning that HiOp will also sort the arrays used by the CSR format based on the same rule, which seems to increase robustness with the third party linear solvers that require the CSR format.
 
 ### *Symmetric* sparse matrices 
 Only upper triangular nonzero entries should be specified, accessed, and maintained.
-In the current code, only Hessian and the symmetric KKT systems are implelemented as symmetric matrices. Users only need to provide the triangular nonzero entries to Hessian.
-For the symmetric KKT, some linear algebra package, e.g., MA57 from HSL, can read entries from both the upper and lower triangular part. For example, only one entry from KKT[i,j] and KKT[j,i] is required to be presented in MA57.
-If both constraint Jacobian and Lagrangian Hessian are sorted by row in the triplet format, it is easier to copy the entries from Jac/Hes to the lower triangular part and keep the elements sorted by row.
+The Hessian and the symmetric KKT systems are implemented as symmetric matrices. Users only need to provide the upper triangle nonzero entries to Hessian.
+For the symmetric KKT linearizations, some linear algebra package, e.g., MA57 from HSL, can read entries from both the upper and lower triangular part, however, only one from the entries (i,j) and (j,i) is required to be passed to HSL solvers.
+Developers should be remark that the internal sorting rules for sparse matrices in triplet format enable efficient copying of the constraint Jacobian and Lagrangian Hessian in the KKT linear system matrix.
 
 
 ## Obtaining matrices from HiOp


### PR DESCRIPTION
@cnpetra Please read the sections I added. Especially the part about symmetric sparse matrix.
In fact, now Hessian in the interface requires upper triangular part, and both Jac/Hess for the test problems are sorted by row.
However, when I assemble the sparse KKT matrix in triplet form, I copy the entries from Hessian and jac to the **lower** triangular part. This allow me to keep the elements sorted by row too.
Not sure if I should mention this in the document, since it really doesn't matter how the internal code build KKT and pass it to a direct solver.