### PR TITLE
Create push_mirror.yml

### DIFF
--- a/.github/workflows/push_mirror.yml
+++ b/.github/workflows/push_mirror.yml
@@ -1,0 +1,15 @@
+name: Mirroring
+
+on: [push, delete]
+
+jobs:
+  to_gitlab:
+    runs-on: ubuntu-18.04
+    steps:                                              # <-- must use actions/checkout@v1 before mirroring!
+    - uses: actions/checkout@v1
+    - uses: pixta-dev/repository-mirroring-action@v1
+      with:
+        target_repo_url:
+          git@gitlab.pnnl.gov:2222/exasgd/solvers/hiop.git
+        ssh_private_key:                                # <-- use 'secrets' to pass credential information.
+          ${{ secrets.GITLAB_SSH_PRIVATE_KEY }}


### PR DESCRIPTION
Adding GitHub action from market place to create a push mirror to gitlab.pnnl.gov

Original GitHub action source: https://github.com/pixta-dev/repository-mirroring-action
Still need to enter the token created into an [encrypted secret](https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets)
Expected encrypted secret key name: `GITLAB_SSH_PRIVATE_KEY`