### PR TITLE
Fix in linear algebra module CMake config

### DIFF
--- a/src/LinAlg/CMakeLists.txt
+++ b/src/LinAlg/CMakeLists.txt
@@ -1,3 +1,5 @@
+
+# Set linear algebra common source files
 set(hiopLinAlg_SRC
   hiopVectorPar.cpp
   hiopVectorIntSeq.cpp
@@ -10,6 +12,7 @@ set(hiopLinAlg_SRC
   hiopMatrixComplexSparseTriplet.cpp
 )
 
+# Add interfaces for sparse linear solvers when enabled
 if(HIOP_SPARSE)
     if(HIOP_USE_COINHSL)
       set(hiopLinAlg_SRC ${hiopLinAlg_SRC} hiopLinSolverIndefSparseMA57.cpp)
@@ -19,16 +22,7 @@ if(HIOP_SPARSE)
     endif(HIOP_USE_STRUMPACK)
 endif()
 
-if(HIOP_USE_RAJA)
-  set(hiopLinAlg_SRC ${hiopLinAlg_SRC} hiopLinSolverIndefDenseMagma.cpp)
-  foreach(f hiopVectorRajaPar.cpp
-            hiopVectorIntRaja.cpp
-            hiopMatrixRajaDense.cpp
-            hiopMatrixRajaSparseTriplet.cpp)
-    set_source_files_properties(${f} PROPERTIES LANGUAGE CUDA)
-  endforeach()
-endif()
-
+# Add RAJA/Umpire sources when enabled
 if(HIOP_USE_UMPIRE)
   set(hiopLinAlg_SRC ${hiopLinAlg_SRC}
     hiopVectorRajaPar.cpp
@@ -37,17 +31,31 @@ if(HIOP_USE_UMPIRE)
     hiopMatrixRajaSparseTriplet.cpp)
 endif()
 
+# If GPU support is enabled add Magma interface (CUDA version)
+# Treat RAJA sources as CUDA (temporary, need more flexible solutions)
+if(HIOP_USE_GPU)
+  set(hiopLinAlg_SRC ${hiopLinAlg_SRC} hiopLinSolverIndefDenseMagma.cpp)
+  set_source_files_properties(hiopVectorRajaPar.cpp PROPERTIES LANGUAGE CUDA)
+  set_source_files_properties(hiopVectorIntRaja.cpp PROPERTIES LANGUAGE CUDA)
+  set_source_files_properties(hiopMatrixRajaDense.cpp PROPERTIES LANGUAGE CUDA)
+  set_source_files_properties(hiopMatrixRajaSparseTriplet.cpp PROPERTIES LANGUAGE CUDA)
+endif()
+
+# Add interface to UMFPACK when Kron reduction is enabled
 if(HIOP_WITH_KRON_REDUCTION)
   set(hiopLinAlg_SRC ${hiopLinAlg_SRC} hiopLinSolverUMFPACKZ.cpp)
 endif()
 
+# Build and link linear algebra target
 add_library(hiopLinAlg OBJECT ${hiopLinAlg_SRC})
 target_link_libraries(hiopLinAlg PUBLIC hiop_math)
 
+# Link linear algebra target to Umpire & RAJA when enabled
 if(HIOP_USE_UMPIRE)
   target_link_libraries(hiopLinAlg PUBLIC umpire RAJA OpenMP::OpenMP_CXX)
 endif()
 
+# Build Kron reduction app
 if(HIOP_WITH_KRON_REDUCTION)
   add_executable(test_hiopLinAlgComplex.exe test_hiopLinalgComplex.cpp)
   target_link_libraries(test_hiopLinAlgComplex.exe PRIVATE hiop)


### PR DESCRIPTION
This is a quick fix to the logic in the CMake file for linear algebra module. I added some comments explaining what each CMake stanza does. The modifications passes CI tests on newell and marianas.

Note that at this stage we assume GPU == CUDA and Magma is always enabled when GPU is enabled. This needs to be improved eventually, but it is outside the scope of this PR.