### PR TITLE
Removing RAJA from github actions build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
           cc: gcc
           cxx: g++
           build-type: Debug
-          configure-options: -DHIOP_USE_MPI=OFF -DCMAKE_BUILD_TYPE=Debug -DHIOP_BUILD_SHARED=ON -DHIOP_BUILD_STATIC=ON -DCMAKE_INSTALL_PREFIX=..
+          configure-options: -DHIOP_USE_UMPIRE=OFF -DHIOP_USE_RAJA=OFF -DHIOP_USE_MPI=OFF -DCMAKE_BUILD_TYPE=Debug -DHIOP_BUILD_SHARED=ON -DHIOP_BUILD_STATIC=ON -DCMAKE_INSTALL_PREFIX=..
           run-test: true
           install-build: true
           parallel: 4


### PR DESCRIPTION
RAJA Cmake option defaults to ON which will fail in github actions build/tests. This sets RAJA/Umpire to OFF for actions build. [Here is a link to passing build in my fork.](https://github.com/ashermancinelli/hiop/runs/1455141500?check_suite_focus=true)