### PR TITLE
update of DenseCons and MDS interfaces

### DIFF
--- a/src/Drivers/nlpDenseCons_ex1.hpp
+++ b/src/Drivers/nlpDenseCons_ex1.hpp
@@ -188,7 +188,7 @@ public:
 
   bool eval_Jac_cons(const long long& n, const long long& m, 
 		     const long long& num_cons, const long long* idx_cons,
-                     const double* x_in, bool new_x, double** Jac) 
+                     const double* x_in, bool new_x, double* Jac) 
   {
     assert(n==n_vars); 
     if(0==num_cons) return true; //this may happen when Hiop asks for inequalities, which we don't have in this example
@@ -196,7 +196,7 @@ public:
     //use x as auxiliary
     x->setToConstant(1.);
     _mesh->applyM(*x);
-    x->copyTo(Jac[0]);
+    x->copyTo(Jac);
     return true;
   }
 

--- a/src/Drivers/nlpDenseCons_ex1.hpp
+++ b/src/Drivers/nlpDenseCons_ex1.hpp
@@ -187,7 +187,7 @@ public:
   }
 
   bool eval_Jac_cons(const long long& n, const long long& m, 
-		     const long long& num_cons, const long long* idx_cons,
+                     const long long& num_cons, const long long* idx_cons,
                      const double* x_in, bool new_x, double* Jac) 
   {
     assert(n==n_vars); 

--- a/src/Drivers/nlpDenseCons_ex2.cpp
+++ b/src/Drivers/nlpDenseCons_ex2.cpp
@@ -143,9 +143,12 @@ bool Ex2::eval_cons(const long long& n, const long long& m,
   
   return true;
 }
+
+
+
 bool Ex2::eval_Jac_cons(const long long& n, const long long& m,
 			const long long& num_cons, const long long* idx_cons,  
-			const double* x, bool new_x, double** Jac) 
+			const double* x, bool new_x, double* Jac) 
 {
   assert(n==n_vars); assert(m==n_cons); 
   long long n_local=col_partition[my_rank+1]-col_partition[my_rank];
@@ -156,38 +159,49 @@ bool Ex2::eval_Jac_cons(const long long& n, const long long& m,
   
   
   for(int itcon=0; itcon<num_cons; itcon++) {
+
+    assert(itcon*n_local+n_local <= n_local*num_cons);
+    
     //Jacobian of constraint 1 is all ones
     if(idx_cons[itcon]==0) {
-      for(i=0; i<n_local; i++) Jac[itcon][i]=1.0;
+      for(i=0; i<n_local; i++) Jac[itcon*n_local+i] = 1.0; //!Jac[itcon][i]=1.0;
       continue;
     }
     
     //Jacobian of constraint 2 is all ones except the first entry, which is 2
     if(idx_cons[itcon]==1) {
-      for(i=1; i<n_local; i++) Jac[itcon][i]=1.0;
+      for(i=1; i<n_local; i++) Jac[itcon*n_local+i] = 1.0; //!Jac[itcon][i]=1.0;
       //this is an overkill, but finding it useful for educational purposes
       //is local index 0 the global index 0 (x_1)? If yes the Jac should be 2.0
-      Jac[itcon][0] = idx_local2global(n,0)==0?2.:1.;
+
+      //!Jac[itcon][0] = idx_local2global(n,0)==0?2.:1.;
+      Jac[itcon*n_local+0] = idx_local2global(n,0)==0?2.:1.;
       continue;
     }
     
     //Jacobian of constraint 3
-    if(idx_cons[itcon]==2) {
-      for(i=2; i<n_local; i++) Jac[itcon][i]=1.0;
-      Jac[itcon][0] = idx_local2global(n,0)==0?2.:1.;
-      Jac[itcon][1] = idx_local2global(n,1)==1?0.5:1.;
+    if(idx_cons[itcon]==2) {      
+      for(i=2; i<n_local; i++) Jac[itcon*n_local+i] = 1.0; //!Jac[itcon][i]=1.0;
+      //!Jac[itcon][0] = idx_local2global(n,0)==0?2.:1.;
+      Jac[itcon*n_local+0] = idx_local2global(n,0)==0?2.:1.;
+      //!Jac[itcon][1] = idx_local2global(n,1)==1?0.5:1.;
+      Jac[itcon*n_local+1] = idx_local2global(n,1)==1?0.5:1.;
       continue;
     }
     
     //Jacobian of constraint  4
     if(idx_cons[itcon]==3) {
-      for(i=2; i<n_local; i++) Jac[itcon][i]=1.0;
-      Jac[itcon][0] = idx_local2global(n,0)==0?4.:1.; 
-      Jac[itcon][1] = idx_local2global(n,1)==1?2.:1.;
-      Jac[itcon][2] = idx_local2global(n,2)==2?2.:1.;  
+      for(i=2; i<n_local; i++) Jac[itcon*n_local+i] = 1.0; //!Jac[itcon][i]=1.0;
+      //!Jac[itcon][0] = idx_local2global(n,0)==0?4.:1.;
+      Jac[itcon*n_local+0] = idx_local2global(n,0)==0?4.:1.; 
+      //!Jac[itcon][1] = idx_local2global(n,1)==1?2.:1.;
+      Jac[itcon*n_local+1] = idx_local2global(n,1)==1?2.:1.;
+      //!Jac[itcon][2] = idx_local2global(n,2)==2?2.:1.;
+      Jac[itcon*n_local+2] = idx_local2global(n,2)==2?2.:1.;
     }
   }
   return true;
+
 }
 
 bool Ex2::get_vecdistrib_info(long long global_n, long long* cols)

--- a/src/Drivers/nlpDenseCons_ex2.hpp
+++ b/src/Drivers/nlpDenseCons_ex2.hpp
@@ -41,8 +41,9 @@ public:
 			 const double* x, bool new_x, double* cons);
   virtual bool eval_grad_f(const long long& n, const double* x, bool new_x, double* gradf);
   virtual bool eval_Jac_cons(const long long& n, const long long& m,
-			     const long long& num_cons, const long long* idx_cons,  
-			     const double* x, bool new_x, double** Jac);
+                             const long long& num_cons, const long long* idx_cons,  
+                             const double* x, bool new_x, double* Jac);
+
   virtual bool get_vecdistrib_info(long long global_n, long long* cols);
 
   virtual bool get_starting_point(const long long&n, double* x0);

--- a/src/Drivers/nlpDenseCons_ex3.hpp
+++ b/src/Drivers/nlpDenseCons_ex3.hpp
@@ -145,8 +145,8 @@ public:
   }
  
   virtual bool eval_Jac_cons(const long long& n, const long long& m,
-			     const long long& num_cons, const long long* idx_cons,  
-			     const double* x, bool new_x, double* Jac)
+                             const long long& num_cons, const long long* idx_cons,
+                             const double* x, bool new_x, double* Jac)
   {
 
     assert(n==n_vars); assert(m==n_cons); 

--- a/src/Drivers/nlpDenseCons_ex3.hpp
+++ b/src/Drivers/nlpDenseCons_ex3.hpp
@@ -146,8 +146,9 @@ public:
  
   virtual bool eval_Jac_cons(const long long& n, const long long& m,
 			     const long long& num_cons, const long long* idx_cons,  
-			     const double* x, bool new_x, double** Jac)
+			     const double* x, bool new_x, double* Jac)
   {
+
     assert(n==n_vars); assert(m==n_cons); 
     long long n_local=col_partition[my_rank+1]-col_partition[my_rank];
     int i;
@@ -159,16 +160,17 @@ public:
     for(int itcon=0; itcon<num_cons; itcon++) {
       //Jacobian of constraint 1 is all ones
       if(idx_cons[itcon]==0) {
-	for(i=0; i<n_local; i++) Jac[itcon][i]=1.0;
+	for(i=0; i<n_local; i++) Jac[itcon*n_local+i] = 1.0; //!Jac[itcon][i]=1.0;
 	continue;
       }
     
       //Jacobian of constraint 2 is all ones except the first entry, which is 2
       if(idx_cons[itcon]==1) {
-	for(i=1; i<n_local; i++) Jac[itcon][i]=1.0;
+	for(i=1; i<n_local; i++) Jac[itcon*n_local+i] = 1.0; //!Jac[itcon][i]=1.0;
 	//this is an overkill, but finding it useful for educational purposes
 	//is local index 0 the global index 0 (x_1)? If yes the Jac should be 2.0
-	Jac[itcon][0] = idx_local2global(n,0)==0?2.:1.;
+	//!Jac[itcon][0] = idx_local2global(n,0)==0?2.:1.;
+        Jac[itcon*n_local+0] = idx_local2global(n,0)==0?2.:1.;
 	continue;
       }
     }

--- a/src/Drivers/nlpMDSForm_ex4.hpp
+++ b/src/Drivers/nlpMDSForm_ex4.hpp
@@ -248,7 +248,7 @@ public:
 		const double* x, bool new_x,
 		const long long& nsparse, const long long& ndense, 
 		const int& nnzJacS, int* iJacS, int* jJacS, double* MJacS, 
-		double** JacD)
+		double* JacD)
   {
     assert(num_cons==ns || num_cons==3*haveIneq);
 
@@ -345,12 +345,13 @@ public:
 	  assert(con_idx-ns==0 || con_idx-ns==1 || con_idx-ns==2);
 	  assert(num_cons==3);
 	  for(int i=0; i<nd; i++) {
-	    JacD[con_idx-ns][i] = 1.;
+	    //!JacD[con_idx-ns][i] = 1.;
+            JacD[(con_idx-ns)*nd+i] = 1.;
 	  }
 	}
       }
       if(isEq) {
-	memcpy(JacD[0], Md->local_buffer(), ns*nd*sizeof(double));
+	memcpy(JacD, Md->local_buffer(), ns*nd*sizeof(double));
       }
     }
 
@@ -358,12 +359,12 @@ public:
   }
  
   bool eval_Hess_Lagr(const long long& n, const long long& m, 
-			      const double* x, bool new_x, const double& obj_factor,
-			      const double* lambda, bool new_lambda,
-			      const long long& nsparse, const long long& ndense, 
-			      const int& nnzHSS, int* iHSS, int* jHSS, double* MHSS, 
-			      double** HDD,
-			      int& nnzHSD, int* iHSD, int* jHSD, double* MHSD)
+                      const double* x, bool new_x, const double& obj_factor,
+                      const double* lambda, bool new_lambda,
+                      const long long& nsparse, const long long& ndense, 
+                      const int& nnzHSS, int* iHSS, int* jHSS, double* MHSS, 
+                      double* HDD,
+                      int& nnzHSD, int* iHSD, int* jHSD, double* MHSD)
   {
     //Note: lambda is not used since all the constraints are linear and, therefore, do 
     //not contribute to the Hessian of the Lagrangian
@@ -385,7 +386,7 @@ public:
       //memcpy(HDD[0], Q->local_buffer(), nx_dense_squared*sizeof(double));
       const double* Qv = Q->local_buffer();
       for(int i=0; i<nx_dense_squared; i++)
-	HDD[0][i] = obj_factor*Qv[i];
+	HDD[i] = obj_factor*Qv[i];
     }
     return true;
   }
@@ -536,7 +537,7 @@ public:
 		const double* x, bool new_x,
 		const long long& nsparse, const long long& ndense, 
 		const int& nnzJacS, int* iJacS, int* jJacS, double* MJacS, 
-		double** JacD)
+		double* JacD)
   {
     return false; // so that HiOp will call the one-call full-Jacob function below
   }
@@ -546,7 +547,7 @@ public:
 		const double* x, bool new_x,
 		const long long& nsparse, const long long& ndense, 
 		const int& nnzJacS, int* iJacS, int* jJacS, double* MJacS, 
-		double** JacD)
+		double* JacD)
   {
     assert(m==ns+3*haveIneq);
 
@@ -633,13 +634,13 @@ public:
     //dense Jacobian w.r.t y
     if(JacD!=NULL) {
       //just copy the dense Jacobian corresponding to equalities
-      memcpy(JacD[0], Md->local_buffer(), ns*nd*sizeof(double));
+      memcpy(JacD, Md->local_buffer(), ns*nd*sizeof(double));
       
       if(haveIneq) {
 	assert(ns+3 == m);
 	//do an in place fill-in for the ineq Jacobian corresponding to e^T
 	for(int i=0; i<3*nd; ++i)
-	  JacD[ns][i] = 1.;
+	  JacD[ns*nd+i] = 1.;
       }
     }
     return true;

--- a/src/Drivers/nlpMDSForm_ex4.hpp
+++ b/src/Drivers/nlpMDSForm_ex4.hpp
@@ -67,10 +67,12 @@ public:
     Q  = hiop::LinearAlgebraFactory::createMatrixDense(nd,nd);
     Q->setToConstant(1e-8);
     Q->addDiagonal(2.);
-    double** Qa = Q->get_M();
+    double* Qa = Q->local_data();
     for(int i=1; i<nd-1; i++) {
-      Qa[i][i+1] = 1.;
-      Qa[i+1][i] = 1.;
+      //Qa[i][i+1] = 1.;
+      Qa[i*nd+i+1] = 1.;
+      //Qa[i+1][i] = 1.;
+      Qa[(i+1)*nd+i] = 1.;
     }
 
     Md = hiop::LinearAlgebraFactory::createMatrixDense(ns,nd);
@@ -351,7 +353,7 @@ public:
 	}
       }
       if(isEq) {
-	memcpy(JacD, Md->local_buffer(), ns*nd*sizeof(double));
+	memcpy(JacD, Md->local_data(), ns*nd*sizeof(double));
       }
     }
 
@@ -384,7 +386,7 @@ public:
     if(HDD!=NULL) {
       const int nx_dense_squared = nd*nd;
       //memcpy(HDD[0], Q->local_buffer(), nx_dense_squared*sizeof(double));
-      const double* Qv = Q->local_buffer();
+      const double* Qv = Q->local_data();
       for(int i=0; i<nx_dense_squared; i++)
 	HDD[i] = obj_factor*Qv[i];
     }
@@ -634,7 +636,7 @@ public:
     //dense Jacobian w.r.t y
     if(JacD!=NULL) {
       //just copy the dense Jacobian corresponding to equalities
-      memcpy(JacD, Md->local_buffer(), ns*nd*sizeof(double));
+      memcpy(JacD, Md->local_data(), ns*nd*sizeof(double));
       
       if(haveIneq) {
 	assert(ns+3 == m);

--- a/src/Drivers/nlpMDSForm_raja_ex4.cpp
+++ b/src/Drivers/nlpMDSForm_raja_ex4.cpp
@@ -103,7 +103,7 @@ void Ex4::initialize()
   Q_->setToConstant(1e-8);
   Q_->addDiagonal(2.);
 
-  double* data = Q_->local_buffer();
+  double* data = Q_->local_data();
   RAJA::View<double, RAJA::Layout<2>> Qview(data, nd_, nd_);
   RAJA::forall<ex4_raja_exec>(RAJA::RangeSegment(1, nd_-1),
     RAJA_LAMBDA(RAJA::Index_type i)
@@ -459,7 +459,7 @@ bool Ex4::eval_Jac_cons(const long long& n, const long long& m,
     const double* x, bool new_x,
     const long long& nsparse, const long long& ndense, 
     const int& nnzJacS, int* iJacS, int* jJacS, double* MJacS, 
-    double** JacD)
+    double* JacD)
 {
   assert(num_cons==ns_ || num_cons==3*haveIneq_);
 
@@ -550,12 +550,11 @@ bool Ex4::eval_Jac_cons(const long long& n, const long long& m,
     if(num_cons == ns_ && ns_ > static_cast<int>(idx_cons[0]))
     {
       //assert(num_cons==ns_);
-      double* data = JacD[0];
       auto& rm = umpire::ResourceManager::getInstance();
       if(mem_space_ == "DEFAULT")
-        memcpy(data, Md_->local_buffer(), ns_*nd_*sizeof(double));
+        memcpy(JacD, Md_->local_data_const(), ns_*nd_*sizeof(double));
       else
-        rm.copy(data, Md_->local_buffer(), ns_*nd_*sizeof(double));
+        rm.copy(JacD, Md_->local_data_const(), ns_*nd_*sizeof(double));
     }
 
     if(num_cons==3 && haveIneq_ && ns_>0)
@@ -566,7 +565,8 @@ bool Ex4::eval_Jac_cons(const long long& n, const long long& m,
         //do an in place fill-in for the ineq Jacobian corresponding to e^T
         assert(con_idx-ns_==0 || con_idx-ns_==1 || con_idx-ns_==2);
         assert(num_cons==3);
-        double* J = JacD[con_idx-ns_];
+        //double* J = JacD[con_idx-ns_];
+	double* J = JacD + nd_*(con_idx-ns_);
         RAJA::forall<ex4_raja_exec>(RAJA::RangeSegment(0, nd_),
           RAJA_LAMBDA(RAJA::Index_type i)
           {
@@ -595,7 +595,7 @@ bool Ex4::eval_Hess_Lagr(const long long& n, const long long& m,
     const double* lambda, bool new_lambda,
     const long long& nsparse, const long long& ndense, 
     const int& nnzHSS, int* iHSS, int* jHSS, double* MHSS, 
-    double** HDD,
+    double* HDD,
     int& nnzHSD, int* iHSD, int* jHSD, double* MHSD)
 {
   //Note: lambda is not used since all the constraints are linear and, therefore, do 
@@ -626,11 +626,11 @@ bool Ex4::eval_Hess_Lagr(const long long& n, const long long& m,
   if(HDD!=NULL)
   {
     const int nx_dense_squared = nd_*nd_;
-    const double* Qv = Q_->local_buffer();
+    const double* Qv = Q_->local_data();
     RAJA::forall<ex4_raja_exec>(RAJA::RangeSegment(0, nx_dense_squared),
       RAJA_LAMBDA(RAJA::Index_type i)
       {
-        HDD[0][i] = obj_factor*Qv[i];
+        HDD[i] = obj_factor*Qv[i];
       });
   }
   return true;
@@ -820,7 +820,7 @@ bool Ex4OneCallCons::eval_Jac_cons(const long long& n, const long long& m,
     const double* x, bool new_x,
     const long long& nsparse, const long long& ndense, 
     const int& nnzJacS, int* iJacS, int* jJacS, double* MJacS, 
-    double** JacD)
+    double* JacD)
 {
   assert(m==ns_+3*haveIneq_);
 
@@ -885,15 +885,16 @@ bool Ex4OneCallCons::eval_Jac_cons(const long long& n, const long long& m,
     //just copy the dense Jacobian corresponding to equalities
     auto& rm = umpire::ResourceManager::getInstance();
     if(mem_space_ == "DEFAULT")
-      memcpy(JacD[0], Md_->local_buffer(), ns_*nd_*sizeof(double));
+      memcpy(JacD, Md_->local_data_const(), ns_*nd_*sizeof(double));
     else
-      rm.copy(JacD[0], Md_->local_buffer(), ns_*nd_*sizeof(double));
+      rm.copy(JacD, Md_->local_data_const(), ns_*nd_*sizeof(double));
 
     if(haveIneq_)
     {
       assert(ns_+3 == m);
       //do an in place fill-in for the ineq Jacobian corresponding to e^T
-      double* J = JacD[ns_];
+      //double* J = JacD[ns_];
+      double* J = JacD + ns_*nd_;
       RAJA::forall<ex4_raja_exec>(RAJA::RangeSegment(0, 3*nd_),
         RAJA_LAMBDA(RAJA::Index_type i)
         {

--- a/src/Drivers/nlpMDSForm_raja_ex4.cpp
+++ b/src/Drivers/nlpMDSForm_raja_ex4.cpp
@@ -566,7 +566,7 @@ bool Ex4::eval_Jac_cons(const long long& n, const long long& m,
         assert(con_idx-ns_==0 || con_idx-ns_==1 || con_idx-ns_==2);
         assert(num_cons==3);
         //double* J = JacD[con_idx-ns_];
-	double* J = JacD + nd_*(con_idx-ns_);
+        double* J = JacD + nd_*(con_idx-ns_);
         RAJA::forall<ex4_raja_exec>(RAJA::RangeSegment(0, nd_),
           RAJA_LAMBDA(RAJA::Index_type i)
           {

--- a/src/Drivers/nlpMDSForm_raja_ex4.hpp
+++ b/src/Drivers/nlpMDSForm_raja_ex4.hpp
@@ -112,13 +112,13 @@ public:
         const double* x, bool new_x,
         const long long& nsparse, const long long& ndense, 
         const int& nnzJacS, int* iJacS, int* jJacS, double* MJacS, 
-        double** JacD);
+        double* JacD);
 
   virtual bool eval_Jac_cons(const long long& n, const long long& m, 
         const double* x, bool new_x,
         const long long& nsparse, const long long& ndense, 
         const int& nnzJacS, int* iJacS, int* jJacS, double* MJacS, 
-        double** JacD)
+        double* JacD)
   {
     //return false so that HiOp will rely on the Jacobian evaluator defined above
     return false;
@@ -129,7 +129,7 @@ public:
       const double* lambda, bool new_lambda,
       const long long& nsparse, const long long& ndense, 
       const int& nnzHSS, int* iHSS, int* jHSS, double* MHSS, 
-      double** HDD,
+      double* HDD,
       int& nnzHSD, int* iHSD, int* jHSD, double* MHSD);
 
   /* Implementation of the primal starting point specification */
@@ -203,7 +203,7 @@ class Ex4OneCallCons : public Ex4
           const double* x, bool new_x,
           const long long& nsparse, const long long& ndense, 
           const int& nnzJacS, int* iJacS, int* jJacS, double* MJacS, 
-          double** JacD)
+          double* JacD)
       {
         return false; // so that HiOp will call the one-call full-Jacob function below
       }
@@ -212,7 +212,7 @@ class Ex4OneCallCons : public Ex4
           const double* x, bool new_x,
           const long long& nsparse, const long long& ndense, 
           const int& nnzJacS, int* iJacS, int* jJacS, double* MJacS, 
-          double** JacD);
+          double* JacD);
 };
 
 #endif

--- a/src/Drivers/nlpMDS_ex5.hpp
+++ b/src/Drivers/nlpMDS_ex5.hpp
@@ -78,10 +78,12 @@ public:
     Q_  = hiop::LinearAlgebraFactory::createMatrixDense(nd_,nd_);
     Q_->setToConstant(0.);
     Q_->addDiagonal(2. * (2*convex_obj_-1)); //-2 or 2
-    double** Qa = Q_->get_M();
+    double* Qa = Q_->local_data();
     for(int i=1; i<nd-1; i++) {
-      Qa[i][i+1] = 1.;
-      Qa[i+1][i] = 1.;
+      //Qa[i][i+1] = 1.;
+      Qa[i*nd_+i+1] = 1.;
+      //Qa[i+1][i] = 1.;
+      Qa[(i+1)*nd_+i] = 1.;
     }
 
     Md_ = hiop::LinearAlgebraFactory::createMatrixDense(ns_, nd_);
@@ -471,7 +473,7 @@ public:
     //
     if(JacD!=NULL) {
       //eq
-      memcpy(JacD, Md_->local_buffer(), ns_*nd_*sizeof(double));
+      memcpy(JacD, Md_->local_data(), ns_*nd_*sizeof(double));
       
       //ineq
       for(int i=0; i<3*nd_; i++) {
@@ -489,7 +491,7 @@ public:
       }
       
       if(rankdefic_eq_) {
-	memcpy(JacD+con_idx*nd_, Md_->local_buffer(), ns_*nd_*sizeof(double));
+	memcpy(JacD+con_idx*nd_, Md_->local_data(), ns_*nd_*sizeof(double));
 	con_idx += ns_;
       }
 
@@ -526,7 +528,7 @@ public:
     if(HDD!=NULL) {
       const int nx_dense_squared = nd_*nd_;
       //memcpy(HDD[0], Q->local_buffer(), nx_dense_squared*sizeof(double));
-      const double* Qv = Q_->local_buffer();
+      const double* Qv = Q_->local_data();
       for(int i=0; i<nx_dense_squared; i++)
 	HDD[i] = obj_factor*Qv[i];
     }

--- a/src/Drivers/nlpMDS_ex5.hpp
+++ b/src/Drivers/nlpMDS_ex5.hpp
@@ -303,7 +303,7 @@ public:
 		const double* x, bool new_x,
 		const long long& nsparse, const long long& ndense, 
 		const int& nnzJacS, int* iJacS, int* jJacS, double* MJacS, 
-		double** JacD)
+		double* JacD)
   {
     //return false so that HiOp will rely on the on-call constraint evaluator defined below
     return false;
@@ -314,7 +314,7 @@ public:
  		const double* x, bool new_x,
  		const long long& nsparse, const long long& ndense, 
  		const int& nnzJacS, int* iJacS, int* jJacS, double* MJacS, 
- 		double** JacD)
+ 		double* JacD)
   {
     assert(m == ns_ + 3 + 2*rankdefic_ineq_ + ns_*rankdefic_eq_);
     assert(nnzJacS ==  2*ns_ + rankdefic_eq_*2*ns_ +  (ns_==0) ? 0 : 3+ns_ + rankdefic_ineq_*2*(2+ns_));
@@ -471,23 +471,25 @@ public:
     //
     if(JacD!=NULL) {
       //eq
-      memcpy(JacD[0], Md_->local_buffer(), ns_*nd_*sizeof(double));
+      memcpy(JacD, Md_->local_buffer(), ns_*nd_*sizeof(double));
       
       //ineq
       for(int i=0; i<3*nd_; i++) {
-	JacD[ns_][i] = 1.;
+	//!JacD[ns_][i] = 1.;
+        JacD[ns_*nd_+i] = 1.;
       }
 
       int con_idx=ns_+3;
       if(rankdefic_ineq_) {
 	for(int i=0; i<2*nd_; i++) {
-	  JacD[con_idx][i] = 2.;
+	  //!JacD[con_idx][i] = 2.;
+          JacD[con_idx*nd_+i] = 2.;
 	}
 	con_idx += 2;
       }
       
       if(rankdefic_eq_) {
-	memcpy(JacD[con_idx], Md_->local_buffer(), ns_*nd_*sizeof(double));
+	memcpy(JacD+con_idx*nd_, Md_->local_buffer(), ns_*nd_*sizeof(double));
 	con_idx += ns_;
       }
 
@@ -498,12 +500,12 @@ public:
   }
  
   bool eval_Hess_Lagr(const long long& n, const long long& m, 
-			      const double* x, bool new_x, const double& obj_factor,
-			      const double* lambda, bool new_lambda,
-			      const long long& nsparse, const long long& ndense, 
-			      const int& nnzHSS, int* iHSS, int* jHSS, double* MHSS, 
-			      double** HDD,
-			      int& nnzHSD, int* iHSD, int* jHSD, double* MHSD)
+                      const double* x, bool new_x, const double& obj_factor,
+                      const double* lambda, bool new_lambda,
+                      const long long& nsparse, const long long& ndense, 
+                      const int& nnzHSS, int* iHSS, int* jHSS, double* MHSS, 
+                      double* HDD,
+                      int& nnzHSD, int* iHSD, int* jHSD, double* MHSD)
   {
     //Note: lambda is not used since all the constraints are linear and, therefore, do 
     //not contribute to the Hessian of the Lagrangian
@@ -526,7 +528,7 @@ public:
       //memcpy(HDD[0], Q->local_buffer(), nx_dense_squared*sizeof(double));
       const double* Qv = Q_->local_buffer();
       for(int i=0; i<nx_dense_squared; i++)
-	HDD[0][i] = obj_factor*Qv[i];
+	HDD[i] = obj_factor*Qv[i];
     }
     return true;
   }

--- a/src/Interface/chiopInterface.hpp
+++ b/src/Interface/chiopInterface.hpp
@@ -125,7 +125,7 @@ class cppUserProblem : public hiopInterfaceMDS
       const double* x, bool new_x,
       const long long& nsparse, const long long& ndense, 
       const int& nnzJacS, int* iJacS, int* jJacS, double* MJacS, 
-      double** JacD)
+      double* JacD)
     {
       return false;
     };
@@ -133,10 +133,11 @@ class cppUserProblem : public hiopInterfaceMDS
       const double* x, bool new_x,
       const long long& nsparse, const long long& ndense, 
       const int& nnzJacS, int* iJacS, int* jJacS, double* MJacS, 
-      double** JacD)
+      double* JacD)
     {
       cprob->eval_Jac_cons(n, m, (double *) x, new_x, nsparse, ndense, 
-                                          nnzJacS, iJacS, jJacS, MJacS, &JacD[0][0], cprob->user_data);
+                           nnzJacS, iJacS, jJacS, MJacS,
+                           JacD, cprob->user_data);
       return true;
     };
     bool eval_Hess_Lagr(const long long& n, const long long& m,
@@ -144,15 +145,17 @@ class cppUserProblem : public hiopInterfaceMDS
       const double* lambda, bool new_lambda,
       const long long& nsparse, const long long& ndense, 
       const int& nnzHSS, int* iHSS, int* jHSS, double* MHSS, 
-      double** HDD,
+      double* HDD,
       int& nnzHSD, int* iHSD, int* jHSD, double* MHSD)
     {
       //Note: lambda is not used since all the constraints are linear and, therefore, do 
       //not contribute to the Hessian of the Lagrangian
-      cprob->eval_Hess_Lagr(n, m, (double *) x, new_x, obj_factor, (double *) lambda, new_lambda, nsparse, ndense,
-                                          nnzHSS, iHSS, jHSS, MHSS, 
-                                          &HDD[0][0], 
-                                          nnzHSD, iHSD, jHSD, MHSD, cprob->user_data);
+      cprob->eval_Hess_Lagr(n, m, (double *) x, new_x, obj_factor,
+                            (double *) lambda, new_lambda, nsparse, ndense,
+                            nnzHSS, iHSS, jHSS, MHSS, 
+                            HDD, 
+                            nnzHSD, iHSD, jHSD, MHSD,
+                            cprob->user_data);
       return true;
     };
 private:

--- a/src/Interface/hiopInterface.hpp
+++ b/src/Interface/hiopInterface.hpp
@@ -246,7 +246,7 @@ public:
   /**
    * Method provides a primal or starting point. This point is subject to internal adjustments.
    *
-   * @note Avoid using this method since it will removed in a future release and replaced with
+   * @note Avoid using this method since it will be removed in a future release and replaced with
    * the same-name method below.
    *
    * The method returns true (and populates @p x0) or returns false, in which case HiOp will 

--- a/src/Interface/hiopInterface.hpp
+++ b/src/Interface/hiopInterface.hpp
@@ -300,33 +300,40 @@ class hiopInterfaceDenseConstraints : public hiopInterfaceBase
 public:
   hiopInterfaceDenseConstraints() {};
   virtual ~hiopInterfaceDenseConstraints() {};
-  /** Evaluates the Jacobian of the subset of constraints indicated by idx_cons and of size num_cons.
-   *  Example: Assuming idx_cons[k]=i, which means that the gradient of the (i+1)th constraint is
-   *  to be evaluated, one needs to do Jac[k][0]=d/dx_0 con_i(x), Jac[k][1]=d/dx_1 con_i(x), ...
-   *  When MPI enabled, each rank computes only the local columns of the Jacobian, that is the partials
-   *  with respect to local variables.
+  /** 
+   * Evaluates the Jacobian of the subset of constraints indicated by idx_cons and of size num_cons.
+   * Example: Assuming idx_cons[k]=i, which means that the gradient of the (i+1)th constraint is
+   * to be evaluated, one needs to do Jac[k][0]=d/dx_0 con_i(x), Jac[k][1]=d/dx_1 con_i(x), ...
+   * When MPI enabled, each rank computes only the local columns of the Jacobian, that is the partials
+   * with respect to local variables.
    *
-   *  Parameters: see eval_cons
+   * The parameter 'Jac' is passed as as a contiguous array storing the dense Jacobian matrix by rows.
+   *
+   * Parameters: see eval_cons
    */
   virtual bool eval_Jac_cons(const long long& n, const long long& m, 
 			     const long long& num_cons, const long long* idx_cons,  
 			     const double* x, bool new_x,
-			     double** Jac) = 0;
+                             double* Jac) = 0;
   
-  /** Evaluates the Jacobian of equality and inequality constraints in one call. 
+  /**
+   * Evaluates the Jacobian of equality and inequality constraints in one call. 
    *
    * The main difference from the above 'eval_Jac_cons' is that the implementer/user of this 
    * method does not have to split the constraints into equalities and inequalities; instead,
    * HiOp does this internally.
    *
+   * The parameter 'Jac' is passed as as a contiguous array storing the dense Jacobian matrix by rows.
+   *
    * TODO: build an example (new one-call Nlp formulation derived from ex2) to illustrate this 
    * feature and to test HiOp's internal implementation of eq.-ineq. spliting.
    */
   virtual bool eval_Jac_cons(const long long& n, const long long& m,
-  			     const double* x, bool new_x,
-  			     double** Jac) { return false; }
-
-  
+                             const double* x, bool new_x,
+                             double* Jac)
+  {
+    return false;
+  }
 };
 
 /** Specialized interface for NLPs having mixed DENSE and sparse (MDS) blocks in the 
@@ -373,8 +380,7 @@ public:
    *  - first six: see eval_cons (in parent class)
    *  - nnzJacS, iJacS, jJacS, MJacS: number of nonzeros, (i,j) indexes, and values of 
    * the sparse Jacobian
-   *  - JacD: dense Jacobian as a contiguous array storing the matrix by rows; array is
-   * "primed" to support double indexing JacD[i][j]
+   *  - JacD: dense Jacobian as a contiguous array storing the matrix by rows
    * 
    * Notes for implementer of this method: 
    * 1) 'JacD' parameter will be always non-null
@@ -392,8 +398,7 @@ public:
 			     const double* x, bool new_x,
 			     const long long& nsparse, const long long& ndense, 
 			     const int& nnzJacS, int* iJacS, int* jJacS, double* MJacS, 
-			     double** JacD) = 0;
-  
+			     double* JacD) = 0;
   /** Evaluates the Jacobian of equality and inequality constraints in one call. This Jacobian is
    * mixed dense-sparse (MDS), which means is structurally split in the sparse (triplet format) and 
    * dense matrices (rows storage)
@@ -411,8 +416,7 @@ public:
    *  - nnzJacS, iJacS, jJacS, MJacS: number of nonzeros, (i,j) indexes, and values of 
    * the sparse Jacobian block; indexes are within the sparse Jacobian block (not within 
    * the entire Jacobian)
-   *  - JacD: dense Jacobian block as a contiguous array storing the matrix by rows; array is
-   * "primed" to support double indexing JacD[i][j]
+   *  - JacD: dense Jacobian block as a contiguous array storing the matrix by rows
    * 
    * Notes for implementer of this method: 
    * 1) 'JacD' parameter will be always non-null
@@ -431,7 +435,10 @@ public:
 			     const double* x, bool new_x,
 			     const long long& nsparse, const long long& ndense, 
 			     const int& nnzJacS, int* iJacS, int* jJacS, double* MJacS, 
-			     double** JacD){ return false; }
+			     double* JacD)
+  {
+    return false;
+  }
 
   
   /** Evaluates the Hessian of the Lagrangian function in 3 structural blocks
@@ -452,9 +459,8 @@ public:
 			      const double* lambda, bool new_lambda,
 			      const long long& nsparse, const long long& ndense, 
 			      const int& nnzHSS, int* iHSS, int* jHSS, double* MHSS, 
-			      double** HDD,
+			      double* HDD,
 			      int& nnzHSD, int* iHSD, int* jHSD, double* MHSD) = 0;
-
 };
 
 

--- a/src/LinAlg/hiopLinSolverIndefDenseMagma.cpp
+++ b/src/LinAlg/hiopLinSolverIndefDenseMagma.cpp
@@ -54,7 +54,7 @@ namespace hiop
     //
     //query sizes
     //
-    magma_dsytrf(uplo, N, M_->local_buffer(), lda, ipiv, &info );
+    magma_dsytrf(uplo, N, M_->local_data(), lda, ipiv, &info );
 
     nlp_->runStats.linsolv.tmFactTime.stop();
     nlp_->runStats.linsolv.flopsFact = gflops / nlp_->runStats.linsolv.tmFactTime.getElapsedTime() / 1000.;
@@ -86,7 +86,7 @@ namespace hiop
     int posEigVal=0;
     int nullEigVal=0;
     double t=0;
-    double* MM = M_->local_buffer();
+    double* MM = M_->local_data();
     for(int k=0; k<N; k++) {
       //c       2 by 2 block
       //c       use det (d  s)  =  (d/t * c - t) * t  ,  t = dabs(s)
@@ -140,7 +140,7 @@ namespace hiop
     
     char uplo='L'; // M is upper in C++ so it's lower in fortran
     int info;
-    DSYTRS(&uplo, &N, &NRHS, M_->local_buffer(), &LDA, ipiv, x.local_data(), &LDB, &info);
+    DSYTRS(&uplo, &N, &NRHS, M_->local_data(), &LDA, ipiv, x.local_data(), &LDB, &info);
     if(info<0) {
       nlp_->log->printf(hovError, "hiopLinSolverMagmaBuKa: (LAPACK) DSYTRS returned error %d\n", info);
       assert(false);
@@ -280,13 +280,13 @@ namespace hiop
     if(mem_space == "default" || mem_space == "host")
     {
       nlp_->runStats.linsolv.tmDeviceTransfer.start();
-      magma_dsetmatrix(N, N,    M_->local_buffer(), LDA, device_M_,   ldda_, magma_device_queue_);
+      magma_dsetmatrix(N, N,    M_->local_data(), LDA, device_M_,   ldda_, magma_device_queue_);
       magma_dsetmatrix(N, NRHS, x.local_data(),   LDB, device_rhs_, lddb_, magma_device_queue_);
       nlp_->runStats.linsolv.tmDeviceTransfer.stop();
     }
     else
     {
-      device_M_   = M_->local_buffer();
+      device_M_   = M_->local_data();
       device_rhs_ = x.local_data();
     }
     

--- a/src/LinAlg/hiopMatrixDense.hpp
+++ b/src/LinAlg/hiopMatrixDense.hpp
@@ -217,6 +217,7 @@ public:
   //TODO: this is not kosher!
   virtual double** local_data() const {assert(false && "not implemented in base class"); return nullptr;}
   virtual double*  local_buffer() const {assert(false && "not implemented in base class"); return nullptr;}
+  virtual double*  local_buffer2() {assert(false && "not implemented in base class"); return nullptr;}
   //do not use this unless you sure you know what you're doing
   virtual double** get_M(){assert(false && "not implemented in base class"); return nullptr;}
 

--- a/src/LinAlg/hiopMatrixDense.hpp
+++ b/src/LinAlg/hiopMatrixDense.hpp
@@ -214,9 +214,8 @@ public:
   virtual long long get_local_size_m() const {assert(false && "not implemented in base class"); return -1;}
   virtual MPI_Comm get_mpi_comm() const { return comm_; }
 
-  //virtual double** local_data() const {assert(false && "not implemented in base class"); return nullptr;}
-  virtual double*  local_data_const() const {assert(false && "not implemented in base class"); return nullptr;}
-  virtual double*  local_data() {assert(false && "not implemented in base class"); return nullptr;}
+  virtual double* local_data_const() const {assert(false && "not implemented in base class"); return nullptr;}
+  virtual double* local_data() {assert(false && "not implemented in base class"); return nullptr;}
 protected:
   //do not use this unless you sure you know what you're doing
   virtual double** get_M(){assert(false && "not implemented in base class"); return nullptr;}

--- a/src/LinAlg/hiopMatrixDense.hpp
+++ b/src/LinAlg/hiopMatrixDense.hpp
@@ -214,13 +214,13 @@ public:
   virtual long long get_local_size_m() const {assert(false && "not implemented in base class"); return -1;}
   virtual MPI_Comm get_mpi_comm() const { return comm_; }
 
-  //TODO: this is not kosher!
-  virtual double** local_data() const {assert(false && "not implemented in base class"); return nullptr;}
-  virtual double*  local_buffer() const {assert(false && "not implemented in base class"); return nullptr;}
-  virtual double*  local_buffer2() {assert(false && "not implemented in base class"); return nullptr;}
+  //virtual double** local_data() const {assert(false && "not implemented in base class"); return nullptr;}
+  virtual double*  local_data_const() const {assert(false && "not implemented in base class"); return nullptr;}
+  virtual double*  local_data() {assert(false && "not implemented in base class"); return nullptr;}
+protected:
   //do not use this unless you sure you know what you're doing
   virtual double** get_M(){assert(false && "not implemented in base class"); return nullptr;}
-
+public:
   virtual long long m() const {return m_local_;}
   virtual long long n() const {return n_global_;}
 #ifdef HIOP_DEEPCHECKS

--- a/src/LinAlg/hiopMatrixDense.hpp
+++ b/src/LinAlg/hiopMatrixDense.hpp
@@ -216,9 +216,6 @@ public:
 
   virtual double* local_data_const() const {assert(false && "not implemented in base class"); return nullptr;}
   virtual double* local_data() {assert(false && "not implemented in base class"); return nullptr;}
-protected:
-  //do not use this unless you sure you know what you're doing
-  virtual double** get_M(){assert(false && "not implemented in base class"); return nullptr;}
 public:
   virtual long long m() const {return m_local_;}
   virtual long long n() const {return n_global_;}

--- a/src/LinAlg/hiopMatrixDenseRowMajor.cpp
+++ b/src/LinAlg/hiopMatrixDenseRowMajor.cpp
@@ -506,6 +506,7 @@ void hiopMatrixDenseRowMajor::timesMat(double beta, hiopMatrix& W_, double alpha
     W.setToConstant(beta);
     return;
   }
+
   timesMat_local(beta,W_,alpha,X_);
   // if(0==myrank_) timesMat_local(beta,W_,alpha,X_);
   // else          timesMat_local(0.,  W_,alpha,X_);
@@ -542,8 +543,9 @@ void hiopMatrixDenseRowMajor::timesMat_local(double beta, hiopMatrix& W_, double
   int ldx=X.n(), ldm=n_local_, ldw=X.n();
 
   double* XM=X.local_data_const();
-  double* WM=W.local_data_const();
+  double* WM=W.local_data();
   //DGEMM(&trans,&trans, &M,&N,&K, &alpha,XM[0],&ldx, this->M_[0],&ldm, &beta,WM[0],&ldw);
+
   DGEMM(&trans,&trans, &M,&N,&K, &alpha,XM,&ldx, this->M_[0],&ldm, &beta,WM,&ldw);
 
   /* C = alpha*op(A)*op(B) + beta*C in our case is

--- a/src/LinAlg/hiopMatrixDenseRowMajor.hpp
+++ b/src/LinAlg/hiopMatrixDenseRowMajor.hpp
@@ -208,9 +208,8 @@ public:
   virtual long long get_local_size_m() const { return m_local_; }
   virtual MPI_Comm get_mpi_comm() const { return comm_; }
 
-  //inline double** local_data() const {return M_; }
-  inline double* local_data_const() const {return M_[0]; }
-  inline double* local_data() {return M_[0]; }
+  double* local_data_const() const {return M_[0]; }
+  double* local_data() {return M_[0]; }
 protected:
   //do not use this unless you sure you know what you're doing
   inline double** get_M() { return M_; }

--- a/src/LinAlg/hiopMatrixDenseRowMajor.hpp
+++ b/src/LinAlg/hiopMatrixDenseRowMajor.hpp
@@ -211,6 +211,7 @@ public:
   //TODO: this is not kosher!
   inline double** local_data() const {return M_; }
   inline double*  local_buffer() const {return M_[0]; }
+  inline double*  local_buffer2() {return M_[0]; }
   //do not use this unless you sure you know what you're doing
   inline double** get_M() { return M_; }
 

--- a/src/LinAlg/hiopMatrixDenseRowMajor.hpp
+++ b/src/LinAlg/hiopMatrixDenseRowMajor.hpp
@@ -208,13 +208,13 @@ public:
   virtual long long get_local_size_m() const { return m_local_; }
   virtual MPI_Comm get_mpi_comm() const { return comm_; }
 
-  //TODO: this is not kosher!
-  inline double** local_data() const {return M_; }
-  inline double*  local_buffer() const {return M_[0]; }
-  inline double*  local_buffer2() {return M_[0]; }
+  //inline double** local_data() const {return M_; }
+  inline double* local_data_const() const {return M_[0]; }
+  inline double* local_data() {return M_[0]; }
+protected:
   //do not use this unless you sure you know what you're doing
   inline double** get_M() { return M_; }
-
+public:
   virtual long long m() const {return m_local_;}
   virtual long long n() const {return n_global_;}
 #ifdef HIOP_DEEPCHECKS

--- a/src/LinAlg/hiopMatrixMDS.hpp
+++ b/src/LinAlg/hiopMatrixMDS.hpp
@@ -218,7 +218,7 @@ public:
   {
     return mSp->M();
   }
-  inline double** de_local_data() { return mDe->local_data(); }
+  inline double* de_local_data() { return mDe->local_buffer2(); }
 
 #ifdef HIOP_DEEPCHECKS
   virtual bool assertSymmetry(double tol=1e-16) const { return false; }
@@ -420,7 +420,7 @@ public:
   inline int* sp_irow() { return mSp->i_row(); }
   inline int* sp_jcol() { return mSp->j_col(); }
   inline double* sp_M() { return mSp->M(); }
-  inline double** de_local_data() { return mDe->local_data(); }
+  inline double* de_local_data() { return mDe->local_buffer2(); }
 
 #ifdef HIOP_DEEPCHECKS
   virtual bool assertSymmetry(double tol=1e-16) const

--- a/src/LinAlg/hiopMatrixMDS.hpp
+++ b/src/LinAlg/hiopMatrixMDS.hpp
@@ -218,7 +218,7 @@ public:
   {
     return mSp->M();
   }
-  inline double* de_local_data() { return mDe->local_buffer2(); }
+  inline double* de_local_data() { return mDe->local_data(); }
 
 #ifdef HIOP_DEEPCHECKS
   virtual bool assertSymmetry(double tol=1e-16) const { return false; }
@@ -420,7 +420,7 @@ public:
   inline int* sp_irow() { return mSp->i_row(); }
   inline int* sp_jcol() { return mSp->j_col(); }
   inline double* sp_M() { return mSp->M(); }
-  inline double* de_local_data() { return mDe->local_buffer2(); }
+  inline double* de_local_data() { return mDe->local_data(); }
 
 #ifdef HIOP_DEEPCHECKS
   virtual bool assertSymmetry(double tol=1e-16) const

--- a/src/LinAlg/hiopMatrixRajaDense.cpp
+++ b/src/LinAlg/hiopMatrixRajaDense.cpp
@@ -781,7 +781,7 @@ void hiopMatrixRajaDense::timesVec(
 void hiopMatrixRajaDense::transTimesVec(
   double beta,
   hiopVector& y_,
-	double alpha,
+  double alpha,
   const hiopVector& x_) const
 {
   hiopVectorRajaPar& y = dynamic_cast<hiopVectorRajaPar&>(y_);
@@ -810,7 +810,7 @@ void hiopMatrixRajaDense::transTimesVec(
 void hiopMatrixRajaDense::transTimesVec(
   double beta,
   double* ya,
-	double alpha,
+  double alpha,
   const double* xa) const
 {
   double* data = data_dev_;
@@ -819,6 +819,7 @@ void hiopMatrixRajaDense::transTimesVec(
   // this loop is inefficient if m_local_ is large
   // low n_local_ values effectively serialize this kernel
   // TODO: consider performance benefits of using nested RAJA loop
+
   RAJA::View<const double, RAJA::Layout<2>> Mview(data, m_local, n_local);
   RAJA::forall<hiop_raja_exec>(RAJA::RangeSegment(0, n_local),
     RAJA_LAMBDA(RAJA::Index_type j)
@@ -862,7 +863,7 @@ void hiopMatrixRajaDense::timesMat(
   timesMat_local(beta, Wmat, alpha, Xmat);
 #else
   auto& W = dynamic_cast<hiopMatrixRajaDense&>(Wmat);
-  double** WM = W.local_data_host();
+  //double* WM = W.local_data_host();
   const auto& X = dynamic_cast<const hiopMatrixRajaDense&>(Xmat);
   
   assert(W.m() == this->m());

--- a/src/LinAlg/hiopMatrixRajaDense.hpp
+++ b/src/LinAlg/hiopMatrixRajaDense.hpp
@@ -1,6 +1,5 @@
 // Copyright (c) 2017, Lawrence Livermore National Security, LLC.
 // Produced at the Lawrence Livermore National Laboratory (LLNL).
-// Written by Cosmin G. Petra, petra1@llnl.gov.
 // LLNL-CODE-742473. All rights reserved.
 //
 // This file is part of HiOp. For details, see https://github.com/LLNL/hiop. HiOp 
@@ -239,14 +238,14 @@ public:
   virtual long long get_local_size_m() const { return m_local_; }
   virtual MPI_Comm get_mpi_comm() const { return comm_; }
 
-  //TODO: this is not kosher!
-  inline double** local_data_host() const {return M_host_; }
-  inline double** local_data() const {return M_dev_; }
-  inline double*  local_buffer_host() const {return M_host_[0]; }
-  inline double*  local_buffer() const {return data_dev_; }
+  //inline double** local_data_host() const {return M_host_; }
+  //inline double** local_data() const {return M_dev_; }
+  inline double* local_data_host() const {return M_host_[0]; }
+  inline double* local_data() const {return data_dev_; }
+protected:
   //do not use this unless you sure you know what you're doing
   inline double** get_M_host() { return M_host_; }
-
+public:
   virtual long long m() const {return m_local_;}
   virtual long long n() const {return n_global_;}
 #ifdef HIOP_DEEPCHECKS

--- a/src/LinAlg/hiopMatrixRajaDense.hpp
+++ b/src/LinAlg/hiopMatrixRajaDense.hpp
@@ -238,10 +238,9 @@ public:
   virtual long long get_local_size_m() const { return m_local_; }
   virtual MPI_Comm get_mpi_comm() const { return comm_; }
 
-  //inline double** local_data_host() const {return M_host_; }
-  //inline double** local_data() const {return M_dev_; }
   inline double* local_data_host() const {return M_host_[0]; }
-  inline double* local_data() const {return data_dev_; }
+  double* local_data() {return data_dev_; }
+  double* local_data_const() const { return data_dev_; }
 protected:
   //do not use this unless you sure you know what you're doing
   inline double** get_M_host() { return M_host_; }

--- a/src/LinAlg/hiopMatrixRajaDense.hpp
+++ b/src/LinAlg/hiopMatrixRajaDense.hpp
@@ -238,12 +238,9 @@ public:
   virtual long long get_local_size_m() const { return m_local_; }
   virtual MPI_Comm get_mpi_comm() const { return comm_; }
 
-  inline double* local_data_host() const {return M_host_[0]; }
+  inline double* local_data_host() const {return data_host_; }
   double* local_data() {return data_dev_; }
   double* local_data_const() const { return data_dev_; }
-protected:
-  //do not use this unless you sure you know what you're doing
-  inline double** get_M_host() { return M_host_; }
 public:
   virtual long long m() const {return m_local_;}
   virtual long long n() const {return n_global_;}
@@ -254,14 +251,10 @@ public:
   void copyToDev();
   void copyFromDev();
 
-  void setRowPointers();
-
 private:
   std::string mem_space_;
   double* data_host_; ///< pointer to host mirror of matrix data
   double* data_dev_;  ///< pointer to memory space of matrix data
-  double** M_host_;   ///< array of pointers to matrix rows on host mirror
-  double** M_dev_;    ///< array of pointers to matrix rows on device
   int n_local_;       ///< local number of columns
   long long glob_jl_; ///< global index of first column in the local data block
   long long glob_ju_; ///< global index of first column in the next data block
@@ -283,4 +276,3 @@ private:
 };
 
 } // namespace hiop
-

--- a/src/LinAlg/hiopMatrixRajaSparseTriplet.cpp
+++ b/src/LinAlg/hiopMatrixRajaSparseTriplet.cpp
@@ -349,7 +349,7 @@ void hiopMatrixRajaSparseTriplet::transAddToSymDenseMatrixUpperTriangle(int row_
   assert(col_start>=0 && col_start+nrows_<=W.n());
   assert(W.n()==W.m());
 
-  RAJA::View<double, RAJA::Layout<2>> WM(W.local_buffer(), W.m(), W.n());
+  RAJA::View<double, RAJA::Layout<2>> WM(W.local_data(), W.m(), W.n());
   auto Wm = W.m();
   auto Wn = W.n();
   int* iRow = iRow_;
@@ -493,7 +493,7 @@ addMDinvMtransToDiagBlockOfSymDeMatUTri(int rowAndCol_dest_start,
   assert(row_dest_start>=0 && row_dest_start+n<=W.m());
   assert(col_dest_start>=0 && col_dest_start+nrows_<=W.n());
   assert(D.get_size() == this->ncols_);
-  RAJA::View<double, RAJA::Layout<2>> WM(W.local_buffer(), W.m(), W.n());
+  RAJA::View<double, RAJA::Layout<2>> WM(W.local_data(), W.m(), W.n());
   const double* DM = D.local_data_const();
   
   if(row_starts_host==NULL)
@@ -593,7 +593,7 @@ addMDinvNtransToSymDeMatUTri(int row_dest_start, int col_dest_start,
   assert(col_dest_start>=0 && col_dest_start+m2<=W.n());
 
   //double** WM = W.get_M();
-  RAJA::View<double, RAJA::Layout<2>> WM(W.local_buffer(), W.m(), W.n());
+  RAJA::View<double, RAJA::Layout<2>> WM(W.local_data(), W.m(), W.n());
   const double* DM = D.local_data_const();
 
   // TODO: allocAndBuildRowStarts -> should create row_starts_host internally (name='prepareRowStarts' ?)
@@ -937,7 +937,7 @@ void hiopMatrixRajaSymSparseTriplet::addUpperTriangleToSymDenseMatrixUpperTriang
   assert(W.n()==W.m());
 
   // double** WM = W.get_M();
-  RAJA::View<double, RAJA::Layout<2>> WM(W.local_buffer(), W.get_local_size_m(), W.get_local_size_n());
+  RAJA::View<double, RAJA::Layout<2>> WM(W.local_data(), W.get_local_size_m(), W.get_local_size_n());
   auto Wm = W.m();
   auto Wn = W.n();
   auto iRow = this->iRow_;

--- a/src/LinAlg/hiopVectorRajaPar.cpp
+++ b/src/LinAlg/hiopVectorRajaPar.cpp
@@ -947,7 +947,7 @@ void hiopVectorRajaPar::negate()
  */
 void hiopVectorRajaPar::invert()
 {
-#ifndef NDEBUG
+#ifdef HIOP_DEEPCHECKS
   const double small_real = 1e-35;
 #endif
   double *data = data_dev_;

--- a/src/Optimization/hiopAlgFilterIPM.cpp
+++ b/src/Optimization/hiopAlgFilterIPM.cpp
@@ -1225,6 +1225,11 @@ decideAndCreateLinearSystem(hiopNlpFormulation* nlp)
   } else {
     return new hiopKKTLinSysCompressedMDSXYcYd(nlp);
   }
+  assert(false && 
+	 "Could not match linear algebra to NLP formulation. Likely, HiOp was"
+	 "not built with all linear algebra modules/options");
+
+  return NULL;
 }
 
 hiopSolveStatus hiopAlgFilterIPMNewton::run()

--- a/src/Optimization/hiopDualsUpdater.cpp
+++ b/src/Optimization/hiopDualsUpdater.cpp
@@ -245,7 +245,7 @@ int hiopDualsLsqUpdate::factorizeMat(hiopMatrixDense& M)
 #endif
   if(M.m()==0) return 0;
   char uplo='L'; int N=M.n(), lda=N, info;
-  DPOTRF(&uplo, &N, M.local_buffer(), &lda, &info);
+  DPOTRF(&uplo, &N, M.local_data(), &lda, &info);
   if(info>0)
     _nlp->log->printf(hovError, "hiopKKTLinSysLowRank::factorizeMat: dpotrf (Chol fact) detected %d minor being indefinite.\n", info);
   else
@@ -263,7 +263,7 @@ int hiopDualsLsqUpdate::solveWithFactors(hiopMatrixDense& M, hiopVector& r)
   if(M.m()==0) return 0;
   char uplo='L'; //we have upper triangular in C++, but this is lower in fortran
   int N=M.n(), lda=N, nrhs=1, info;
-  DPOTRS(&uplo,&N, &nrhs, M.local_buffer(), &lda, r.local_data(), &lda, &info);
+  DPOTRS(&uplo,&N, &nrhs, M.local_data(), &lda, r.local_data(), &lda, &info);
   if(info<0) 
     _nlp->log->printf(hovError, "hiopKKTLinSysLowRank::solveWithFactors: dpotrs returned error %d\n", info);
 #ifdef HIOP_DEEPCHECKS

--- a/src/Optimization/hiopHessianLowRank.cpp
+++ b/src/Optimization/hiopHessianLowRank.cpp
@@ -1020,8 +1020,10 @@ symmMatTimesDiagTimesMatTrans_local(double beta, hiopMatrixDense& W,
 #endif
   
   //#define chunk 512; //!opt
-  double *xi, *xj, acc;
-  double *Wdata=W.local_data(), *Xdata=X.local_data_const();
+  const double *xi, *xj;
+  double acc;
+  double *Wdata=W.local_data();
+  const double *Xdata=X.local_data_const();
   const double* dd=d.local_data_const();
   for(int i=0; i<k; i++) {
     //xi=Xdata[i];

--- a/src/Optimization/hiopHessianLowRank.cpp
+++ b/src/Optimization/hiopHessianLowRank.cpp
@@ -906,6 +906,8 @@ void hiopHessianLowRank::timesVecCmn(double beta, hiopVector& y, double alpha, c
   long long n=St->n();
   assert(l_curr==St->m());
   assert(y.get_size()==n);
+  assert(St->get_local_size_n() == Yt->get_local_size_n());
+
   //we have B+=B-B*s*B*s'/(s'*B*s)+yy'/(y'*s)
   //B0 is sigma*I. There is an additional diagonal log-barrier term _Dx
 
@@ -926,11 +928,12 @@ void hiopHessianLowRank::timesVecCmn(double beta, hiopVector& y, double alpha, c
   hiopVectorPar *yk=dynamic_cast<hiopVectorPar*>(nlp->alloc_primal_vec());
   hiopVectorPar *sk=dynamic_cast<hiopVectorPar*>(nlp->alloc_primal_vec());
   //allocate and compute a_k and b_k
-  vector<hiopVector*> a(l_curr),b(l_curr);
+  vector<hiopVector*> a(l_curr), b(l_curr);
+  int n_local = Yt->get_local_size_n();
   for(int k=0; k<l_curr; k++) {
     //bk=yk/sqrt(yk'*sk)
-    yk->copyFrom(Yt->local_data()[k]);
-    sk->copyFrom(St->local_data()[k]);
+    yk->copyFrom(Yt->local_data() + k*n_local);
+    sk->copyFrom(St->local_data() + k*n_local);
     double skTyk=yk->dotProductWith(*sk);
     assert(skTyk>0);
     b[k]=dynamic_cast<hiopVectorPar*>(nlp->alloc_primal_vec());

--- a/src/Optimization/hiopKKTLinSys.cpp
+++ b/src/Optimization/hiopKKTLinSys.cpp
@@ -875,7 +875,7 @@ int hiopKKTLinSysLowRank::solveWithRefin(hiopMatrixDense& M, hiopVector& rhs)
   char UPLO='L';
 
   int NRHS=1;
-  double* A=M.local_buffer();
+  double* A=M.local_data();
   int LDA=N;
   double* AF=new double[N*N];
   int LDAF=N;
@@ -939,14 +939,14 @@ int hiopKKTLinSysLowRank::solveWithRefin(hiopMatrixDense& M, hiopVector& rhs)
 
       int _V_ipiv_vec[1000]; double _V_work_vec[1000]; int lwork=1000;
       M.copyFrom(*Aref);
-      DSYTRF(&UPLO, &N, M.local_buffer(), &LDA, _V_ipiv_vec, _V_work_vec, &lwork, &info);
+      DSYTRF(&UPLO, &N, M.local_data(), &LDA, _V_ipiv_vec, _V_work_vec, &lwork, &info);
       assert(info==0);
-      DSYTRS(&UPLO, &N, &NRHS, M.local_buffer(), &LDA, _V_ipiv_vec, resid->local_data(), &LDB, &info);
+      DSYTRS(&UPLO, &N, &NRHS, M.local_data(), &LDA, _V_ipiv_vec, resid->local_data(), &LDB, &info);
       assert(info==0);
     } else { //iter refin based on symmetric positive definite factorization+solve
       M.copyFrom(*Aref);
       //for(int i=0; i<4; i++) M.local_data()[i][i] +=1e-8;
-      DPOTRF(&UPLO, &N, M.local_buffer(), &LDA, &info);
+      DPOTRF(&UPLO, &N, M.local_data(), &LDA, &info);
       if(info>0)
 	nlp_->log->printf(hovError, "hiopKKTLinSysLowRank::factorizeMat: dpotrf (Chol fact) "
 			  "detected %d minor being indefinite.\n", info);
@@ -955,7 +955,7 @@ int hiopKKTLinSysLowRank::solveWithRefin(hiopMatrixDense& M, hiopVector& rhs)
 	  nlp_->log->printf(hovError, "hiopKKTLinSysLowRank::factorizeMat: dpotrf returned "
 			    "error %d\n", info);
 
-      DPOTRS(&UPLO,&N, &NRHS, M.local_buffer(), &LDA, resid->local_data(), &LDA, &info);
+      DPOTRS(&UPLO,&N, &NRHS, M.local_data(), &LDA, resid->local_data(), &LDA, &info);
       if(info<0)
 	nlp_->log->printf(hovError, "hiopKKTLinSysLowRank::solveWithFactors: dpotrs returned "
 			  "error %d\n", info);
@@ -1023,7 +1023,7 @@ int hiopKKTLinSysLowRank::solve(hiopMatrixDense& M, hiopVector& rhs)
   char UPLO='L';
   int N=M.n();
   int NRHS=1;
-  double* A=M.local_buffer();
+  double* A=M.local_data();
   int LDA=N;
   double* AF=new double[N*N];
   int LDAF=N;

--- a/src/Optimization/hiopKKTLinSysDense.hpp
+++ b/src/Optimization/hiopKKTLinSysDense.hpp
@@ -423,8 +423,15 @@ public:
 	
 	//add -I (of size nineq) starting at index (nx, nx+nineq+neq)
 	int col_start = nx+nineq+neq;
-	double** MsysM = Msys.local_data();
-	for(int i=nx; i<nx+nineq; i++) MsysM[i][col_start++] -= 1.;
+	double* MsysM = Msys.local_data();
+        int m_Msys = Msys.m();
+        assert(m_Msys == Msys.n());
+	for(int i=nx; i<nx+nineq; i++) {
+          //MsysM[i][col_start++] -= 1.;
+          assert(i*m_Msys+col_start < m_Msys*m_Msys);
+          MsysM[i*m_Msys+col_start] -= 1.;
+          col_start++;
+        }
 
 	//add perturbations for IC (singularity)
 	assert(delta_cc == delta_cd);

--- a/src/Optimization/hiopNlpFormulation.cpp
+++ b/src/Optimization/hiopNlpFormulation.cpp
@@ -923,7 +923,7 @@ bool hiopNlpDenseConstraints::eval_Jac_c_d_interface_impl(hiopVector& x, bool ne
   }
 
   hiopVector* x_user = nlp_transformations.applyTox(x, new_x);
-  double* Jac_consde = cons_Jac_de->local_buffer2();
+  double* Jac_consde = cons_Jac_de->local_data();
   double* Jac_user = nlp_transformations.applyToJacobCons(Jac_consde, n_cons);
 
   runStats.tmEvalJac_con.start();
@@ -932,7 +932,7 @@ bool hiopNlpDenseConstraints::eval_Jac_c_d_interface_impl(hiopVector& x, bool ne
 				      Jac_user);
   
   Jac_consde = nlp_transformations.applyInvToJacobCons(Jac_user, n_cons);
-  assert(cons_Jac_de->local_buffer2() == Jac_consde &&
+  assert(cons_Jac_de->local_data() == Jac_consde &&
 	 "mismatch between Jacobian mem adress pre- and post-transformations should not happen");
 
   Jac_cde->copyRowsFrom(*cons_Jac_, cons_eq_mapping_, n_cons_eq);
@@ -952,7 +952,7 @@ bool hiopNlpDenseConstraints::eval_Jac_c(hiopVector& x, bool new_x, hiopMatrix& 
     log->printf(hovError, "[internal error] hiopNlpDenseConstraints NLP works only with dense matrices\n");
     return false;
   } else {
-    return this->eval_Jac_c(x, new_x, Jac_cde->local_buffer2());
+    return this->eval_Jac_c(x, new_x, Jac_cde->local_data());
   }
 }
 
@@ -963,7 +963,7 @@ bool hiopNlpDenseConstraints::eval_Jac_d(hiopVector& x, bool new_x, hiopMatrix& 
     log->printf(hovError, "[internal error] hiopNlpDenseConstraints NLP works only with dense matrices\n");
     return false;
   } else {
-    return this->eval_Jac_d(x, new_x, Jac_dde->local_buffer2());
+    return this->eval_Jac_d(x, new_x, Jac_dde->local_data());
   }
 }
 

--- a/src/Optimization/hiopNlpFormulation.cpp
+++ b/src/Optimization/hiopNlpFormulation.cpp
@@ -885,7 +885,7 @@ bool hiopNlpDenseConstraints::eval_Jac_c(hiopVector& x, bool new_x, double* Jac_
   runStats.tmEvalJac_con.start();
   bool bret = interface.eval_Jac_cons(nlp_transformations.n_post(), n_cons,
                                       n_cons_eq, cons_eq_mapping_,
-				      x_user->local_data_const(), new_x, Jac_c_user);
+                                      x_user->local_data_const(), new_x, Jac_c_user);
   runStats.tmEvalJac_con.stop(); runStats.nEvalJac_con_eq++;
 
   Jac_c = nlp_transformations.applyInvToJacobEq(Jac_c_user, n_cons_eq);

--- a/src/Optimization/hiopNlpFormulation.hpp
+++ b/src/Optimization/hiopNlpFormulation.hpp
@@ -303,8 +303,8 @@ public:
   virtual bool eval_Jac_c(hiopVector& x, bool new_x, hiopMatrix& Jac_c);
   virtual bool eval_Jac_d(hiopVector& x, bool new_x, hiopMatrix& Jac_d);
   /* specialized evals to avoid overhead of dynamic cast. Generic variants available above. */
-  virtual bool eval_Jac_c(hiopVector& x, bool new_x, double** Jac_c);
-  virtual bool eval_Jac_d(hiopVector& x, bool new_x, double** Jac_d);
+  virtual bool eval_Jac_c(hiopVector& x, bool new_x, double* Jac_c);
+  virtual bool eval_Jac_d(hiopVector& x, bool new_x, double* Jac_d);
 protected:
   //calls specific hiopInterfaceXXX::eval_Jac_cons and deals with specializations of
   //hiopMatrix arguments

--- a/src/Optimization/hiopNlpTransforms.cpp
+++ b/src/Optimization/hiopNlpTransforms.cpp
@@ -223,30 +223,40 @@ void hiopFixedVarsRemover::applyInvToArray(const double* x_fs, double* x_rs)
 }
 
 /* from rs to fs */
-void hiopFixedVarsRemover::applyToMatrix(const double*const* M_rs, const int& m_in, double** M_fs)
+void hiopFixedVarsRemover::applyToMatrix(const double* M_rs, const int& m_in, double* M_fs)
 {
   int rs_idx;
+  const int nfs = fs2rs_idx_map.size();
+  assert(nfs == fs_n_local());
+  const int nrs = rs_n_local();
+
   for(int i=0; i<m_in; i++) {
-    for(int j=0; j<fs2rs_idx_map.size(); j++) {
+    for(int j=0; j<nfs; j++) {
       rs_idx = fs2rs_idx_map[j];
       if(rs_idx<0) {
-  	M_fs[i][j] = 0.; //really no need to initialize this, these entries will be later ignored
+  	//M_fs[i][j] = 0.; //really no need to initialize this, these entries will be later ignored
+        M_fs[i*nfs+j] = 0.;
       } else {
-  	M_fs[i][j] = M_rs[i][rs_idx];
+  	//M_fs[i][j] = M_rs[i][rs_idx];
+        M_fs[i*nfs+j] = M_rs[i*nrs+rs_idx];
       }
     }
   }
 }
 
 /* from fs to rs */
-void hiopFixedVarsRemover::applyInvToMatrix(const double*const* M_fs, const int& m_in, double** M_rs)
+void hiopFixedVarsRemover::applyInvToMatrix(const double* M_fs, const int& m_in, double* M_rs)
 {
   int rs_idx;
+  const int nfs = fs2rs_idx_map.size();
+  assert(nfs == fs_n_local());
+  const int nrs = rs_n_local();
+
   for(int i=0; i<m_in; i++) {
-    for(int j=0; j<fs2rs_idx_map.size(); j++) {
+    for(int j=0; j<fs2rs_idx_map.size(); j++) {  
       rs_idx = fs2rs_idx_map[j];
       if(rs_idx>=0) {
-  	M_rs[i][rs_idx] = M_fs[i][j];
+  	M_rs[i*nrs+rs_idx] = M_fs[i*nfs+j];
       }
     }
   }

--- a/src/Optimization/hiopNlpTransforms.hpp
+++ b/src/Optimization/hiopNlpTransforms.hpp
@@ -78,7 +78,8 @@ public:
   virtual long long n_post()=0;
   virtual long long n_post_local()=0;
   /* number of vars in the NLP to which the transformation is to be applied */
-  virtual long long n_pre ()=0;
+  virtual long long n_pre()=0;
+  virtual long long n_pre_local()=0;
 
   /* transforms variable vector */
   virtual inline hiopVector* applyTox(hiopVector& x, const bool& new_x) { return &x; };
@@ -106,13 +107,13 @@ public:
   virtual inline double* applyInvToCons(double* cons_in, const int* m_in) { return cons_in; }
 
   //! todo -> abstractize the below methods to work with other Jacobian types: sparse and MDS
-  virtual inline double** applyToJacobEq      (double** Jac_in, const int& m_in) { return Jac_in; }
-  virtual inline double** applyInvToJacobEq   (double** Jac_in, const int& m_in) { return Jac_in; }
-  virtual inline double** applyToJacobIneq    (double** Jac_in, const int& m_in) { return Jac_in; }
-  virtual inline double** applyInvToJacobIneq (double** Jac_in, const int& m_in) { return Jac_in; }
-  virtual inline double** applyToJacobCons    (double** Jac_in, const int& m_in) { return Jac_in; }
+  virtual inline double* applyToJacobEq      (double* Jac_in, const int& m_in) { return Jac_in; }
+  virtual inline double* applyInvToJacobEq   (double* Jac_in, const int& m_in) { return Jac_in; }
+  virtual inline double* applyToJacobIneq    (double* Jac_in, const int& m_in) { return Jac_in; }
+  virtual inline double* applyInvToJacobIneq (double* Jac_in, const int& m_in) { return Jac_in; }
+  virtual inline double* applyToJacobCons    (double* Jac_in, const int& m_in) { return Jac_in; }
   //the following two are for when the underlying NLP formulation works with full body constraints
-  virtual inline double** applyInvToJacobCons (double** Jac_in, const int& m_in) { return Jac_in; }
+  virtual inline double* applyInvToJacobCons (double* Jac_in, const int& m_in) { return Jac_in; }
 
   //! todo -> transformations for Hessian ?!?
 public:
@@ -150,6 +151,7 @@ public:
   virtual inline long long n_pre () { return rs_n(); }
 
   virtual inline long long n_post_local() { return fs_n_local(); }
+  virtual inline long long n_pre_local() { return rs_n_local(); }
 
   /* from reduced space to full space */
   inline hiopVector* applyTox(hiopVector& x, const bool& new_x) 
@@ -192,27 +194,29 @@ public:
     return grad_rs_ref;
   }
   /* from rs to fs */
-  inline double** applyToJacobEq(double** Jac_in, const int& m_in)
+  inline double* applyToJacobEq(double* Jac_in, const int& m_in)
   {
     Jacc_rs_ref = Jac_in;
     assert(Jacc_fs->m()==m_in);
-    applyToMatrix(Jac_in, m_in, Jacc_fs->get_M());
-    return Jacc_fs->get_M();
+    //applyToMatrix(Jac_in, m_in, Jacc_fs->get_M());
+    applyToMatrix(Jac_in, m_in, Jacc_fs->local_buffer2());
+    return Jacc_fs->local_buffer2();
   }
-  inline double** applyInvToJacobEq(double** Jac_in, const int& m_in)
+  inline double* applyInvToJacobEq(double* Jac_in, const int& m_in)
   {
     assert(Jacc_fs->m()==m_in);
     applyInvToMatrix(Jac_in, m_in, Jacc_rs_ref);
     return Jacc_rs_ref;
   }
-  inline double** applyToJacobIneq(double** Jac_in, const int& m_in)
+  inline double* applyToJacobIneq(double* Jac_in, const int& m_in)
   {
     Jacd_rs_ref = Jac_in;
     assert(Jacd_fs->m()==m_in);
-    applyToMatrix(Jac_in, m_in, Jacd_fs->get_M());
-    return Jacd_fs->get_M();
+    //applyToMatrix(Jac_in, m_in, Jacd_fs->get_M());
+    applyToMatrix(Jac_in, m_in, Jacd_fs->local_buffer2());
+    return Jacd_fs->local_buffer2();
   }
-  inline double** applyInvToJacobIneq(double** Jac_in, const int& m_in)
+  inline double* applyInvToJacobIneq(double* Jac_in, const int& m_in)
   {
     assert(Jacd_fs->m()==m_in);
     applyInvToMatrix(Jac_in, m_in, Jacd_rs_ref);
@@ -230,19 +234,20 @@ public:
   long long* allocRSVectorDistrib();
   inline void setMPIComm(const MPI_Comm& commIn) { comm = commIn; }
 #endif
-  /* "copies" a full space vector tp a reduced space vector */
+  /* "copies" a full space vector to a reduced space vector */
   void copyFsToRs(const hiopVector& fsVec,  hiopVector& rsVec);
   void copyFsToRs(const hiopInterfaceBase::NonlinearityType* fs, hiopInterfaceBase::NonlinearityType* rs);
   
   inline long long fs_n() const { return n_fs;}
   inline long long rs_n() const { return n_rs;}
-  inline long long fs_n_local() const { assert(xl_fs); return xl_fs->get_local_size();}
+  inline long long fs_n_local() const { assert(xl_fs); return xl_fs->get_local_size(); }
+  inline long long rs_n_local() const { assert(xl_fs); return fs_n_local()-n_fixed_vars_local;}
 protected: 
   void applyToArray   (const double* vec_rs, double* vec_fs);
   void applyInvToArray(const double* vec_fs, double* vec_rs);
 
-  void applyToMatrix   (const double*const* M_rs, const int& m_in, double** M_fs);
-  void applyInvToMatrix(const double*const* M_fs, const int& m_in, double** M_rs);
+  void applyToMatrix   (const double* M_rs, const int& m_in, double* M_fs);
+  void applyInvToMatrix(const double* M_fs, const int& m_in, double* M_rs);
 protected:
   long long n_fixed_vars_local;
   long long n_fixed_vars;
@@ -265,7 +270,7 @@ protected:
   //references to reduced-space buffers - returned in applyInvXXX
   hiopVector* x_rs_ref_;
   double* grad_rs_ref;
-  double **Jacc_rs_ref, **Jacd_rs_ref;
+  double *Jacc_rs_ref, *Jacd_rs_ref;
 #ifdef HIOP_USE_MPI
   std::vector<long long> fs_vec_distrib;
   MPI_Comm comm;
@@ -288,6 +293,7 @@ public:
   virtual long long n_pre () { /*assert(xl_copy);*/ return n_vars; } //xl_copy->get_size(); }
 
   inline long long n_post_local()  { return n_vars_local; } //xl_copy->get_local_size(); }
+  inline long long n_pre_local()  { return n_vars_local; } //xl_copy->get_local_size(); }
 
   inline bool setup() { return true; }
 
@@ -366,7 +372,22 @@ public:
       return list_trans_.front()->n_pre(); 
     }
   }
-
+  /* number of local vars in the NLP to which the tranformation is to be applied */
+  inline virtual long long n_pre_local() 
+  { 
+#ifdef HIOP_DEEPCHECKS
+    assert(n_vars_usernlp>0);
+#endif 
+    if(list_trans_.empty()) {
+      return n_vars_local_usernlp;
+    } else {
+#ifdef HIOP_DEEPCHECKS
+      assert(n_vars_usernlp==list_trans_.back()->n_post());
+#endif
+      return list_trans_.front()->n_pre_local(); 
+    }
+  }
+  
   hiopVector* applyTox(hiopVector& x, const bool& new_x) 
   {
     hiopVector* ret = &x;
@@ -404,33 +425,33 @@ public:
     return ret;
   }
 
-  double** applyToJacobEq(double** Jac_in, const int& m_in)
+  double* applyToJacobEq(double* Jac_in, const int& m_in)
   {
-    double** ret = Jac_in;
+    double* ret = Jac_in;
     for(std::list<hiopNlpTransformation*>::iterator it=list_trans_.begin(); it!=list_trans_.end(); ++it)
       ret = (*it)->applyToJacobEq(ret, m_in);
     return ret;
   }
 
-  double** applyInvToJacobEq(double** Jac_in, const int& m_in)
+  double* applyInvToJacobEq(double* Jac_in, const int& m_in)
   {
-    double** ret = Jac_in;
+    double* ret = Jac_in;
     for(std::list<hiopNlpTransformation*>::reverse_iterator it=list_trans_.rbegin(); it!=list_trans_.rend(); ++it)
       ret = (*it)->applyInvToJacobEq(ret, m_in);
     return ret;
   }
 
-  double** applyToJacobIneq(double** Jac_in, const int& m_in)
+  double* applyToJacobIneq(double* Jac_in, const int& m_in)
   {
-    double** ret = Jac_in;
+    double* ret = Jac_in;
     for(std::list<hiopNlpTransformation*>::iterator it=list_trans_.begin(); it!=list_trans_.end(); ++it)
       ret = (*it)->applyToJacobIneq(ret, m_in);
     return ret;
   }
 
-  double** applyInvToJacobIneq(double** Jac_in, const int& m_in)
+  double* applyInvToJacobIneq(double* Jac_in, const int& m_in)
   {
-    double** ret = Jac_in;
+    double* ret = Jac_in;
     for(std::list<hiopNlpTransformation*>::reverse_iterator it=list_trans_.rbegin(); it!=list_trans_.rend(); ++it)
       ret = (*it)->applyInvToJacobIneq(ret, m_in);
     return ret;

--- a/src/Optimization/hiopNlpTransforms.hpp
+++ b/src/Optimization/hiopNlpTransforms.hpp
@@ -199,8 +199,8 @@ public:
     Jacc_rs_ref = Jac_in;
     assert(Jacc_fs->m()==m_in);
     //applyToMatrix(Jac_in, m_in, Jacc_fs->get_M());
-    applyToMatrix(Jac_in, m_in, Jacc_fs->local_buffer2());
-    return Jacc_fs->local_buffer2();
+    applyToMatrix(Jac_in, m_in, Jacc_fs->local_data());
+    return Jacc_fs->local_data();
   }
   inline double* applyInvToJacobEq(double* Jac_in, const int& m_in)
   {
@@ -213,8 +213,8 @@ public:
     Jacd_rs_ref = Jac_in;
     assert(Jacd_fs->m()==m_in);
     //applyToMatrix(Jac_in, m_in, Jacd_fs->get_M());
-    applyToMatrix(Jac_in, m_in, Jacd_fs->local_buffer2());
-    return Jacd_fs->local_buffer2();
+    applyToMatrix(Jac_in, m_in, Jacd_fs->local_data());
+    return Jacd_fs->local_data();
   }
   inline double* applyInvToJacobIneq(double* Jac_in, const int& m_in)
   {

--- a/src/Utils/hiopCSR_IO.hpp
+++ b/src/Utils/hiopCSR_IO.hpp
@@ -75,8 +75,8 @@ namespace hiop
       //count nnz
       const double zero_tol = 1e-25;
       int nnz=0;
-      double** M = Msys.local_data();
-      for(int i=0; i<m; i++) for(int j=i; j<m; j++) if(fabs(M[i][j])>zero_tol) nnz++;
+      double* M = Msys.local_data();
+      for(int i=0; i<m; i++) for(int j=i; j<m; j++) if(fabs(M[i*m+j])>zero_tol) nnz++;
       
       //start writing -> indexes are starting at 1
       fprintf(f, "%d\n %d\n", m, nnz);
@@ -86,7 +86,7 @@ namespace hiop
       fprintf(f, "%d ", offset);
       for(int i=0; i<m; i++) {
 	for(int j=i; j<m; j++) 
-	  if(fabs(M[i][j])>zero_tol)
+	  if(fabs(M[i*m+j])>zero_tol)
 	    offset++;
 	
 	fprintf(f, "%d ", offset);
@@ -97,7 +97,7 @@ namespace hiop
       //array of the column indexes of nonzeros
       for(int i=0; i<m; i++) {
 	for(int j=i; j<m; j++) 
-	  if(fabs(M[i][j])>zero_tol)
+	  if(fabs(M[i*m+j])>zero_tol)
 	    fprintf(f, "%d ", j+1);
     }
       fprintf(f, "\n");
@@ -105,8 +105,8 @@ namespace hiop
       //array of nonzero entries of the matrix
       for(int i=0; i<m; i++) {
 	for(int j=i; j<m; j++) 
-	  if(fabs(M[i][j])>zero_tol)
-	    fprintf(f, "%.20f ", M[i][j]);
+	  if(fabs(M[i*m+j])>zero_tol)
+	    fprintf(f, "%.20f ", M[i*m+j]);
       }
       fprintf(f, "\n");
       

--- a/tests/LinAlg/matrixTests.hpp
+++ b/tests/LinAlg/matrixTests.hpp
@@ -197,6 +197,7 @@ public:
     {
       setLocalElement(&A, i, index_to_zero, zero);
     }
+
     A.transTimesVec(beta, y, alpha, x);
 
     fail += verifyAnswer(&y,

--- a/tests/LinAlg/matrixTestsDense.cpp
+++ b/tests/LinAlg/matrixTestsDense.cpp
@@ -69,8 +69,9 @@ void MatrixTestsDense::setLocalElement(
   hiop::hiopMatrixDense* amat = dynamic_cast<hiop::hiopMatrixDense*>(A);
   if(amat != nullptr)
   {
-    real_type** data = amat->get_M();
-    data[i][j] = val;
+    real_type* data = amat->local_data();
+    //data[i][j] = val;
+    data[i*amat->get_local_size_n()+j] = val;
   }
   else THROW_NULL_DEREF;
 }
@@ -111,7 +112,8 @@ real_type MatrixTestsDense::getLocalElement(
 {
   const hiop::hiopMatrixDense* amat = dynamic_cast<const hiop::hiopMatrixDense*>(A);
   if(amat != nullptr)
-    return amat->local_data()[i][j];
+    //return amat->local_data_const()[i][j];
+    return amat->local_data_const()[i*amat->get_local_size_n()+j];
   else THROW_NULL_DEREF;
 }
 
@@ -172,7 +174,7 @@ real_type* MatrixTestsDense::getLocalData(hiop::hiopMatrixDense* A)
   auto* amat = dynamic_cast<hiop::hiopMatrixDenseRowMajor*>(A);
   if(amat != nullptr)
   {
-    return amat->local_buffer();
+    return amat->local_data();
   }
   else THROW_NULL_DEREF;
 }

--- a/tests/LinAlg/matrixTestsRajaDense.cpp
+++ b/tests/LinAlg/matrixTestsRajaDense.cpp
@@ -72,8 +72,8 @@ void MatrixTestsRajaDense::setLocalElement(
   if(amat != nullptr)
   {
     amat->copyFromDev();
-    real_type** data = amat->get_M_host();
-    data[i][j] = val;
+    real_type* data = amat->local_data_host(); 
+    data[i*amat->get_local_size_n() + j] = val;
     amat->copyToDev();
   }
   else THROW_NULL_DEREF;
@@ -104,10 +104,10 @@ void MatrixTestsRajaDense::setLocalRow(
   hiop::hiopMatrixRajaDense* A = dynamic_cast<hiop::hiopMatrixRajaDense*>(Amat);
   const local_ordinal_type N = getNumLocCols(A);
   A->copyFromDev();
-  real_type** local_data = A->local_data_host();
+  real_type* local_data = A->local_data_host();
   for (int j=0; j<N; j++)
   {
-    local_data[row][j] =  val;
+    local_data[row*N+j] =  val;
   }
   A->copyToDev();
 }
@@ -124,7 +124,7 @@ real_type MatrixTestsRajaDense::getLocalElement(
   if(amat != nullptr)
   {
     amat->copyFromDev();
-    return amat->local_data_host()[i][j];
+    return amat->local_data_host()[i*amat->get_local_size_n() + j];
   }
   else THROW_NULL_DEREF;
 }
@@ -190,7 +190,7 @@ real_type* MatrixTestsRajaDense::getLocalData(hiop::hiopMatrixDense* A)
   hiop::hiopMatrixRajaDense* amat = dynamic_cast<hiop::hiopMatrixRajaDense*>(A);
   if(amat != nullptr)
   {
-    return amat->local_buffer();
+    return amat->local_data();
   }
   else THROW_NULL_DEREF;
 }
@@ -220,16 +220,16 @@ int MatrixTestsRajaDense::verifyAnswer(hiop::hiopMatrixDense* Amat, const double
   // Copy data to the host mirror
   A->copyFromDev();
   // Get array of pointers to dense matrix rows
-  double** local_matrix_data = A->local_data_host();
+  double* local_matrix_data = A->local_data_host();
 
   int fail = 0;
   for (local_ordinal_type i=0; i<M; i++)
   {
     for (local_ordinal_type j=0; j<N; j++)
     {
-      if (!isEqual(local_matrix_data[i][j], answer))
+      if (!isEqual(local_matrix_data[i*N+j], answer))
       {
-        std::cout << i << " " << j << " = " << local_matrix_data[i][j] << " != " << answer << "\n";
+        std::cout << i << " " << j << " = " << local_matrix_data[i*N+j] << " != " << answer << "\n";
         fail++;
       }
     }
@@ -255,16 +255,16 @@ int MatrixTestsRajaDense::verifyAnswer(
   // Copy data to the host mirror
   A->copyFromDev();
   // Get array of pointers to dense matrix rows
-  double** local_matrix_data = A->local_data_host();
+  double* local_matrix_data = A->local_data_host();
   
   int fail = 0;
   for (local_ordinal_type i=0; i<M; i++)
   {
     for (local_ordinal_type j=0; j<N; j++)
     {
-      if (!isEqual(local_matrix_data[i][j], expect(i, j)))
+      if (!isEqual(local_matrix_data[i*N+j], expect(i, j)))
       {
-        std::cout << i << ", " << j << ": = " << local_matrix_data[i][j] << " != " << expect(i, j) << "\n";
+        std::cout << i << ", " << j << ": = " << local_matrix_data[i*N+j] << " != " << expect(i, j) << "\n";
         fail++;
       }
     }

--- a/tests/LinAlg/matrixTestsRajaSparseTriplet.cpp
+++ b/tests/LinAlg/matrixTestsRajaSparseTriplet.cpp
@@ -94,10 +94,10 @@ real_type MatrixTestsRajaSparseTriplet::getLocalElement(
   {
     auto* amat = const_cast<hiop::hiopMatrixRajaDense*>(mat);
     amat->copyFromDev();
-    double** M = amat->get_M_host();
-    return M[row][col];
+    //double** M = amat->get_M_host();
+    //return M[row][col];
+    return amat->local_data_const()[row*amat->get_local_size_n() + col];
   }
-
   else THROW_NULL_DEREF;
 }
 
@@ -189,14 +189,14 @@ int MatrixTestsRajaSparseTriplet::verifyAnswer(
   const local_ordinal_type N = A->get_local_size_n();
   int fail = 0;
   A->copyFromDev();
-  double** mat = A->get_M_host();
+  const double* mat = A->local_data_host();
   for (local_ordinal_type i=0; i<M; i++)
   {
     for (local_ordinal_type j=0; j<N; j++)
     {
-      if (!isEqual(mat[i][j], expect(i, j)))
+      if (!isEqual(mat[i*N+j], expect(i, j)))
       {
-        printf("(%d, %d) failed. %f != %f.\n", i, j, mat[i][j], expect(i, j));
+        printf("(%d, %d) failed. %f != %f.\n", i, j, mat[i*N+j], expect(i, j));
         fail++;
       }
       // else

--- a/tests/LinAlg/matrixTestsRajaSymSparseTriplet.cpp
+++ b/tests/LinAlg/matrixTestsRajaSymSparseTriplet.cpp
@@ -77,10 +77,9 @@ real_type MatrixTestsRajaSymSparseTriplet::getLocalElement(
   {
     auto* amat = const_cast<hiop::hiopMatrixRajaDense*>(mat);
     amat->copyFromDev();
-    double** M = amat->get_M_host();
-    return M[row][col];
+    double* M = amat->local_data_const();
+    return M[row*amat->get_local_size_n()+col];
   }
-
   else THROW_NULL_DEREF;
 }
 
@@ -146,12 +145,12 @@ int MatrixTestsRajaSymSparseTriplet::verifyAnswer(
   const local_ordinal_type N = A->get_local_size_n();
   int fail = 0;
   A->copyFromDev();
-  double** mat = A->get_M_host();
+  double* mat = A->local_data_host();
   for (local_ordinal_type i=0; i<M; i++)
   {
     for (local_ordinal_type j=0; j<N; j++)
     {
-      if (!isEqual(mat[i][j], expect(i, j)))
+      if (!isEqual(mat[i*N+j], expect(i, j)))
       {
         //printf("(%d, %d) failed. %f != %f.\n", i, j, mat[i][j], expect(i, j));
         fail++;

--- a/tests/LinAlg/matrixTestsSparseTriplet.cpp
+++ b/tests/LinAlg/matrixTestsSparseTriplet.cpp
@@ -209,7 +209,7 @@ int MatrixTestsSparseTriplet::verifyAnswer(hiop::hiopMatrix* A, local_ordinal_ty
  * Pass a function-like object to calculate the expected
  * answer dynamically, based on the row and column
  */
-  [[nodiscard]]
+[[nodiscard]]
 int MatrixTestsSparseTriplet::verifyAnswer(
     hiop::hiopMatrixDense* A,
     std::function<real_type(local_ordinal_type, local_ordinal_type)> expect)

--- a/tests/LinAlg/matrixTestsSparseTriplet.cpp
+++ b/tests/LinAlg/matrixTestsSparseTriplet.cpp
@@ -88,8 +88,9 @@ real_type MatrixTestsSparseTriplet::getLocalElement(
   
   if (mat != nullptr)
   {
-    double** M = mat->local_data();
-    return M[row][col];
+    const double* M = mat->local_data_const();
+    //return M[row][col];
+    return M[row*mat->get_local_size_n()+col];
   }
 
   else THROW_NULL_DEREF;

--- a/tests/LinAlg/matrixTestsSymSparseTriplet.cpp
+++ b/tests/LinAlg/matrixTestsSymSparseTriplet.cpp
@@ -73,8 +73,9 @@ real_type MatrixTestsSymSparseTriplet::getLocalElement(
   
   if (mat != nullptr)
   {
-    double** M = mat->local_data();
-    return M[row][col];
+    double* M = mat->local_data_const();
+    //return M[row][col];
+    return M[row*mat->n()+col];
   }
 
   else THROW_NULL_DEREF;

--- a/tests/testMatrix.cpp
+++ b/tests/testMatrix.cpp
@@ -165,6 +165,7 @@ int main(int argc, char** argv)
     if(rank == 0)
     {
       // These functions are only meant to be called locally
+
       fail += test.matrixTimesMat(A_mxk_nodist, A_kxn_nodist, A_mxn_nodist);
       fail += test.matrixAddDiagonal(A_nxn_nodist, x_n_nodist);
       fail += test.matrixAddSubDiagonal(A_nxn_nodist, x_m_nodist);

--- a/tests/testMatrixSparse.cpp
+++ b/tests/testMatrixSparse.cpp
@@ -191,9 +191,13 @@ int main(int argc, char** argv)
     /// @todo use linear algebra factory for these
     hiop::hiopMatrixRajaDense W_dense(N_global + W_delta, N_global + W_delta, mem_space);
 
+    std::cout << "aaaaaa\n";
+
     // local_ordinal_type test_offset = 10;
     local_ordinal_type test_offset = 4;
     fail += test.matrixAddMDinvMtransToDiagBlockOfSymDeMatUTri(*mxn_sparse, vec_n, W_dense, test_offset);
+
+    std::cout << "bbbbb\n";
 
     // testing adding sparse matrix to the upper triangular area of a symmetric dense matrix    
     //fail += test.addToSymDenseMatrixUpperTriangle(W_dense, *mxn_sparse);

--- a/tests/testMatrixSparse.cpp
+++ b/tests/testMatrixSparse.cpp
@@ -191,13 +191,9 @@ int main(int argc, char** argv)
     /// @todo use linear algebra factory for these
     hiop::hiopMatrixRajaDense W_dense(N_global + W_delta, N_global + W_delta, mem_space);
 
-    std::cout << "aaaaaa\n";
-
     // local_ordinal_type test_offset = 10;
     local_ordinal_type test_offset = 4;
     fail += test.matrixAddMDinvMtransToDiagBlockOfSymDeMatUTri(*mxn_sparse, vec_n, W_dense, test_offset);
-
-    std::cout << "bbbbb\n";
 
     // testing adding sparse matrix to the upper triangular area of a symmetric dense matrix    
     //fail += test.addToSymDenseMatrixUpperTriangle(W_dense, *mxn_sparse);


### PR DESCRIPTION
The primarily goal is to disable double (**) pointers in the interfaces, addressing #81 and device dereferencing issues associated with double pointers (to double, _i.e.,_ `double**`).

In addition, this PR
 - removes public accessors for `double**` and renames `get_local_buffer` to `get_local_data` for all dense matrix classes to make it consistent with the vector classes
 - improves documentation of the base interface methods by (minimally) formatting the comments in the doxygen style. 

Passes CI and was also tested on summit.
