### PR TITLE
Fix bugs in the full KKT linear system

### DIFF
--- a/src/Drivers/nlpSparse_ex6_driver.cpp
+++ b/src/Drivers/nlpSparse_ex6_driver.cpp
@@ -71,8 +71,8 @@ int main(int argc, char **argv)
 
   Ex6 nlp_interface(n);
   hiopNlpSparse nlp(nlp_interface);
-//  nlp.options->SetStringValue("compute_mode", "cpu");
-  nlp.options->SetStringValue("compute_mode", "hybrid");
+  nlp.options->SetStringValue("compute_mode", "cpu");
+//  nlp.options->SetStringValue("compute_mode", "hybrid");
   nlp.options->SetStringValue("KKTLinsys", "xdycyd");
 //  nlp.options->SetStringValue("KKTLinsys", "full");
   nlp.options->SetStringValue("write_kkt", "yes");

--- a/src/LinAlg/hiopLinSolverSparseSTRUMPACK.cpp
+++ b/src/LinAlg/hiopLinSolverSparseSTRUMPACK.cpp
@@ -231,6 +231,7 @@ namespace hiop
     * initialize strumpack parameters
     */
 //    spss.options().set_matching(MatchingJob::NONE);
+    spss.options().enable_METIS_NodeNDP();
     spss.options().disable_gpu();
     spss.options().set_verbose(false);
 

--- a/src/LinAlg/hiopMatrixSparseTriplet.cpp
+++ b/src/LinAlg/hiopMatrixSparseTriplet.cpp
@@ -925,13 +925,13 @@ void hiopMatrixSparseTriplet::convertToCSR(int &csr_nnz, int **csr_kRowPtr_in, i
   double *csr_kVal = *csr_kVal_in;
   int *csr_jCol = *csr_jCol_in;
 
-  int *index_covert_extra_Diag2CSR_temp = new int[n];
+  int *index_covert_extra_Diag2CSR_temp = new int[n]{};
   int *nnz_each_row_tmp = new int[n]{};
 
   // set correct col index and value
   {
-    *index_covert_CSR2Triplet_in = new int[csr_nnz];
-    *index_covert_extra_Diag2CSR_in = new int[n];
+    *index_covert_CSR2Triplet_in = new int[csr_nnz]{};
+    *index_covert_extra_Diag2CSR_in = new int[n]{};
 
     int *index_covert_CSR2Triplet = *index_covert_CSR2Triplet_in;
     int *index_covert_extra_Diag2CSR = *index_covert_extra_Diag2CSR_in;

--- a/src/LinAlg/hiopMatrixSparseTriplet.cpp
+++ b/src/LinAlg/hiopMatrixSparseTriplet.cpp
@@ -890,7 +890,7 @@ void hiopMatrixSparseTriplet::convertToCSR(int &csr_nnz, int **csr_kRowPtr_in, i
   */
   int n_diag_val=0;
   std::unordered_map<int,int> extra_diag_nnz_map_temp;
-  int *diag_defined = new int[n]{};
+  int *diag_defined = new int[n];
 
   // compute nnz in each row
   {
@@ -919,19 +919,19 @@ void hiopMatrixSparseTriplet::convertToCSR(int &csr_nnz, int **csr_kRowPtr_in, i
     assert(csr_nnz==csr_kRowPtr[n]);
     assert(csr_nnz+extra_diag_nnz_map_temp.size()==nnz);
 
-    *csr_kVal_in = new double[csr_nnz]{};
-    *csr_jCol_in = new int[csr_nnz]{};
+    *csr_kVal_in = new double[csr_nnz];
+    *csr_jCol_in = new int[csr_nnz];
   }
   double *csr_kVal = *csr_kVal_in;
   int *csr_jCol = *csr_jCol_in;
 
-  int *index_covert_extra_Diag2CSR_temp = new int[n]{};
+  int *index_covert_extra_Diag2CSR_temp = new int[n];
   int *nnz_each_row_tmp = new int[n]{};
 
   // set correct col index and value
   {
-    *index_covert_CSR2Triplet_in = new int[csr_nnz]{};
-    *index_covert_extra_Diag2CSR_in = new int[n]{};
+    *index_covert_CSR2Triplet_in = new int[csr_nnz];
+    *index_covert_extra_Diag2CSR_in = new int[n];
 
     int *index_covert_CSR2Triplet = *index_covert_CSR2Triplet_in;
     int *index_covert_extra_Diag2CSR = *index_covert_extra_Diag2CSR_in;
@@ -976,15 +976,6 @@ void hiopMatrixSparseTriplet::convertToCSR(int &csr_nnz, int **csr_kRowPtr_in, i
 
     // correct the missing diagonal term and sort the nonzeros
     for(int i=0;i<n;i++){
-/*      if(nnz_each_row_tmp[i] != csr_kRowPtr[i+1]-csr_kRowPtr[i]){
-        assert(nnz_each_row_tmp[i] == csr_kRowPtr[i+1]-csr_kRowPtr[i]-1);
-        nnz_tmp = nnz_each_row_tmp[i] + csr_kRowPtr[i];
-        csr_jCol[nnz_tmp] = i;
-        csr_kVal[nnz_tmp] = values_[nnz-n+i];
-        index_covert_CSR2Triplet[nnz_tmp] = nnz-n+i;
-        total_nnz_tmp += 1;
-      }
-*/
       // sort the nonzeros
       {
         std::vector<int> ind_temp(csr_kRowPtr[i+1]-csr_kRowPtr[i]);

--- a/src/Utils/hiopCppStdUtils.hpp
+++ b/src/Utils/hiopCppStdUtils.hpp
@@ -69,7 +69,7 @@ namespace hiop {
 
     // arr[i] should be present at index[i] index
     for (int i=0; i<n; i++)
-        temp[index[i]] = arr[i];
+        temp[i] = arr[index[i]];
 
     // Copy temp[] to arr[]
     for (int i=0; i<n; i++)


### PR DESCRIPTION
Fix bug when passing the full KKT matrix to STRUMPACK.
After this fix, HiOp with STRUMPACK passes the test problem EX6 with 5000 variables.

Note that the default ordering strategy in Metis is used in STRUMPACK, and STRUMPACK prints some mild warnings about it.
Will try different ordering schemes and/or discuss this issue with the STRUMPACK team before fixing it (probably in another PR).
