### PR TITLE
LinAlgFactory and Raja Vector Improvements

### DIFF
--- a/src/LinAlg/hiopLinAlgFactory.cpp
+++ b/src/LinAlg/hiopLinAlgFactory.cpp
@@ -204,22 +204,28 @@ hiopMatrixSparse* LinearAlgebraFactory::createMatrixSymSparse(int size, int nnz)
 /**
  * @brief Static method to create a raw C array
  */
-double* LinearAlgebraFactory::createRawArray(int n)
+double* LinearAlgebraFactory::createRawArray(int n, int value)
 {
   if (mem_space_ == "DEFAULT")
   {
-    return new double[n];
+    double *tmp = new double[n];
+    std::fill(tmp, tmp + n, value);
+    return tmp;
   }
   else
   {
 #ifdef HIOP_USE_RAJA
     auto& resmgr = umpire::ResourceManager::getInstance();
     umpire::Allocator al  = resmgr.getAllocator(mem_space_);
-    return static_cast<double*>(al.allocate(n*sizeof(double)));
+    double *tmp = static_cast<double*>(al.allocate(n*sizeof(double)));
+    resmgr.memset(tmp, value);
+    return tmp;
 #else
     assert(false && "requested memory space not available because Hiop was not"
            "built with RAJA support");
-    return new double[n];
+    double *tmp = new double[n];
+    std::fill(tmp, tmp + n, value);
+    return tmp;
 #endif
   }
 }

--- a/src/LinAlg/hiopLinAlgFactory.hpp
+++ b/src/LinAlg/hiopLinAlgFactory.hpp
@@ -108,8 +108,11 @@ public:
 
   /**
    * @brief Static method to create a raw C array
+   *
+   * @param value default value of the memory. This is an int as Umpire
+   *              can only set blocks of memory to integer values.
    */
-  static double* createRawArray(int n);
+  static double* createRawArray(int n, int value=0);
 
   /**
    * @brief Static method to delete a raw C array

--- a/src/LinAlg/hiopVectorRajaPar.cpp
+++ b/src/LinAlg/hiopVectorRajaPar.cpp
@@ -325,15 +325,12 @@ void hiopVectorRajaPar::copyFromStarting(int start_index_in_this, const double* 
  */
 void hiopVectorRajaPar::copyFromStarting(int start_index, const hiopVector& vec)
 {
-#ifdef HIOP_DEEPCHECKS
+#ifdef HIOP_DEEPCHECKS 
   assert(n_local_ == n_ && "are you sure you want to call this?");
 #endif
   const hiopVectorRajaPar& v = dynamic_cast<const hiopVectorRajaPar&>(vec);
-  assert(start_index + v.n_local_ <= n_local_);
-  
-  auto& rm = umpire::ResourceManager::getInstance();
-  double* vv = const_cast<double*>(v.data_dev_); // scary: 
-  rm.copy(this->data_dev_ + start_index, vv, v.n_local_*sizeof(double));
+  assert(start_index + v.get_local_size() <= n_local_);
+  this->copyFromStarting(start_index, v.local_data_const(), v.get_local_size());
 }
 
 /**

--- a/tests/LinAlg/vectorTests.hpp
+++ b/tests/LinAlg/vectorTests.hpp
@@ -182,7 +182,7 @@ public:
     v.copyFrom(from);
     int fail = verifyAnswer(&v, one);
 
-    // const real_type* from_buffer = createLocalBuffer(N, three);
+    // const real_type* from_buffer = hiop::LinearAlgebraFactory::createRawArray(N, three);
     // v.copyFrom(from_buffer);
     // fail += verifyAnswer(&v, three);
 
@@ -209,7 +209,7 @@ public:
     assert(Nx > Nfrom);
     x.setToConstant(two);
 
-    real_type* from_buffer = createLocalBuffer(Nx, one);
+    real_type* from_buffer = hiop::LinearAlgebraFactory::createRawArray(Nx, one);
 
     x.copyFromStarting(1, from_buffer, Nx-1);
     fail += verifyAnswer(&x,
@@ -217,7 +217,7 @@ public:
       {
         return (i == 0) ? two : one;
       });
-    deleteLocalBuffer(from_buffer);
+    hiop::LinearAlgebraFactory::deleteRawArray(from_buffer);
 
     x.setToConstant(two);
     from.setToConstant(one);
@@ -245,11 +245,11 @@ public:
     fail += verifyAnswer(&x, two);
 
     // Testing copying from a zero size array
-    real_type* zero_buffer = createLocalBuffer(0, one);
+    real_type* zero_buffer = hiop::LinearAlgebraFactory::createRawArray(0, one);
     x.setToConstant(two);
     x.copyFromStarting(0, zero_buffer, 0);
     fail += verifyAnswer(&x, two);
-    deleteLocalBuffer(zero_buffer);
+    hiop::LinearAlgebraFactory::deleteRawArray(zero_buffer);
 
     printMessage(fail, __func__, rank);
     return reduceReturn(fail, &x);
@@ -1538,8 +1538,6 @@ protected:
       hiop::hiopVector* x,
       std::function<real_type(local_ordinal_type)> expect) = 0;
   virtual bool reduceReturn(int failures, hiop::hiopVector* x) = 0;
-  virtual real_type* createLocalBuffer(local_ordinal_type N, real_type val) = 0;
-  virtual void deleteLocalBuffer(real_type* buffer) = 0;
 };
 
 }} // namespace hiop::tests

--- a/tests/LinAlg/vectorTestsPar.cpp
+++ b/tests/LinAlg/vectorTestsPar.cpp
@@ -150,20 +150,4 @@ int VectorTestsPar::verifyAnswer(
   return local_fail;
 }
 
-/// Wrap new command
-real_type* VectorTestsPar::createLocalBuffer(local_ordinal_type N, real_type val)
-{
-  real_type* buffer = new real_type[N];
-  for(local_ordinal_type i = 0; i < N; ++i)
-    buffer[i] = val;
-  return buffer;
-}
-
-/// Wrap delete command
-void VectorTestsPar::deleteLocalBuffer(real_type* buffer)
-{
-  delete [] buffer;
-}
-
-
 }} // namespace hiop::tests

--- a/tests/LinAlg/vectorTestsPar.hpp
+++ b/tests/LinAlg/vectorTestsPar.hpp
@@ -81,8 +81,6 @@ private:
       hiop::hiopVector* x,
       std::function<real_type(local_ordinal_type)> expect) override;
   virtual bool reduceReturn(int failures, hiop::hiopVector* x) override;
-  virtual real_type* createLocalBuffer(local_ordinal_type N, real_type val);
-  virtual void deleteLocalBuffer(real_type* buffer);
 
 #ifdef HIOP_USE_MPI
   MPI_Comm getMPIComm(hiop::hiopVector* x);

--- a/tests/LinAlg/vectorTestsRajaPar.cpp
+++ b/tests/LinAlg/vectorTestsRajaPar.cpp
@@ -163,42 +163,4 @@ int VectorTestsRajaPar::verifyAnswer(hiop::hiopVector* v, std::function<real_typ
   return local_fail;
 }
 
-/// Wrap new command
-real_type* VectorTestsRajaPar::createLocalBuffer(local_ordinal_type N, real_type val)
-{
-  auto& resmgr = umpire::ResourceManager::getInstance();
-  umpire::Allocator hal = resmgr.getAllocator("HOST");
-  real_type* buffer = static_cast<real_type*>(hal.allocate(N*sizeof(real_type)));
-
-  // Set buffer elements to the initial value
-  for(local_ordinal_type i = 0; i < N; ++i)
-    buffer[i] = val;
-
-#ifdef HIOP_USE_CUDA
-  umpire::Allocator dal = resmgr.getAllocator("DEVICE");
-  real_type* dev_buffer = static_cast<real_type*>(dal.allocate(N*sizeof(real_type)));
-  resmgr.copy(dev_buffer, buffer, N*sizeof(real_type));
-  hal.deallocate(buffer);
-  return dev_buffer;
-#endif
-
-  return buffer;
-}
-
-/// Wrap delete command
-void VectorTestsRajaPar::deleteLocalBuffer(real_type* buffer)
-{
-#ifdef HIOP_USE_CUDA
-  const std::string hiop_umpire_dev = "DEVICE";
-#else
-  const std::string hiop_umpire_dev = "HOST"; 
-#endif
-
-  auto& resmgr = umpire::ResourceManager::getInstance();
-  umpire::Allocator al = resmgr.getAllocator(hiop_umpire_dev);
-  al.deallocate(buffer);
-}
-
-
-
 }} // namespace hiop::tests

--- a/tests/LinAlg/vectorTestsRajaPar.hpp
+++ b/tests/LinAlg/vectorTestsRajaPar.hpp
@@ -84,8 +84,6 @@ private:
       hiop::hiopVector* x,
       std::function<real_type(local_ordinal_type)> expect) override;
   virtual bool reduceReturn(int failures, hiop::hiopVector* x) override;
-  virtual real_type* createLocalBuffer(local_ordinal_type N, real_type val);
-  virtual void deleteLocalBuffer(real_type* buffer);
 
 #ifdef HIOP_USE_MPI
   MPI_Comm getMPIComm(hiop::hiopVector* x);


### PR DESCRIPTION
In developing #141, I came across some potential improvements to the linear algebra factory, along with `hiopVectorRajaPar.cpp`. 

Changes made:
- Addition of default value for memory to be set to in linear algebra factory `createRawArray` method
- Modification of vector tests to use modified linear algebra factory method
- Modified raja vector `copyFromStarting` that uses a vector to call internal `copyFromStarting` that uses raw array data