### PR TITLE
Using magma2.5.4 build on ascent

### DIFF
--- a/BUILD.sh
+++ b/BUILD.sh
@@ -118,11 +118,12 @@ ascent)
     module purge
     module load cuda/11
     module use /gpfs/wolf/proj-shared/csc359/ascent/Modulefiles/Core
+    module use /gpfs/wolf/proj-shared/csc359/ascent/spack-modulefiles/
     module load exasgd-base
     module load gcc-ext/7.4.0
     module load spectrum-mpi-ext
     module load openblas
-    module load magma/2.5.3-cuda11
+    module load magma-2.5.4-gcc-7.4.0-vjotnd3 #magma/2.5.3-cuda11
     module load metis
     module load mpfr
     module load suitesparse


### PR DESCRIPTION
This passes CI on ascent with magma 2.5.4 built from spack [(link here)](https://code.ornl.gov/ecpcitest/exasgd/hiop/-/pipelines/129386). Feel free to reject this PR and manually change your branch, this just seemed like the easiest way forward. CC @pelesh 