### PR TITLE
Replacing #elif with #else in unit test driver for vector kernels

### DIFF
--- a/tests/testVector.cpp
+++ b/tests/testVector.cpp
@@ -125,7 +125,7 @@ int main(int argc, char** argv)
     std::cout << "  ... using unified virtual memory space:\n";
   }
   fail += runTests<VectorTestsRajaPar>("um", comm);
-#elif
+#else
   if (rank == 0)
   {
     std::cout << "\nTesting HiOp RAJA vector\n";
@@ -156,7 +156,7 @@ int main(int argc, char** argv)
       std::cout << "  ... using unified virtual memory space:\n";
     }
     fail += runIntTests<VectorTestsIntRaja>("um");
-#elif
+#else
     if (rank == 0)
     {
       std::cout << "\nTesting HiOp RAJA int vector\n";


### PR DESCRIPTION
Fixes issue caught by Newell full build test matrix:
```shell
/people/svcexasgd/gitlab/19613/tests/testVector.cpp:128:6: error: #elif with no expression
#elif
      ^
/people/svcexasgd/gitlab/19613/tests/testVector.cpp:159:6: error: #elif with no expression
#elif
```