### PR TITLE
remove flawed assert condition, fixes #171

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -306,6 +306,7 @@ install(FILES src/Interface/hiopInterface.hpp
   src/Optimization/hiopFilter.hpp
   src/Optimization/hiopHessianLowRank.hpp
   src/Optimization/hiopDualsUpdater.hpp
+  src/Optimization/hiopFactAcceptor.hpp
   src/LinAlg/hiopVector.hpp
   src/LinAlg/hiopVectorPar.hpp
   src/LinAlg/hiopVectorInt.hpp
@@ -336,6 +337,7 @@ install(FILES src/Interface/hiopInterface.hpp
   src/LinAlg/hiop_blasdefs.hpp
   src/Drivers/IpoptAdapter.hpp
   ${CMAKE_BINARY_DIR}/hiop_defs.hpp
+  ${CMAKE_BINARY_DIR}/FortranCInterface.hpp
   DESTINATION include)
 
 if(HIOP_USE_RAJA)

--- a/src/Optimization/hiopPDPerturbation.hpp
+++ b/src/Optimization/hiopPDPerturbation.hpp
@@ -181,7 +181,6 @@ public:
 	if(!guts_of_compute_perturb_wrong_inertia(delta_wx, delta_wd)) {
 	  return false;
 	}
-	assert(delta_cc == 0. && delta_cd == 0.);
 	deltas_test_type_ = dttDeltac0Deltawpos;
         break;
       case dttDeltac0Deltawpos:


### PR DESCRIPTION
This is a flawed assert condition which should be removed from the code.

This line is only executed on marianas under GCC debug mode. 
Probably it is because some round-off errors send the logic control of inertia correction to different switch case, and then hit the  flawed assert condition. 

@ashermancinelli All the `delta_` variables have been initialized before entering this function, and hence round-off error is the last thing I can guess. Since I don't have access to marianas, I wonder if you could help us to try this fix on marianas.
It probably can converge the problem, under a different path. 

Fixes #171 
