### PR TITLE
Options consistence reset fix

### DIFF
--- a/src/Utils/hiopOptions.cpp
+++ b/src/Utils/hiopOptions.cpp
@@ -354,8 +354,8 @@ void hiopOptions::ensureConsistence()
         log_printf(hovWarning,
                    "The option 'KKTLinsys=%s' is not valid with 'Hessian=quasiNewtonApprox'. "
                    "Will use 'KKTLinsys=auto'\n", strKKT.c_str());
+        set_val("KKTLinsys", "auto");
       }
-      set_val("KKTLinsys", "auto");
     }
   }
 


### PR DESCRIPTION
fixes a misplaced statement related to reseting an option to its default value when found to be inconsistence with build and other runtime parameters