### PR TITLE
Fix bugs in RAJA vector copy methods

### DIFF
--- a/src/LinAlg/hiopMatrixRajaDense.cpp
+++ b/src/LinAlg/hiopMatrixRajaDense.cpp
@@ -153,20 +153,17 @@ hiopMatrixRajaDense::hiopMatrixRajaDense(
   auto& resmgr = umpire::ResourceManager::getInstance();
   umpire::Allocator devalloc  = resmgr.getAllocator(mem_space_);
   data_dev_ = static_cast<double*>(devalloc.allocate(n_local_*max_rows_*sizeof(double)));
-  //M_dev_    = static_cast<double**>(devalloc.allocate((max_rows_ == 0 ? 1 : max_rows_) * sizeof(double*)));
   if(mem_space_ == "DEVICE")
   {
     // If memory space is on device, create a host mirror
     umpire::Allocator hostalloc = resmgr.getAllocator("HOST");
     data_host_  = static_cast<double*>(hostalloc.allocate(n_local_*max_rows_*sizeof(double)));
-    //M_host_     = static_cast<double**>(hostalloc.allocate((max_rows_ == 0 ? 1 : max_rows_) * sizeof(double*)));
     yglob_host_ = static_cast<double*>(hostalloc.allocate(m_local_ * sizeof(double)));
     ya_host_    = static_cast<double*>(hostalloc.allocate(m_local_ * sizeof(double)));
   }
   else
   {
     data_host_ = data_dev_;
-    //M_host_    = M_dev_;
     // If memory space is not on device, these buffers are allocated in memory space
     yglob_host_ = static_cast<double*>(devalloc.allocate(m_local_ * sizeof(double)));
     ya_host_    = static_cast<double*>(devalloc.allocate(m_local_ * sizeof(double)));
@@ -203,7 +200,6 @@ hiopMatrixRajaDense::~hiopMatrixRajaDense()
   }
 }
 
-/// TODO: check again
 /**
  * @brief Matrix copy constructor
  * 
@@ -218,24 +214,22 @@ hiopMatrixRajaDense::hiopMatrixRajaDense(const hiopMatrixRajaDense& dm)
   comm_     = dm.comm_;
   myrank_   = dm.myrank_;
   max_rows_ = dm.max_rows_;
+  mem_space_ = dm.mem_space_;
 
   auto& resmgr = umpire::ResourceManager::getInstance();
   umpire::Allocator devalloc = resmgr.getAllocator(mem_space_);
   data_dev_ = static_cast<double*>(devalloc.allocate(n_local_*max_rows_*sizeof(double)));
-  //M_dev_    = static_cast<double**>(devalloc.allocate((max_rows_ == 0 ? 1 : max_rows_) * sizeof(double*)));
   if(mem_space_ == "DEVICE")
   {
     // If memory space is on device, create a host mirror
     umpire::Allocator hostalloc = resmgr.getAllocator("HOST");
     data_host_  = static_cast<double*>(hostalloc.allocate(n_local_*max_rows_*sizeof(double)));
-    //M_host_     = static_cast<double**>(hostalloc.allocate((max_rows_ == 0 ? 1 : max_rows_) * sizeof(double*)));
     yglob_host_ = static_cast<double*>(hostalloc.allocate(m_local_ * sizeof(double)));
     ya_host_    = static_cast<double*>(hostalloc.allocate(m_local_ * sizeof(double)));
   }
   else
   {
     data_host_ = data_dev_;
-    //M_host_    = M_dev_;
     // If memory space is not on device, these buffers are allocated in memory space
     yglob_host_ = static_cast<double*>(devalloc.allocate(m_local_ * sizeof(double)));
     ya_host_    = static_cast<double*>(devalloc.allocate(m_local_ * sizeof(double)));

--- a/src/LinAlg/hiopVectorRajaPar.cpp
+++ b/src/LinAlg/hiopVectorRajaPar.cpp
@@ -303,11 +303,12 @@ void hiopVectorRajaPar::copyFrom(const double* local_array)
  */
 void hiopVectorRajaPar::copyFromStarting(int start_index_in_this, const double* v, int nv)
 {
+  assert(start_index_in_this+nv <= n_local_);
+
+  // If nothing to copy, return.  
   if(nv == 0)
     return;
 
-  assert(start_index_in_this+nv <= n_local_);
-  
   auto& rm = umpire::ResourceManager::getInstance();
   double* vv = const_cast<double*>(v); // <- cast away const
   rm.copy(data_dev_ + start_index_in_this, vv, nv*sizeof(double));
@@ -414,11 +415,12 @@ void hiopVectorRajaPar::copyToStarting(int start_index, hiopVector& dst)
  */
 void hiopVectorRajaPar::copyToStarting(hiopVector& vec, int start_index/*_in_dest*/)
 {
-  if(n_local_ == 0)
-    return;
-
   const hiopVectorRajaPar& v = dynamic_cast<const hiopVectorRajaPar&>(vec);
   assert(start_index+n_local_ <= v.n_local_);
+
+  // If there is nothing to copy, return.
+  if(n_local_ == 0)
+    return;
 
   auto& rm = umpire::ResourceManager::getInstance();
   rm.copy(v.data_dev_ + start_index, this->data_dev_, this->n_local_*sizeof(double));

--- a/src/LinAlg/hiopVectorRajaPar.hpp
+++ b/src/LinAlg/hiopVectorRajaPar.hpp
@@ -163,6 +163,7 @@ public:
   virtual bool isfinite_local() const;
   
   virtual void print(FILE*, const char* withMessage=NULL, int max_elems=-1, int rank=-1) const;
+  virtual void print(){} ///< @todo Temporary to surpress warnings, will be removed.
 
   /* more accessers */
   inline long long get_local_size() const { return n_local_; }


### PR DESCRIPTION
Umpire copy throws exceptions when its arguments point to zero length arrays. The proposed fix will skip calling copy method altogether if there is nothing to copy to avoid Umpire exceptions. 

This bug fix does not affect situations when there is a nonzero amount of data to be copied and some of the arrays are not correctly allocated.

Suggest to squash upon merge.

CC @CameronRutherford 