### PR TITLE
Update of write_kkt

### DIFF
--- a/src/LinAlg/csr_iajaaa.md
+++ b/src/LinAlg/csr_iajaaa.md
@@ -6,9 +6,9 @@ The .iajaaa files contain
 
 1. number of rows (nrows) [1 int]
 
-2. number of nonzeros (nnz) [1 int]
+2. number of primal variables, number of equality constraints, and number of inequality constraints of the underlying NLP problem [3 ints]
 
-3. number of primal variables, number of equality constraints, and number of inequality constraints of the underlying NLP problem [3 ints]
+3. number of nonzeros (nnz) [1 int]
 
 4. array of pointers/offsets in 4. and 5. of the first nonzero of each row; first entry is 1 and the last entry is nnz+1 [nrows+1 ints]
 

--- a/src/LinAlg/csr_iajaaa.md
+++ b/src/LinAlg/csr_iajaaa.md
@@ -1,25 +1,27 @@
 # CSR Format used by HiOp to save linear systems
 
-Each of the linear systems saved by HiOp in a .iajaaa file (see [this](readme.md) for more information) consists of the systems's matrix, the right-hand side(s) (rhs), and the solution(s). The matrix is assumed to be symmetric and the indexes are Fortran style (1-based). An example Matlab script that loads and solves such linear systems is provided [here](load_kkt_mat.m). 
+Each of the linear systems saved by HiOp in a .iajaaa file (see [this](readme.md) for more information) consists of the systems's matrix, the right-hand side(s) (rhs), and the solution(s). The matrix is assumed to be square and the indexes are Fortran style (1-based). For symmetric matrices only the elements from the upper triangle are used. An example Matlab script that loads and solves such linear systems is provided [here](load_kkt_mat.m). 
 
 The .iajaaa files contain
 
-1. number of rows (nrows) [1 double]
+1. number of rows (nrows) [1 int]
 
-2. number of nonzeros (nnz) [1 double]
+2. number of nonzeros (nnz) [1 int]
 
-3. array of pointers/offsets in 4. and 5. of the first nonzero of each row; first entry is 1 and the last entry is nnz+1 [nrows+1 ints]
+3. number of primal variables, number of equality constraints, and number of inequality constraints of the underlying NLP problem [3 ints]
 
-4. array of the column indexes of nonzeros [nnz ints]
+4. array of pointers/offsets in 4. and 5. of the first nonzero of each row; first entry is 1 and the last entry is nnz+1 [nrows+1 ints]
 
-5. array of nonzero entries  [nnz doubles]
+5. array of the column indexes of nonzeros [nnz ints]
 
-6. rhs [nrows doubles]
+6. array of nonzero entries  [nnz doubles]
 
-7. solution [nrows doubles]
+7. rhs [nrows doubles]
 
-8. more rhs-solution pairs (repetitions of 6-7 above)
+8. solution [nrows doubles]
+
+9. more rhs-solution pairs (repetitions of 7-8 above)
 
 Please remark that there is a slight variation  of the .iajaaa format used by Ipopt (more exactly by Pardiso from within Ipopt), namely,
-+ HiOp's also saves the solution, see 7. below;
-+ multiple rhs-solution pairs can be present (*i.e.*,6-7 can repeat) at the end of the output files
++ HiOp's also saves the solution, see 8. above;
++ multiple rhs-solution pairs can be present (*i.e.*,7-8 can repeat) at the end of the output files

--- a/src/LinAlg/csr_iajaaa.md
+++ b/src/LinAlg/csr_iajaaa.md
@@ -1,6 +1,8 @@
 # CSR Format used by HiOp to save linear systems
 
-Each of the linear systems saved by HiOp in a .iajaaa file (see [this](readme.md) for more information) consists of the systems's matrix, the right-hand side(s) (rhs), and the solution(s). The matrix is assumed to be square and the indexes are Fortran style (1-based). For symmetric matrices only the elements from the upper triangle are used. An example Matlab script that loads and solves such linear systems is provided [here](load_kkt_mat.m). 
+Each of the linear systems saved by HiOp in a .iajaaa file (see [this](readme.md) for more information) consists of the systems's matrix, the right-hand side(s) (rhs), and the solution(s). The matrix is assumed to be square and the indexes are Fortran style (1-based). For KKT symmetric matrices only the elements from the upper or lower triangle are used. The lower triangle elements are saved for all symmetric KKT systems, while for the rest of the symmetric KKT systems (MDS and dense) the upper triangle elements are saved.
+
+An example Matlab script that loads and solves such linear systems is provided [here](load_kkt_mat.m). 
 
 The .iajaaa files contain
 

--- a/src/LinAlg/load_kkt_mat.m
+++ b/src/LinAlg/load_kkt_mat.m
@@ -6,12 +6,15 @@ fclose(f);
 
 %% data loading
 m=A(1); % matrix size 
-nnz=A(2); % number of nnz of the upper triangle
-rowp = A(3:m+3); % row pointers in colidx and vals (see below)
-colidx=A(m+4:nnz+m+3); % column indexes for each nz
-vals=A(nnz+m+4:nnz+nnz+m+3); % values for each nz
-rhs=A(nnz+nnz+m+4:nnz+nnz+m+m+3); % rhs 
-sol=A(nnz+nnz+m+m+4:nnz+nnz+m+m+m+3); % solution
+nnz=A(2); % number of nnz of matrix (or of the upper triangle for symmetric matrices)
+nx=A(3); % number of (primal) variables of the underlying NLP
+meq=A(4); % number of equalities of the underlying NLP
+nineq=A(5); % number of inequalities of the underlying NLP
+rowp = A(6:m+6); % row pointers in colidx and vals (see below)
+colidx=A(m+7:nnz+m+6); % column indexes for each nz
+vals=A(nnz+m+7:nnz+nnz+m+6); % values for each nz
+rhs=A(nnz+nnz+m+7:nnz+nnz+m+m+6); % rhs 
+sol=A(nnz+nnz+m+m+7:nnz+nnz+m+m+m+6); % solution
 fprintf('Loaded a matrix of size %d with %d nonzeros from "%s"\n', ...
     m, nnz, filename);
 
@@ -23,7 +26,8 @@ for ii=2:m+1
     end
 end
 
-%% form the matrix and fill lower triangle
+%% form the matrix
+% if the matrix is known to be symmetric fill the lower triangle
 M = sparse(rowidx, colidx, vals, m, m);
 M=M+transpose(triu(M,1));
 

--- a/src/LinAlg/load_kkt_mat.m
+++ b/src/LinAlg/load_kkt_mat.m
@@ -28,13 +28,21 @@ end
 
 %% form the matrix
 M = sparse(rowidx, colidx, vals, m, m);
-% if the matrix is known to be symmetric fill, you also need to know whether
-%  A. the lower triangle was saved, in which case use
-% M=M+transpose(tril(M,-1));
-% or
-% B. the upper triangle was saved, in which case use
-% M=M+transpose(triu(M,1));
 
+% if the matrix is known to be symmetric, it is either lower or upper
+% triangle
+if istril(M)
+  %  A. the lower triangle was saved
+  M=M+transpose(tril(M,-1));
+else 
+    if istriu(M)
+      %the upper triangle was saved
+      M=M+transpose(triu(M,1));
+    else
+        %the matrix is not symmetric; do nothing
+    end
+end
+    
 %% solve using Matlab and check the residuals of the Matlab solution 
 %% and of the solution from .iajaaa file
 sol2 = M\rhs;

--- a/src/LinAlg/load_kkt_mat.m
+++ b/src/LinAlg/load_kkt_mat.m
@@ -28,8 +28,12 @@ end
 
 %% form the matrix
 M = sparse(rowidx, colidx, vals, m, m);
-% if the matrix is known to be symmetric fill the lower triangle
-M=M+transpose(triu(M,1));
+% if the matrix is known to be symmetric fill, you also need to know whether
+%  A. the lower triangle was saved, in which case use
+% M=M+transpose(tril(M,-1));
+% or
+% B. the upper triangle was saved, in which case use
+% M=M+transpose(triu(M,1));
 
 %% solve using Matlab and check the residuals of the Matlab solution 
 %% and of the solution from .iajaaa file

--- a/src/LinAlg/load_kkt_mat.m
+++ b/src/LinAlg/load_kkt_mat.m
@@ -1,15 +1,15 @@
 %% specify filename
-filename = 'kkt_mat_0.iajaaa';
+filename = 'kkt_linsys_0.iajaaa';
 f = fopen(filename,'r');
 A = fscanf(f, '%f');
 fclose(f);
 
 %% data loading
 m=A(1); % matrix size 
-nnz=A(2); % number of nnz of matrix (or of the upper triangle for symmetric matrices)
-nx=A(3); % number of (primal) variables of the underlying NLP
-meq=A(4); % number of equalities of the underlying NLP
-nineq=A(5); % number of inequalities of the underlying NLP
+nx=A(2); % number of (primal) variables of the underlying NLP
+meq=A(3); % number of equalities of the underlying NLP
+nineq=A(4); % number of inequalities of the underlying NLP
+nnz=A(5); % number of nnz of matrix (or of the upper triangle for symmetric matrices)
 rowp = A(6:m+6); % row pointers in colidx and vals (see below)
 colidx=A(m+7:nnz+m+6); % column indexes for each nz
 vals=A(nnz+m+7:nnz+nnz+m+6); % values for each nz
@@ -27,8 +27,8 @@ for ii=2:m+1
 end
 
 %% form the matrix
-% if the matrix is known to be symmetric fill the lower triangle
 M = sparse(rowidx, colidx, vals, m, m);
+% if the matrix is known to be symmetric fill the lower triangle
 M=M+transpose(triu(M,1));
 
 %% solve using Matlab and check the residuals of the Matlab solution 

--- a/src/LinAlg/readme.md
+++ b/src/LinAlg/readme.md
@@ -66,8 +66,8 @@ HiOp offers support for converting sparse triplet format to  compressed sparse r
 ### *Symmetric* sparse matrices 
 Only upper triangular nonzero entries should be specified, accessed, and maintained.
 The Hessian and the symmetric KKT systems are implemented as symmetric matrices. Users only need to provide the upper triangle nonzero entries to Hessian.
-For the symmetric KKT linearizations, some linear algebra package, e.g., MA57 from HSL, can read entries from both the upper and lower triangular part, however, only one from the entries (i,j) and (j,i) is required to be passed to HSL solvers.
-Developers should be remark that the internal sorting rules for sparse matrices in triplet format enable efficient copying of the constraint Jacobian and Lagrangian Hessian in the KKT linear system matrix.
+For the symmetric KKT linearizations, some linear algebra package, e.g., MA57 from HSL, can read entries from both the upper and lower triangular part, however, only one from the entries (i,j) and (j,i) is required to be passed to HSL solvers. 
+HiOp developers should be remark that the internal sorting rules for sparse matrices in triplet format enable efficient copying of the constraint Jacobian and Lagrangian Hessian in the KKT linear system matrix; also, the symmetric KKT linear systems store only the lower triangle entries for the sake of efficiency.
 
 
 ## Obtaining matrices from HiOp

--- a/src/LinAlg/readme.md
+++ b/src/LinAlg/readme.md
@@ -67,7 +67,7 @@ HiOp offers support for converting sparse triplet format to  compressed sparse r
 Only upper triangular nonzero entries should be specified, accessed, and maintained.
 The Hessian and the symmetric KKT systems are implemented as symmetric matrices. Users only need to provide the upper triangle nonzero entries to Hessian.
 For the symmetric KKT linearizations, some linear algebra package, e.g., MA57 from HSL, can read entries from both the upper and lower triangular part, however, only one from the entries (i,j) and (j,i) is required to be passed to HSL solvers. 
-HiOp developers should be remark that the internal sorting rules for sparse matrices in triplet format enable efficient copying of the constraint Jacobian and Lagrangian Hessian in the KKT linear system matrix; also, the symmetric KKT linear systems store only the lower triangle entries for the sake of efficiency.
+HiOp developers should remark that the internal sorting rules for triplet format enable efficient copying of the constraint Jacobian and Lagrangian Hessian in the KKT linear system matrix; also, the symmetric KKT linear systems store only the lower triangle entries for the sake of efficiency.
 
 
 ## Obtaining matrices from HiOp

--- a/src/Optimization/hiopKKTLinSysDense.hpp
+++ b/src/Optimization/hiopKKTLinSysDense.hpp
@@ -154,8 +154,12 @@ public:
     nlp_->log->write("KKT Linsys:", Msys, hovMatrices);
 
     //write matrix to file if requested
-    if(nlp_->options->GetString("write_kkt") == "yes") write_linsys_counter++;
-    if(write_linsys_counter>=0) csr_writer.writeMatToFile(Msys, write_linsys_counter); 
+    if(nlp_->options->GetString("write_kkt") == "yes") {
+      write_linsys_counter++;
+    }
+    if(write_linsys_counter>=0) {
+      csr_writer.writeMatToFile(Msys, write_linsys_counter, nx, neq, nineq);
+    }
     
     return true;
   }
@@ -304,8 +308,12 @@ public:
     nlp_->log->write("KKT Linsys:", Msys, hovMatrices);
 
     //write matrix to file if requested
-    if(nlp_->options->GetString("write_kkt") == "yes") write_linsys_counter++;
-    if(write_linsys_counter>=0) csr_writer.writeMatToFile(Msys, write_linsys_counter);
+    if(nlp_->options->GetString("write_kkt") == "yes") {
+      write_linsys_counter++;
+    }
+    if(write_linsys_counter>=0) {
+      csr_writer.writeMatToFile(Msys, write_linsys_counter, nx, neq, nineq);
+    }
 
     nlp_->log->write("KKT XDYcYd Linsys (to be factorized):", Msys, hovMatrices);
     return true;

--- a/src/Optimization/hiopKKTLinSysMDS.cpp
+++ b/src/Optimization/hiopKKTLinSysMDS.cpp
@@ -286,8 +286,12 @@ namespace hiop
     nlp_->runStats.kkt.tmUpdateLinsys.stop();
       
     //write matrix to file if requested
-    if(nlp_->options->GetString("write_kkt") == "yes") write_linsys_counter_++;
-    if(write_linsys_counter_>=0) csr_writer_.writeMatToFile(Msys, write_linsys_counter_); 
+    if(nlp_->options->GetString("write_kkt") == "yes") {
+      write_linsys_counter_++;
+    }
+    if(write_linsys_counter_>=0) {
+      csr_writer_.writeMatToFile(Msys, write_linsys_counter_, nxd+nxs, neq, nineq);
+    }
     
     return true;
   }
@@ -340,11 +344,11 @@ namespace hiop
     //ths[nxde+nyc:nxde+nyc+nyd-1] = ryd
     ryd.copyToStarting(*rhs_, nxde+nyc);
 
-    if(write_linsys_counter_>=0) 
+    if(write_linsys_counter_>=0) {
       csr_writer_.writeRhsToFile(*rhs_, write_linsys_counter_);
-
+    }
+    
     nlp_->runStats.kkt.tmSolveRhsManip.stop();
-
     nlp_->runStats.kkt.tmSolveTriangular.start();
     
     // solve
@@ -357,9 +361,9 @@ namespace hiop
 			nlp_->runStats.linsolv.get_summary_last_solve().c_str());
     }
     
-    if(write_linsys_counter_>=0) 
+    if(write_linsys_counter_>=0) {
       csr_writer_.writeSolToFile(*rhs_, write_linsys_counter_);
-
+    }
     if(false==linsol_ok) return false;
 
     nlp_->runStats.kkt.tmSolveRhsManip.start();
@@ -368,7 +372,6 @@ namespace hiop
     rhs_->startingAtCopyToStartingAt(0,        dx,  nxsp, nxde);
     rhs_->startingAtCopyToStartingAt(nxde,     dyc, 0);   
     rhs_->startingAtCopyToStartingAt(nxde+nyc, dyd, 0);
-
 
     // compute dxs
     hiopVector& dxs = *_buff_xs_;

--- a/src/Optimization/hiopKKTLinSysSparse.cpp
+++ b/src/Optimization/hiopKKTLinSysSparse.cpp
@@ -91,7 +91,8 @@ namespace hiop
     if(!Jac_dSp_) { assert(false); return false; }
 
     long long nx = HessSp_->n(), neq=Jac_cSp_->m(), nineq=Jac_dSp_->m();
-    int nnz = HessSp_->numberOfNonzeros() + Jac_cSp_->numberOfNonzeros() + Jac_dSp_->numberOfNonzeros() + nx + neq + nineq;
+    int nnz = HessSp_->numberOfNonzeros() + Jac_cSp_->numberOfNonzeros() + Jac_dSp_->numberOfNonzeros();
+    nnz += nx + neq + nineq;
 
     linSys_ = determineAndCreateLinsys(nx, neq, nineq, nnz);
         
@@ -113,9 +114,12 @@ namespace hiop
 
       // copy Jac and Hes to the full iterate matrix
       long long dest_nnz_st{0};
-      Msys.copyRowsBlockFrom(*HessSp_,  0,   nx,     0,      dest_nnz_st); dest_nnz_st += HessSp_->numberOfNonzeros();
-      Msys.copyRowsBlockFrom(*Jac_cSp_, 0,   neq,    nx,     dest_nnz_st); dest_nnz_st += Jac_cSp_->numberOfNonzeros();
-      Msys.copyRowsBlockFrom(*Jac_dSp_, 0,   nineq,  nx+neq, dest_nnz_st); dest_nnz_st += Jac_dSp_->numberOfNonzeros();
+      Msys.copyRowsBlockFrom(*HessSp_,  0,   nx,     0,      dest_nnz_st);
+      dest_nnz_st += HessSp_->numberOfNonzeros();
+      Msys.copyRowsBlockFrom(*Jac_cSp_, 0,   neq,    nx,     dest_nnz_st);
+      dest_nnz_st += Jac_cSp_->numberOfNonzeros();
+      Msys.copyRowsBlockFrom(*Jac_dSp_, 0,   nineq,  nx+neq, dest_nnz_st);
+      dest_nnz_st += Jac_dSp_->numberOfNonzeros();
 
       //build the diagonal Hx = Dx + delta_wx
       if(NULL == Hx_) {

--- a/src/Optimization/hiopKKTLinSysSparse.cpp
+++ b/src/Optimization/hiopKKTLinSysSparse.cpp
@@ -160,8 +160,12 @@ namespace hiop
     } // end of update of the linear system
 
     //write matrix to file if requested
-    if(nlp_->options->GetString("write_kkt") == "yes") write_linsys_counter_++;
-    if(write_linsys_counter_>=0) csr_writer_.writeMatToFile(Msys, write_linsys_counter_); 
+    if(nlp_->options->GetString("write_kkt") == "yes") {
+      write_linsys_counter_++;
+    }
+    if(write_linsys_counter_>=0) {
+      csr_writer_.writeMatToFile(Msys, write_linsys_counter_, nx, neq, nineq);
+    }
 
     nlp_->runStats.tmSolverInternal.stop();
     return true;
@@ -194,9 +198,9 @@ namespace hiop
     ryc.copyToStarting(*rhs_, nx);
     ryd.copyToStarting(*rhs_, nx+nyc);
 
-    if(write_linsys_counter_>=0)
+    if(write_linsys_counter_>=0) {
       csr_writer_.writeRhsToFile(*rhs_, write_linsys_counter_);
-
+    }
     nlp_->runStats.kkt.tmSolveRhsManip.stop();
 
     nlp_->runStats.kkt.tmSolveTriangular.start();
@@ -212,9 +216,9 @@ namespace hiop
 			nlp_->runStats.linsolv.get_summary_last_solve().c_str());
     }
 
-    if(write_linsys_counter_>=0)
+    if(write_linsys_counter_>=0) {
       csr_writer_.writeSolToFile(*rhs_, write_linsys_counter_);
-
+    }
     if(false==linsol_ok) return false;
 
     nlp_->runStats.kkt.tmSolveRhsManip.start();
@@ -376,8 +380,12 @@ namespace hiop
     }
     
     //write matrix to file if requested
-    if(nlp_->options->GetString("write_kkt") == "yes") write_linsys_counter_++;
-    if(write_linsys_counter_>=0) csr_writer_.writeMatToFile(Msys, write_linsys_counter_); 
+    if(nlp_->options->GetString("write_kkt") == "yes") {
+      write_linsys_counter_++;
+    }
+    if(write_linsys_counter_>=0) {
+      csr_writer_.writeMatToFile(Msys, write_linsys_counter_, nx, neq, nineq);
+    }
 
     return true;
   }
@@ -675,8 +683,12 @@ namespace hiop
     }
  
     //write matrix to file if requested
-    if(nlp_->options->GetString("write_kkt") == "yes") write_linsys_counter_++;
-    if(write_linsys_counter_>=0) csr_writer_.writeMatToFile(Msys, write_linsys_counter_); 
+    if(nlp_->options->GetString("write_kkt") == "yes") {
+      write_linsys_counter_++;
+    }
+    if(write_linsys_counter_>=0) {
+      csr_writer_.writeMatToFile(Msys, write_linsys_counter_, nx, neq, nineq);
+    }
 
     return true;
   }

--- a/src/Utils/hiopCSR_IO.hpp
+++ b/src/Utils/hiopCSR_IO.hpp
@@ -178,7 +178,7 @@ namespace hiop
         _nlp->log->printf(hovError, "Could not open '%s' for writing the linsys.\n", fname.c_str());
         return;
       }
-      
+
       //count nnz
       int nnz=Msys.numberOfNonzeros();
       


### PR DESCRIPTION
Updates the CSR file IO code to write NLP sizes.

Also the documentation is updated: 
 - lower triangle elements are saved for sparse symmetric KKT linearization
 - upper triangle elems are saved for other symmetric KKT linearizations