### PR TITLE
Adjust var/con bounds and relax var/con bounds

### DIFF
--- a/src/Drivers/nlpDenseCons_ex3_driver.cpp
+++ b/src/Drivers/nlpDenseCons_ex3_driver.cpp
@@ -73,6 +73,9 @@ int main(int argc, char **argv)
 
   hiopNlpDenseConstraints nlp(nlp_interface);
 
+  // relax var/con bounds before solving the problem
+  nlp.options->SetNumericValue("bound_relax_perturb", 1e-10);
+
   //set options before the solver is even allocated
   nlp.options->SetStringValue("fixed_var", "relax");
 

--- a/src/LinAlg/hiopVector.hpp
+++ b/src/LinAlg/hiopVector.hpp
@@ -137,8 +137,12 @@ public:
   /** @brief Set each component of this hiopVector to the maximum of itself and the given constant. */
   virtual void component_max(const double constant) = 0;
   /** @brief Set each component of this hiopVector to the maximum of itself and the corresponding component of 'v'. */
-  virtual void component_max(const hiopVector& v ) = 0;
-
+  virtual void component_max(const hiopVector& v) = 0;
+  /** @brief Set each component to its absolute value */
+  virtual void component_abs () = 0;
+  /** @brief Apply sign function to each component */
+  virtual void component_sgn () = 0;
+  
   /// @brief Scale each element of this  by the constant alpha
   virtual void scale( double alpha ) = 0;
   /// @brief this += alpha * x

--- a/src/LinAlg/hiopVector.hpp
+++ b/src/LinAlg/hiopVector.hpp
@@ -139,9 +139,9 @@ public:
   /** @brief Set each component of this hiopVector to the maximum of itself and the corresponding component of 'v'. */
   virtual void component_max(const hiopVector& v) = 0;
   /** @brief Set each component to its absolute value */
-  virtual void component_abs () = 0;
+  virtual void component_abs() = 0;
   /** @brief Apply sign function to each component */
-  virtual void component_sgn () = 0;
+  virtual void component_sgn() = 0;
   
   /// @brief Scale each element of this  by the constant alpha
   virtual void scale( double alpha ) = 0;
@@ -196,6 +196,9 @@ public:
   virtual int allPositive() = 0;
   /// @brief True if elements corresponding to nonzeros in w are all positive
   virtual int allPositive_w_patternSelect(const hiopVector& w) = 0;
+  /// @brief Return the minimum value in this vector
+  virtual double min() const = 0;
+  virtual double min_w_pattern(const hiopVector& select) const = 0;
   /// @brief Return the minimum value in this vector, and the index at which it occurs.
   virtual void min( double& m, int& index ) const = 0;
   /// @brief Project the vector into the bounds, used for shifting the ini pt in the bounds

--- a/src/LinAlg/hiopVectorPar.cpp
+++ b/src/LinAlg/hiopVectorPar.cpp
@@ -426,6 +426,26 @@ void hiopVectorPar::component_max(const hiopVector& v_)
   }
 }
 
+void hiopVectorPar::component_abs ()
+{
+  for(int i=0; i<n_local_; i++) {
+    data_[i] = fabs(data_[i]);  
+  }
+}
+
+void hiopVectorPar::component_sgn ()
+{
+  for(int i=0; i<n_local_; i++) {
+    if(data_[i]<0.0) {
+      data_[i] = -1.0;
+    } else if(data_[i]>0.0) {
+      data_[i] = 1.0;
+    } else {
+      data_[i] = 0.0;
+    }
+  }
+}
+
 void hiopVectorPar::scale(double num)
 {
   if(1.0==num) return;

--- a/src/LinAlg/hiopVectorPar.cpp
+++ b/src/LinAlg/hiopVectorPar.cpp
@@ -426,23 +426,18 @@ void hiopVectorPar::component_max(const hiopVector& v_)
   }
 }
 
-void hiopVectorPar::component_abs ()
+void hiopVectorPar::component_abs()
 {
   for(int i=0; i<n_local_; i++) {
     data_[i] = fabs(data_[i]);  
   }
 }
 
-void hiopVectorPar::component_sgn ()
+void hiopVectorPar::component_sgn()
 {
   for(int i=0; i<n_local_; i++) {
-    if(data_[i]<0.0) {
-      data_[i] = -1.0;
-    } else if(data_[i]>0.0) {
-      data_[i] = 1.0;
-    } else {
-      data_[i] = 0.0;
-    }
+    int sign = (0.0 < data_[i]) - (data_[i] < 0.0);
+    data_[i] = static_cast<double>(sign);      
   }
 }
 
@@ -554,6 +549,40 @@ void  hiopVectorPar::addConstant_w_patternSelect(double c, const hiopVector& ix_
   assert(this->n_local_ == ix.n_local_);
   const double* ix_vec = ix.data_;
   for(int i=0; i<n_local_; i++) if(ix_vec[i]==1.) data_[i]+=c;
+}
+
+double hiopVectorPar::min() const
+{
+  double ret_val = std::numeric_limits<double>::max();
+  for(int i=0; i<n_local_; i++) {
+    ret_val = (ret_val < data_[i]) ? ret_val : data_[i];
+  }
+#ifdef HIOP_USE_MPI
+  double ret_val_g;
+  int ierr=MPI_Allreduce(&ret_val, &ret_val_g, 1, MPI_DOUBLE, MPI_MIN, comm_); assert(MPI_SUCCESS==ierr);
+  ret_val = ret_val_g;
+#endif
+  return ret_val;
+}
+
+double hiopVectorPar::min_w_pattern(const hiopVector& select) const
+{
+  const hiopVectorPar& ix = dynamic_cast<const hiopVectorPar&>(select);
+  assert(this->n_local_ == ix.n_local_);
+  
+  double ret_val = std::numeric_limits<double>::max();
+  const double* ix_vec = ix.data_;
+  for(int i=0; i<n_local_; i++) {
+    if(ix_vec[i]==1.) {
+      ret_val = (ret_val < data_[i]) ? ret_val : data_[i];
+    }   
+  }
+#ifdef HIOP_USE_MPI
+  double ret_val_g;
+  int ierr=MPI_Allreduce(&ret_val, &ret_val_g, 1, MPI_DOUBLE, MPI_MIN, comm_); assert(MPI_SUCCESS==ierr);
+  ret_val = ret_val_g;
+#endif
+  return ret_val;
 }
 
 void hiopVectorPar::min( double& m, int& index ) const

--- a/src/LinAlg/hiopVectorPar.hpp
+++ b/src/LinAlg/hiopVectorPar.hpp
@@ -121,7 +121,9 @@ public:
   virtual void component_min(const hiopVector& v);
   virtual void component_max(const double constant);
   virtual void component_max(const hiopVector& v);
-  
+  virtual void component_abs ();
+  virtual void component_sgn ();
+
   virtual void scale( double alpha );
   /// @brief this += alpha * x
   virtual void axpy  ( double alpha, const hiopVector& x );

--- a/src/LinAlg/hiopVectorPar.hpp
+++ b/src/LinAlg/hiopVectorPar.hpp
@@ -121,8 +121,8 @@ public:
   virtual void component_min(const hiopVector& v);
   virtual void component_max(const double constant);
   virtual void component_max(const hiopVector& v);
-  virtual void component_abs ();
-  virtual void component_sgn ();
+  virtual void component_abs();
+  virtual void component_sgn();
 
   virtual void scale( double alpha );
   /// @brief this += alpha * x
@@ -135,6 +135,8 @@ public:
   /// @brief Add c to the elements of this
   virtual void addConstant( double c );
   virtual void addConstant_w_patternSelect(double c, const hiopVector& ix);
+  virtual double min() const;
+  virtual double min_w_pattern(const hiopVector& select) const;  
   virtual void min( double& m, int& index ) const;
   virtual void negate();
   virtual void invert();

--- a/src/LinAlg/hiopVectorRajaPar.cpp
+++ b/src/LinAlg/hiopVectorRajaPar.cpp
@@ -856,6 +856,38 @@ void hiopVectorRajaPar::component_max(const hiopVector& vec)
 }
 
 /**
+ * @brief Set each component to its absolute value
+ */
+void hiopVectorRajaPar::component_abs ()
+{
+  double* dd = data_dev_;
+  RAJA::forall< hiop_raja_exec >( RAJA::RangeSegment(0, n_local_),
+    RAJA_LAMBDA(RAJA::Index_type i)
+    {
+      dd[i] = fabs(dd[i]);
+    });
+}
+
+/**
+ * @brief Set each component to its absolute value
+ */
+void hiopVectorRajaPar::component_sgn ()
+{
+  double* dd = data_dev_;
+  RAJA::forall< hiop_raja_exec >( RAJA::RangeSegment(0, n_local_),
+    RAJA_LAMBDA(RAJA::Index_type i)
+    {
+      if(dd[i]<0.0) {
+        dd[i] = -1.0;
+      } else if(dd[i]>0.0) {
+        dd[i] = 1.0;
+      } else {
+        dd[i] = 0.0;
+      }
+    });
+}
+
+/**
  * @brief Scale `this` vector by `c` 
  * 
  * @note Consider implementing with BLAS call (<D>SCAL)

--- a/src/LinAlg/hiopVectorRajaPar.cpp
+++ b/src/LinAlg/hiopVectorRajaPar.cpp
@@ -861,11 +861,13 @@ void hiopVectorRajaPar::component_max(const hiopVector& vec)
 void hiopVectorRajaPar::component_abs ()
 {
   double* dd = data_dev_;
-  RAJA::forall< hiop_raja_exec >( RAJA::RangeSegment(0, n_local_),
+  RAJA::forall< hiop_raja_exec >(
+    RAJA::RangeSegment(0, n_local_),
     RAJA_LAMBDA(RAJA::Index_type i)
     {
       dd[i] = fabs(dd[i]);
-    });
+    }
+  );
 }
 
 /**
@@ -874,17 +876,14 @@ void hiopVectorRajaPar::component_abs ()
 void hiopVectorRajaPar::component_sgn ()
 {
   double* dd = data_dev_;
-  RAJA::forall< hiop_raja_exec >( RAJA::RangeSegment(0, n_local_),
+  RAJA::forall< hiop_raja_exec >(
+    RAJA::RangeSegment(0, n_local_),
     RAJA_LAMBDA(RAJA::Index_type i)
     {
-      if(dd[i]<0.0) {
-        dd[i] = -1.0;
-      } else if(dd[i]>0.0) {
-        dd[i] = 1.0;
-      } else {
-        dd[i] = 0.0;
-      }
-    });
+      int sign = (0.0 < dd[i]) - (dd[i] < 0.0);
+      dd[i] = static_cast<double>(sign);      
+    }
+  );
 }
 
 /**
@@ -1041,6 +1040,56 @@ void  hiopVectorRajaPar::addConstant_w_patternSelect(double c, const hiopVector&
       assert(id[i] == one || id[i] == zero);
       data[i] += id[i]*c;
     });
+}
+
+/// Find minimum vector element
+double hiopVectorRajaPar::min() const
+{
+  double* data = data_dev_;
+  RAJA::ReduceMin< hiop_raja_reduce, double > minimum(std::numeric_limits<double>::max());
+  RAJA::forall< hiop_raja_exec >(
+    RAJA::RangeSegment(0, n_local_),
+    RAJA_LAMBDA(RAJA::Index_type i)
+    {
+      minimum.min(data[i]);
+		}
+  );
+  double ret_val = minimum.get();
+
+#ifdef HIOP_USE_MPI
+  double ret_val_g;
+  int ierr=MPI_Allreduce(&ret_val, &ret_val_g, 1, MPI_DOUBLE, MPI_MIN, comm_); assert(MPI_SUCCESS==ierr);
+  ret_val = ret_val_g;
+#endif
+  return ret_val;
+}
+
+/// Find minimum vector element for `select` pattern
+double hiopVectorRajaPar::min_w_pattern(const hiopVector& select) const
+{
+  const hiopVectorRajaPar& sel = dynamic_cast<const hiopVectorRajaPar&>(select);
+  assert(this->n_local_ == sel.n_local_);
+  double* data = data_dev_;
+  const double* id = sel.local_data_const();
+  
+  RAJA::ReduceMin< hiop_raja_reduce, double > minimum(std::numeric_limits<double>::max());
+  RAJA::forall< hiop_raja_exec >(
+    RAJA::RangeSegment(0, n_local_),
+    RAJA_LAMBDA(RAJA::Index_type i)
+    {
+      if(id[i] == one) {
+        minimum.min(data[i]);
+      }
+    }
+  );
+  double ret_val = minimum.get();
+
+#ifdef HIOP_USE_MPI
+  double ret_val_g;
+  int ierr=MPI_Allreduce(&ret_val, &ret_val_g, 1, MPI_DOUBLE, MPI_MIN, comm_); assert(MPI_SUCCESS==ierr);
+  ret_val = ret_val_g;
+#endif
+  return ret_val;
 }
 
 /// Find minimum vector element

--- a/src/LinAlg/hiopVectorRajaPar.cpp
+++ b/src/LinAlg/hiopVectorRajaPar.cpp
@@ -1052,7 +1052,7 @@ double hiopVectorRajaPar::min() const
     RAJA_LAMBDA(RAJA::Index_type i)
     {
       minimum.min(data[i]);
-		}
+    }
   );
   double ret_val = minimum.get();
 

--- a/src/LinAlg/hiopVectorRajaPar.hpp
+++ b/src/LinAlg/hiopVectorRajaPar.hpp
@@ -110,6 +110,8 @@ public:
   virtual void component_min(const hiopVector& v);
   virtual void component_max(const double constant);
   virtual void component_max(const hiopVector& v);
+  virtual void component_abs ();
+  virtual void component_sgn ();  
   virtual void scale( double alpha );
   /** this += alpha * x */
   virtual void axpy  ( double alpha, const hiopVector& x );

--- a/src/LinAlg/hiopVectorRajaPar.hpp
+++ b/src/LinAlg/hiopVectorRajaPar.hpp
@@ -110,8 +110,8 @@ public:
   virtual void component_min(const hiopVector& v);
   virtual void component_max(const double constant);
   virtual void component_max(const hiopVector& v);
-  virtual void component_abs ();
-  virtual void component_sgn ();  
+  virtual void component_abs();
+  virtual void component_sgn();  
   virtual void scale( double alpha );
   /** this += alpha * x */
   virtual void axpy  ( double alpha, const hiopVector& x );
@@ -123,7 +123,9 @@ public:
   /** Add c to the elements of this */
   virtual void addConstant( double c );
   virtual void addConstant_w_patternSelect(double c, const hiopVector& ix);
+  virtual double min() const;
   virtual void min( double& m, int& index ) const;
+  virtual double min_w_pattern(const hiopVector& select) const;  
   virtual void negate();
   virtual void invert();
   virtual double logBarrier_local(const hiopVector& select) const;

--- a/src/Optimization/hiopAlgFilterIPM.cpp
+++ b/src/Optimization/hiopAlgFilterIPM.cpp
@@ -1425,17 +1425,17 @@ hiopSolveStatus hiopAlgFilterIPMNewton::run()
 				 _err_nlp_optim, _err_nlp_feas, _err_nlp_complem, _err_nlp,
 				 _err_log_optim, _err_log_feas, _err_log_complem, _err_log);
       if(!bret) {
-	solver_status_ = Error_In_User_Function;
-	return Error_In_User_Function;
+        solver_status_ = Error_In_User_Function;
+        return Error_In_User_Function;
       }
       nlp->log->
-	printf(hovScalars,
-	       "  Nlp    errs: pr-infeas:%23.17e   dual-infeas:%23.17e  comp:%23.17e  overall:%23.17e\n",
-	       _err_nlp_feas, _err_nlp_optim, _err_nlp_complem, _err_nlp);
+        printf(hovScalars,
+               "  Nlp    errs: pr-infeas:%23.17e   dual-infeas:%23.17e  comp:%23.17e  overall:%23.17e\n",
+               _err_nlp_feas, _err_nlp_optim, _err_nlp_complem, _err_nlp);
       nlp->log->
-	printf(hovScalars,
-	       "  LogBar errs: pr-infeas:%23.17e   dual-infeas:%23.17e  comp:%23.17e  overall:%23.17e\n",
-	       _err_log_feas, _err_log_optim, _err_log_complem, _err_log);
+        printf(hovScalars,
+               "  LogBar errs: pr-infeas:%23.17e   dual-infeas:%23.17e  comp:%23.17e  overall:%23.17e\n",
+               _err_log_feas, _err_log_optim, _err_log_complem, _err_log);
 
       filter.reinitialize(theta_max);
       //recheck residuals at the first iteration in case the starting pt is  very good
@@ -1462,19 +1462,17 @@ hiopSolveStatus hiopAlgFilterIPMNewton::run()
 
     {
       if(linsol_forcequick) {
-	linsol_safe_mode_on = false;
+        linsol_safe_mode_on = false;
       } else {
-	//safe mode on for the first three iterations
-	if(iter_num<=2) {
-
-	  linsol_safe_mode_on=true;
-
-	} else {
-	  // to do	  if(linsol_safe_mode_on || noinertiacorr)
-	  if("speculative"==hiop::tolower(nlp->options->GetString("linsol_mode"))) {
-	    linsol_safe_mode_on=false;
-	  }
-	}
+        //safe mode on for the first three iterations
+        if(iter_num<=2) {
+          linsol_safe_mode_on=true;
+        } else {
+          // to do	  if(linsol_safe_mode_on || noinertiacorr)
+          if("speculative"==hiop::tolower(nlp->options->GetString("linsol_mode"))) {
+            linsol_safe_mode_on=false;
+          }
+        }
       }
     }
 
@@ -1488,33 +1486,33 @@ hiopSolveStatus hiopAlgFilterIPMNewton::run()
       //
       if(!kkt->update(it_curr, _grad_f, _Jac_c, _Jac_d, _Hess_Lagr)) {
 
-	nlp->runStats.kkt.end_optimiz_iteration();
+        nlp->runStats.kkt.end_optimiz_iteration();
 
-	if(linsol_safe_mode_on) {
-	  nlp->log->write("Unrecoverable error in step computation (factorization) [1]. Will exit here.",
-			  hovError);
-	  return solver_status_ = Err_Step_Computation;
-	} else {
+        if(linsol_safe_mode_on) {
+          nlp->log->write("Unrecoverable error in step computation (factorization) [1]. Will exit here.",
+                          hovError);
+          return solver_status_ = Err_Step_Computation;
+        } else {
 
-	  //failed with 'linsol_mode'='forcequick' means unrecoverable
-	  if(linsol_forcequick) {
+          //failed with 'linsol_mode'='forcequick' means unrecoverable
+          if(linsol_forcequick) {
 
-	    nlp->log->write("Unrecoverable error in step computation (factorization) [2]. Will exit here.",
-			    hovError);
-	    return solver_status_ = Err_Step_Computation;
-	  }
+            nlp->log->write("Unrecoverable error in step computation (factorization) [2]. Will exit here.",
+                            hovError);
+            return solver_status_ = Err_Step_Computation;
+          }
 
-	  linsol_safe_mode_on = true;
-	  linsol_safe_mode_lastiter = iter_num;
+          linsol_safe_mode_on = true;
+          linsol_safe_mode_lastiter = iter_num;
 
-	  nlp->log->printf(hovWarning,
-			   "Requesting additional accuracy and stability from the KKT linear system "
-			   "at iteration %d (safe mode ON)\n", iter_num);
+          nlp->log->printf(hovWarning,
+                           "Requesting additional accuracy and stability from the KKT linear system "
+                           "at iteration %d (safe mode ON)\n", iter_num);
 
-	  // repeat linear solve (computeDirections) in safe mode (meaning additional accuracy
-	  // and stability is requested)
-	  continue;
-	}
+          // repeat linear solve (computeDirections) in safe mode (meaning additional accuracy
+          // and stability is requested)
+          continue;
+        }
       } // end of if(!kkt->update(it_curr, _grad_f, _Jac_c, _Jac_d, _Hess_Lagr))
 
       //
@@ -1522,28 +1520,28 @@ hiopSolveStatus hiopAlgFilterIPMNewton::run()
       //
       if(!kkt->computeDirections(resid, dir)) {
 
-	nlp->runStats.kkt.start_optimiz_iteration();
+        nlp->runStats.kkt.start_optimiz_iteration();
 
-	if(linsol_safe_mode_on) {
-	  nlp->log->write("Unrecoverable error in step computation (solve)[1]. Will exit here.", hovError);
-	  return solver_status_ = Err_Step_Computation;
-	} else {
-	  if(linsol_forcequick) {
-	    nlp->log->write("Unrecoverable error in step computation (solve)[2]. Will exit here.", hovError);
-	    return solver_status_ = Err_Step_Computation;
-	  }
-	  linsol_safe_mode_on = true;
-	  linsol_safe_mode_lastiter = iter_num;
+        if(linsol_safe_mode_on) {
+          nlp->log->write("Unrecoverable error in step computation (solve)[1]. Will exit here.", hovError);
+          return solver_status_ = Err_Step_Computation;
+        } else {
+          if(linsol_forcequick) {
+            nlp->log->write("Unrecoverable error in step computation (solve)[2]. Will exit here.", hovError);
+            return solver_status_ = Err_Step_Computation;
+          }
+          linsol_safe_mode_on = true;
+          linsol_safe_mode_lastiter = iter_num;
 
-	  nlp->log->printf(hovWarning,
-			   "Requesting additional accuracy and stability from the KKT linear system "
-			   "at iteration %d (safe mode ON)\n", iter_num);
+          nlp->log->printf(hovWarning,
+                           "Requesting additional accuracy and stability from the KKT linear system "
+                           "at iteration %d (safe mode ON)\n", iter_num);
 
-	  // repeat linear solve (computeDirections) in safe mode (meaning additional accuracy
-	  // and stability is requested)
-	  continue;
+          // repeat linear solve (computeDirections) in safe mode (meaning additional accuracy
+          // and stability is requested)
+          continue;
 
-	}
+        }
       } // end of if(!kkt->computeDirections(resid, dir))
 
       //at this point all is good in terms of searchDirections computations as far as the linear solve
@@ -1553,7 +1551,7 @@ hiopSolveStatus hiopAlgFilterIPMNewton::run()
       nlp->runStats.kkt.end_optimiz_iteration();
 
       if(perf_report_kkt_) {
-	nlp->log->printf(hovSummary, "%s", nlp->runStats.kkt.get_summary_last_iter().c_str());
+        nlp->log->printf(hovSummary, "%s", nlp->runStats.kkt.get_summary_last_iter().c_str());
       }
 
       nlp->log->printf(hovIteration, "Iter[%d] full search direction -------------\n", iter_num);
@@ -1585,222 +1583,220 @@ hiopSolveStatus hiopAlgFilterIPMNewton::run()
       // linesearch loop
       //
       while(true) {
-	nlp->runStats.tmSolverInternal.start(); //---
+        nlp->runStats.tmSolverInternal.start(); //---
 
-	// check the step against the minimum step size, but accept small
-	// fractionToTheBdry since these may occur for tight bounds at the first iteration(s)
-	if(!iniStep && _alpha_primal<1e-16) {
+        // check the step against the minimum step size, but accept small
+        // fractionToTheBdry since these may occur for tight bounds at the first iteration(s)
+        if(!iniStep && _alpha_primal<1e-16) {
 
-	  if(linsol_safe_mode_on) {
-	    nlp->log->write("Panic: minimum step size reached. The problem may be infeasible or the "
-			    "gradient inaccurate. Will exit here.", hovError);
-	    solver_status_ = Steplength_Too_Small;
-	    break;
-	  } else {
-	    lsStatus = 0;
-	    break;
-	  }
-	}
-	iniStep=false;
-	bret = it_trial->takeStep_primals(*it_curr, *dir, _alpha_primal, _alpha_dual); assert(bret);
-	num_adjusted_bounds = it_trial->adjust_small_slacks(*it_curr, nlp->get_xl(), nlp->get_xu(), 
-                                                     nlp->get_dl(), nlp->get_du(),_mu);
-	if(num_adjusted_bounds > 0) {
-    nlp->log->printf(hovWarning, "%d slacks are too small. Adjust corresponding variable bounds!", num_adjusted_bounds);
-    num_adjusted_bounds = 0;
-  }
-	nlp->runStats.tmSolverInternal.stop(); //---
+          if(linsol_safe_mode_on) {
+            nlp->log->write("Panic: minimum step size reached. The problem may be infeasible or the "
+                            "gradient inaccurate. Will exit here.", hovError);
+            solver_status_ = Steplength_Too_Small;
+            break;
+          } else {
+            lsStatus = 0;
+            break;
+          }
+        }
+        iniStep=false;
+        bret = it_trial->takeStep_primals(*it_curr, *dir, _alpha_primal, _alpha_dual); assert(bret);
+        num_adjusted_bounds = it_trial->adjust_small_slacks(*it_curr, _mu);
+        nlp->runStats.tmSolverInternal.stop(); //---
 
-	//evaluate the problem at the trial iterate (functions only)
-	if(!this->evalNlp_funcOnly(*it_trial, _f_nlp_trial, *_c_trial, *_d_trial)) {
-	  solver_status_ = Error_In_User_Function;
-	  return Error_In_User_Function;
-	}
+        //evaluate the problem at the trial iterate (functions only)
+        if(!this->evalNlp_funcOnly(*it_trial, _f_nlp_trial, *_c_trial, *_d_trial)) {
+          solver_status_ = Error_In_User_Function;
+          return Error_In_User_Function;
+        }
 
-	logbar->updateWithNlpInfo_trial_funcOnly(*it_trial, _f_nlp_trial, *_c_trial, *_d_trial);
+        logbar->updateWithNlpInfo_trial_funcOnly(*it_trial, _f_nlp_trial, *_c_trial, *_d_trial);
 
-	nlp->runStats.tmSolverInternal.start(); //---
-	//compute infeasibility theta at trial point.
-	infeas_nrm_trial = theta_trial = resid->computeNlpInfeasInfNorm(*it_trial, *_c_trial, *_d_trial);
+        nlp->runStats.tmSolverInternal.start(); //---
+        //compute infeasibility theta at trial point.
+        infeas_nrm_trial = theta_trial = resid->computeNlpInfeasInfNorm(*it_trial, *_c_trial, *_d_trial);
 
-	lsNum++;
+        lsNum++;
 
-	nlp->log->printf(hovLinesearch, "  trial point %d: alphaPrimal=%14.8e barier:(%22.16e)>%15.9e "
-			 "theta:(%22.16e)>%22.16e\n",
-			 lsNum, _alpha_primal, logbar->f_logbar, logbar->f_logbar_trial, theta, theta_trial);
+        nlp->log->printf(hovLinesearch, "  trial point %d: alphaPrimal=%14.8e barier:(%22.16e)>%15.9e "
+                         "theta:(%22.16e)>%22.16e\n",
+                         lsNum, _alpha_primal, logbar->f_logbar, logbar->f_logbar_trial, theta, theta_trial);
 
-	if(disableLS) break;
+        if(disableLS) break;
 
-	nlp->log->write("Filter IPM: ", filter, hovLinesearch);
+        nlp->log->write("Filter IPM: ", filter, hovLinesearch);
 
-	// Do the cheap, "sufficient progress" test first, before more involved/expensive tests.
-	// This simple test is good enough when iterate is far away from solution
-	if(theta>=theta_min) {
-	  //check the filter and the sufficient decrease condition (18)
-	  if(!filter.contains(theta_trial,logbar->f_logbar_trial)) {
-	    if(theta_trial<=(1-gamma_theta)*theta ||
-	       logbar->f_logbar_trial<=logbar->f_logbar - gamma_phi*theta) {
-	      //trial good to go
-	      nlp->log->printf(hovLinesearchVerb, "Linesearch: accepting based on suff. decrease "
-			       "(far from solution)\n");
-	      lsStatus=1;
-	      break;
-	    } else {
-	      //there is no sufficient progress
-	      _alpha_primal *= 0.5;
-	      continue;
-	    }
-	  } else {
-	    //it is in the filter
-	    _alpha_primal *= 0.5;
-	    continue;
-	  }
-	  nlp->log->write("Warning (close to panic): got to a point I wasn't supposed reach. (1)",
-			  hovWarning);
-	} else {
-	  // if(theta<theta_min,  then check the switching condition and, if true, rely on Armijo rule.
-	  // first compute grad_phi^T d_x if it hasn't already been computed
-	  if(!grad_phi_dx_computed) {
-	    nlp->runStats.tmSolverInternal.stop(); //---
-	    grad_phi_dx = logbar->directionalDerivative(*dir);
-	    grad_phi_dx_computed=true;
-	    nlp->runStats.tmSolverInternal.start(); //---
-	  }
-	  nlp->log->printf(hovLinesearch, "Linesearch: grad_phi_dx = %22.15e\n", grad_phi_dx);
+        // Do the cheap, "sufficient progress" test first, before more involved/expensive tests.
+        // This simple test is good enough when iterate is far away from solution
+        if(theta>=theta_min) {
+          //check the filter and the sufficient decrease condition (18)
+          if(!filter.contains(theta_trial,logbar->f_logbar_trial)) {
+            if(theta_trial<=(1-gamma_theta)*theta ||
+               logbar->f_logbar_trial<=logbar->f_logbar - gamma_phi*theta) {
+              //trial good to go
+              nlp->log->printf(hovLinesearchVerb, "Linesearch: accepting based on suff. decrease "
+                               "(far from solution)\n");
+              lsStatus=1;
+              break;
+            } else {
+              //there is no sufficient progress
+              _alpha_primal *= 0.5;
+              continue;
+            }
+          } else {
+            //it is in the filter
+            _alpha_primal *= 0.5;
+            continue;
+          }
+          nlp->log->write("Warning (close to panic): got to a point I wasn't supposed reach. (1)",
+                          hovWarning);
+        } else {
+          // if(theta<theta_min,  then check the switching condition and, if true, rely on Armijo rule.
+          // first compute grad_phi^T d_x if it hasn't already been computed
+          if(!grad_phi_dx_computed) {
+            nlp->runStats.tmSolverInternal.stop(); //---
+            grad_phi_dx = logbar->directionalDerivative(*dir);
+            grad_phi_dx_computed=true;
+            nlp->runStats.tmSolverInternal.start(); //---
+          }
+          nlp->log->printf(hovLinesearch, "Linesearch: grad_phi_dx = %22.15e\n", grad_phi_dx);
 
-	  // nlp->log->printf(hovSummary,
-	  // 		 "Linesearch: grad_phi_dx = %22.15e      %22.15e >   %22.15e  \n",
-	  // 		 grad_phi_dx, _alpha_primal*pow(-grad_phi_dx,s_phi), delta*pow(theta,s_theta));
-	  // nlp->log->printf(hovSummary,
-	  // 		 "Linesearch: s_phi=%22.15e;   s_theta=%22.15e; theta=%22.15e; delta=%22.15e\n",
-	  // 		 s_phi, s_theta, theta, delta);
+          // nlp->log->printf(hovSummary,
+          // 		 "Linesearch: grad_phi_dx = %22.15e      %22.15e >   %22.15e  \n",
+          // 		 grad_phi_dx, _alpha_primal*pow(-grad_phi_dx,s_phi), delta*pow(theta,s_theta));
+          // nlp->log->printf(hovSummary,
+          // 		 "Linesearch: s_phi=%22.15e;   s_theta=%22.15e; theta=%22.15e; delta=%22.15e\n",
+          // 		 s_phi, s_theta, theta, delta);
 
-	  // this is the actual switching condition
-	  if(grad_phi_dx<0 && _alpha_primal*pow(-grad_phi_dx,s_phi)>delta*pow(theta,s_theta)) {
+          // this is the actual switching condition
+          if(grad_phi_dx<0 && _alpha_primal*pow(-grad_phi_dx,s_phi)>delta*pow(theta,s_theta)) {
 
-	    if(logbar->f_logbar_trial <= logbar->f_logbar + eta_phi*_alpha_primal*grad_phi_dx) {
-	      lsStatus=3;
-	      nlp->log->printf(hovLinesearchVerb,
-			       "Linesearch: accepting based on Armijo (switch cond also passed)\n");
+            if(logbar->f_logbar_trial <= logbar->f_logbar + eta_phi*_alpha_primal*grad_phi_dx) {
+              lsStatus=3;
+              nlp->log->printf(hovLinesearchVerb,
+                               "Linesearch: accepting based on Armijo (switch cond also passed)\n");
 
-	      //iterate good to go since it satisfies Armijo
-	      break;
-	    } else {
-	      //Armijo is not satisfied
-	      _alpha_primal *= 0.5; //reduce step and try again
-	      continue;
-	    }
-	  } else {//switching condition does not hold
+            //iterate good to go since it satisfies Armijo
+              break;
+            } else {
+              //Armijo is not satisfied
+              _alpha_primal *= 0.5; //reduce step and try again
+              continue;
+            }
+          } else {//switching condition does not hold
 
-	    //ok to go with  "sufficient progress" condition even when close to solution, provided the
-	    //switching condition is not satisfied
+            //ok to go with  "sufficient progress" condition even when close to solution, provided the
+            //switching condition is not satisfied
 
-	    //check the filter and the sufficient decrease condition (18)
-	    if(!filter.contains(theta_trial,logbar->f_logbar_trial)) {
-	      if(theta_trial<=(1-gamma_theta)*theta ||
-		 logbar->f_logbar_trial <= logbar->f_logbar - gamma_phi*theta) {
+            //check the filter and the sufficient decrease condition (18)
+            if(!filter.contains(theta_trial,logbar->f_logbar_trial)) {
+              if(theta_trial<=(1-gamma_theta)*theta ||
+                 logbar->f_logbar_trial <= logbar->f_logbar - gamma_phi*theta) {
 
-		//trial good to go
-		nlp->log->printf(hovLinesearchVerb,
-				 "Linesearch: accepting based on suff. decrease (switch cond also passed)\n");
-		lsStatus=2;
-		break;
-	      } else {
-		//there is no sufficient progress
-		_alpha_primal *= 0.5;
-		continue;
-	      }
-	    } else {
-	      //it is in the filter
-	      _alpha_primal *= 0.5;
-	      continue;
-	    }
-	  } // end of else: switching condition does not hold
+                //trial good to go
+                nlp->log->printf(hovLinesearchVerb,
+                                 "Linesearch: accepting based on suff. decrease (switch cond also passed)\n");
+                lsStatus=2;
+                break;
+              } else {
+                //there is no sufficient progress
+                _alpha_primal *= 0.5;
+                continue;
+              }
+            } else {
+              //it is in the filter
+              _alpha_primal *= 0.5;
+              continue;
+            }
+          } // end of else: switching condition does not hold
 
-	  nlp->log->write("Warning (close to panic): got to a point I wasn't supposed to reach. (2)",
-			  hovWarning);
+          nlp->log->write("Warning (close to panic): got to a point I wasn't supposed to reach. (2)",
+                          hovWarning);
 
-	} //end of else: theta_trial<theta_min
+        } //end of else: theta_trial<theta_min
       } //end of while for the linesearch loop
       nlp->runStats.tmSolverInternal.stop();
 
+      if(num_adjusted_bounds > 0) {
+        nlp->log->printf(hovWarning, "%d slacks are too small. Adjust corresponding variable bounds!\n", num_adjusted_bounds);
+      }
       // post line-search: filter is augmented whenever the switching condition or Armijo rule do not
       // hold for the trial point that was just accepted
       if(lsStatus==1) {
 
-	//need to check switching cond and Armijo to decide if filter is augmented
-	if(!grad_phi_dx_computed) {
-	  grad_phi_dx = logbar->directionalDerivative(*dir);
-	  grad_phi_dx_computed=true;
-	}
+        //need to check switching cond and Armijo to decide if filter is augmented
+        if(!grad_phi_dx_computed) {
+          grad_phi_dx = logbar->directionalDerivative(*dir);
+          grad_phi_dx_computed=true;
+        }
 
-	//this is the actual switching condition
-	if(grad_phi_dx<0 && (_alpha_primal*pow(-grad_phi_dx,s_phi) > delta*pow(theta,s_theta))) {
-	  //check armijo
-	  if(logbar->f_logbar_trial <= logbar->f_logbar + eta_phi*_alpha_primal*grad_phi_dx) {
-	    //filter does not change
-	  } else {
-	    //Armijo does not hold
-	    filter.add(theta_trial, logbar->f_logbar_trial);
-	  }
-	} else { //switching condition does not hold
-	  filter.add(theta_trial, logbar->f_logbar_trial);
-	}
-	break; //from the linear solve (computeDirections) loop
+        //this is the actual switching condition
+        if(grad_phi_dx<0 && (_alpha_primal*pow(-grad_phi_dx,s_phi) > delta*pow(theta,s_theta))) {
+          //check armijo
+          if(logbar->f_logbar_trial <= logbar->f_logbar + eta_phi*_alpha_primal*grad_phi_dx) {
+            //filter does not change
+          } else {
+            //Armijo does not hold
+            filter.add(theta_trial, logbar->f_logbar_trial);
+          }
+        } else { //switching condition does not hold
+          filter.add(theta_trial, logbar->f_logbar_trial);
+        }
+        break; //from the linear solve (computeDirections) loop
 
       } else if(lsStatus==2) {
-	//switching condition does not hold for the trial
-	filter.add(theta_trial, logbar->f_logbar_trial);
+        //switching condition does not hold for the trial
+        filter.add(theta_trial, logbar->f_logbar_trial);
 
-	break; //from the linear solve (computeDirections) loop
+        break; //from the linear solve (computeDirections) loop
 
       } else if(lsStatus==3) {
-	//Armijo (and switching condition) hold, nothing to do.
+        //Armijo (and switching condition) hold, nothing to do.
 
-	break; //from the linear solve (computeDirections) loop
+        break; //from the linear solve (computeDirections) loop
 
       } else if(lsStatus==0) {
 
-	//
-	//small step
-	//
+        //
+        //small step
+        //
 
-	if(linsol_safe_mode_on) {
+        if(linsol_safe_mode_on) {
 
-	  // this is  likely catastrophic
-	  // however take the update;
-	  // if the update doesn't pass the convergence test, the optimiz. loop will exit
+          // this is  likely catastrophic
+          // however take the update;
+          // if the update doesn't pass the convergence test, the optimiz. loop will exit
 
-	  // first exit the linear solve (computeDirections) loop
-	  break;
+          // first exit the linear solve (computeDirections) loop
+          break;
 
-	} else {
-	  //here false == linsol_safe_mode_on
-	  if(linsol_forcequick) {
-	    // this is  likely catastrophic as under 'linsol_mode'='forcequick' we deliberately
-	    //won't switch to safe mode
-	    //
-	    // however take the update;
-	    // if the update doesn't pass the convergence test, the optimiz. loop will exit
+        } else {
+          //here false == linsol_safe_mode_on
+          if(linsol_forcequick) {
+            // this is  likely catastrophic as under 'linsol_mode'='forcequick' we deliberately
+            //won't switch to safe mode
+            //
+            // however take the update;
+            // if the update doesn't pass the convergence test, the optimiz. loop will exit
 
-	    // first exit the linear solve (computeDirections) loop
-	    break;
-	  }
+            // first exit the linear solve (computeDirections) loop
+            break;
+          }
 
-	  linsol_safe_mode_on = true;
-	  linsol_safe_mode_lastiter = iter_num;
+          linsol_safe_mode_on = true;
+          linsol_safe_mode_lastiter = iter_num;
 
-	  nlp->log->printf(hovWarning,
-			   "Requesting additional accuracy and stability from the KKT linear system "
-			   "at iteration %d (safe mode ON)\n", iter_num);
+          nlp->log->printf(hovWarning,
+                           "Requesting additional accuracy and stability from the KKT linear system "
+                           "at iteration %d (safe mode ON)\n", iter_num);
 
-	  // repeat linear solve (computeDirections) in safe mode (meaning additional accuracy
-	  // and stability is requested)
-	  continue;
+          // repeat linear solve (computeDirections) in safe mode (meaning additional accuracy
+          // and stability is requested)
+          continue;
 
-	}
+        }
       } else {
-	assert(false && "unrecognized value for lsStatus");
+        assert(false && "unrecognized value for lsStatus");
       }
     } // end of the linear solve (computeDirections) loop
 

--- a/src/Optimization/hiopAlgFilterIPM.cpp
+++ b/src/Optimization/hiopAlgFilterIPM.cpp
@@ -873,6 +873,7 @@ hiopSolveStatus hiopAlgFilterIPMQuasiNewton::run()
 
   //int algStatus=0;
   bool bret=true; int lsStatus=-1, lsNum=0;
+  int num_adjusted_bounds = 0;
   solver_status_ = NlpSolve_Pending;
   while(true) {
 
@@ -1002,6 +1003,7 @@ hiopSolveStatus hiopAlgFilterIPMQuasiNewton::run()
       }
       iniStep=false;
       bret = it_trial->takeStep_primals(*it_curr, *dir, _alpha_primal, _alpha_dual); assert(bret);
+      num_adjusted_bounds = it_trial->adjust_small_slacks(*it_curr, _mu);
       nlp->runStats.tmSolverInternal.stop(); //---
 
       //evaluate the problem at the trial iterate (functions only)
@@ -1097,6 +1099,10 @@ hiopSolveStatus hiopAlgFilterIPMQuasiNewton::run()
       } //end of else: theta_trial<theta_min
     } //end of while for the linesearch loop
     nlp->runStats.tmSolverInternal.stop();
+
+    if(num_adjusted_bounds > 0) {
+      nlp->log->printf(hovWarning, "%d slacks are too small. Adjust corresponding variable bounds!\n", num_adjusted_bounds);
+    }
 
     //post line-search stuff
     //filter is augmented whenever the switching condition or Armijo rule do not hold for the trial point that was just accepted

--- a/src/Optimization/hiopIterate.hpp
+++ b/src/Optimization/hiopIterate.hpp
@@ -88,12 +88,7 @@ public:
 			      const double& alphaprimal, const double& alphadual);
 
   /// @brief adjust small slack variables
-  virtual int adjust_small_slacks(const hiopIterate& iter_curr,
-                                  const hiopVector& xl, 
-                                  const hiopVector& xu, 
-                                  const hiopVector& dl, 
-                                  const hiopVector& du,
-                                  const double& mu);
+  virtual int adjust_small_slacks(const hiopIterate& iter_curr, const double& mu);
   virtual int adjust_small_slacks(hiopVector& slack, 
                                   const hiopVector& bound, 
                                   const hiopVector& slack_dual, 

--- a/src/Optimization/hiopIterate.hpp
+++ b/src/Optimization/hiopIterate.hpp
@@ -87,6 +87,19 @@ public:
   virtual bool takeStep_duals(const hiopIterate& iter, const hiopIterate& dir,
 			      const double& alphaprimal, const double& alphadual);
 
+  /// @brief adjust small slack variables
+  virtual int adjust_small_slacks(const hiopIterate& iter_curr,
+                                  const hiopVector& xl, 
+                                  const hiopVector& xu, 
+                                  const hiopVector& dl, 
+                                  const hiopVector& du,
+                                  const double& mu);
+  virtual int adjust_small_slacks(hiopVector& slack, 
+                                  const hiopVector& bound, 
+                                  const hiopVector& slack_dual, 
+                                  const hiopVector& select,
+                                  const double& mu);
+
   /**
    * Adjusts the signed duals to ensure the the logbar primal-dual Hessian is not arbitrarily
    * far away from the primal counterpart. This is eq. 16 in the filter IPM paper

--- a/src/Optimization/hiopNlpFormulation.cpp
+++ b/src/Optimization/hiopNlpFormulation.cpp
@@ -349,7 +349,6 @@ bool hiopNlpFormulation::finalizeInitialization()
 	fixedVarsRelaxer->setup();
 	fixedVarsRelaxer->relax(options->GetNumeric("fixed_var_tolerance"),
 				options->GetNumeric("fixed_var_perturb"), *xl, *xu);
-
 	nlp_transformations.append(fixedVarsRelaxer);
 
       } else {
@@ -458,6 +457,14 @@ bool hiopNlpFormulation::finalizeInitialization()
 #else
   n_bnds_low=n_bnds_low_local; n_bnds_upp=n_bnds_upp_local; //n_bnds_lu is ok
 #endif
+
+  // relax bounds
+  if(options->GetNumeric("bound_relax_perturb") > 0.0) {
+    auto* relax_bounds = new hiopBoundsRelaxer(*xl, *xu, *dl, *du);
+    relax_bounds->setup();
+    relax_bounds->relax(options->GetNumeric("bound_relax_perturb"), *xl, *xu, *dl, *du);
+    nlp_transformations.append(relax_bounds);
+  }
 
   // Copy data from host mirror to the memory space
   dl->copyToDev();  du->copyToDev();

--- a/src/Optimization/hiopNlpFormulation.cpp
+++ b/src/Optimization/hiopNlpFormulation.cpp
@@ -342,7 +342,7 @@ bool hiopNlpFormulation::finalizeInitialization()
       
       nlp_transformations.append(fixedVarsRemover);
     } else {
-      if(options->GetString("fixed_var")=="relax") {
+      if(options->GetString("fixed_var")=="relax" && options->GetNumeric("bound_relax_perturb") == 0.0) {
 	log->printf(hovWarning, "Fixed variables will be relaxed internally.\n");
 	auto* fixedVarsRelaxer = new hiopFixedVarsRelaxer(*xl, *xu,
 							  nfixed_vars, nfixed_vars_local);
@@ -351,7 +351,7 @@ bool hiopNlpFormulation::finalizeInitialization()
 				options->GetNumeric("fixed_var_perturb"), *xl, *xu);
 	nlp_transformations.append(fixedVarsRelaxer);
 
-      } else {
+      } else if(options->GetNumeric("bound_relax_perturb") == 0.0) {
 	log->printf(hovError,  
 		    "detected fixed variables but was not instructed "
 		    "how to deal with them (option 'fixed_var' is 'none').\n");

--- a/src/Optimization/hiopNlpTransforms.cpp
+++ b/src/Optimization/hiopNlpTransforms.cpp
@@ -312,6 +312,57 @@ relax(const double& fixed_var_tol, const double& fixed_var_perturb, hiopVector& 
   }
 }
 
+hiopBoundsRelaxer::
+hiopBoundsRelaxer(const hiopVector& xl,
+                  const hiopVector& xu,
+                  const hiopVector& dl,
+                  const hiopVector& du)
+  : xl_ori(NULL), xu_ori(NULL), dl_ori(NULL), du_ori(NULL),
+    n_vars(xl.get_size()), n_vars_local(xl.get_local_size()),
+    n_ineq(dl.get_size())
+{
+  xl_ori = xl.new_copy();
+  xu_ori = xu.new_copy();
+  dl_ori = dl.new_copy();
+  du_ori = du.new_copy();
+}
+
+hiopBoundsRelaxer::~hiopBoundsRelaxer()
+{
+  if(xl_ori) {
+    delete xl_ori;
+  }
+  if(xu_ori) {
+    delete xu_ori;
+  }
+  if(dl_ori) {
+    delete dl_ori;
+  }
+  if(du_ori) {
+    delete du_ori;
+  }
+}
+
+void hiopBoundsRelaxer::
+relax(const double& bound_relax_perturb, hiopVector& xl, hiopVector& xu, hiopVector& dl, hiopVector& du)
+{
+  double* xla = xl.local_data();
+  double* xua = xu.local_data();
+  double* dla = dl.local_data();
+  double* dua = du.local_data();
+  
+  double dbval; // a temp variable
+
+  for(long long i=0; i<n_vars; i++) {
+    xua[i] += bound_relax_perturb*fmax(1.,fabs(xua[i]));
+    xla[i] -= bound_relax_perturb*fmax(1.,fabs(xla[i]));
+  }
+
+  for(long long i=0; i<n_ineq; i++) {
+    dua[i] += bound_relax_perturb*fmax(1.,fabs(dua[i]));
+    dla[i] -= bound_relax_perturb*fmax(1.,fabs(dla[i]));
+  }
+}
 
 /**
 * For class hiopNLPObjGradScaling

--- a/src/Optimization/hiopNlpTransforms.cpp
+++ b/src/Optimization/hiopNlpTransforms.cpp
@@ -346,22 +346,26 @@ hiopBoundsRelaxer::~hiopBoundsRelaxer()
 void hiopBoundsRelaxer::
 relax(const double& bound_relax_perturb, hiopVector& xl, hiopVector& xu, hiopVector& dl, hiopVector& du)
 {
-  double* xla = xl.local_data();
-  double* xua = xu.local_data();
-  double* dla = dl.local_data();
-  double* dua = du.local_data();
-  
-  double dbval; // a temp variable
+  xl.component_abs();
+  xl.component_max(1.);
+  xl.scale(-bound_relax_perturb);
+  xl.axpy(1.0, *xl_ori);
 
-  for(long long i=0; i<n_vars; i++) {
-    xua[i] += bound_relax_perturb*fmax(1.,fabs(xua[i]));
-    xla[i] -= bound_relax_perturb*fmax(1.,fabs(xla[i]));
-  }
+  xu.component_abs();
+  xu.component_max(1.);
+  xu.scale(bound_relax_perturb);
+  xu.axpy(1.0, *xu_ori);
 
-  for(long long i=0; i<n_ineq; i++) {
-    dua[i] += bound_relax_perturb*fmax(1.,fabs(dua[i]));
-    dla[i] -= bound_relax_perturb*fmax(1.,fabs(dla[i]));
-  }
+  dl.component_abs();
+  dl.component_max(1.);
+  dl.scale(-bound_relax_perturb);
+  dl.axpy(1.0, *dl_ori);
+
+  du.component_abs();
+  du.component_max(1.);
+  du.scale(bound_relax_perturb);
+  du.axpy(1.0, *du_ori);
+
 }
 
 /**
@@ -372,8 +376,8 @@ hiopNLPObjGradScaling::hiopNLPObjGradScaling(const double max_grad,
                                              hiopVector& d, 
                                              hiopVector& gradf,
                                              hiopMatrix& Jac_c, 
-                                             hiopMatrix& Jac_d,
-                                             long long *cons_eq_mapping,
+                                             hiopMatrix& Jac_d, 
+                                             long long *cons_eq_mapping, 
                                              long long *cons_ineq_mapping)
       : n_vars(gradf.get_size()), n_vars_local(gradf.get_local_size()),
         scale_factor_obj(1.),
@@ -402,6 +406,7 @@ hiopNLPObjGradScaling::hiopNLPObjGradScaling(const double max_grad,
   const double* eq_arr = scale_factor_c->local_data_const();
   const double* ineq_arr = scale_factor_d->local_data_const();
   double* scale_factor_cd_arr = scale_factor_cd->local_data();
+
   for(int i=0; i<n_eq; ++i) {
     scale_factor_cd_arr[cons_eq_mapping[i]] = eq_arr[i];
   }

--- a/src/Optimization/hiopNlpTransforms.hpp
+++ b/src/Optimization/hiopNlpTransforms.hpp
@@ -487,6 +487,36 @@ private:
   hiopMatrix *Hess_scaled;
   hiopMatrix *Hess_unscaled;
 #endif // 0
+
+class hiopBoundsRelaxer : public hiopNlpTransformation
+{
+public: 
+  hiopBoundsRelaxer(const hiopVector& xl,
+                    const hiopVector& xu,
+                    const hiopVector& dl,
+                    const hiopVector& du);
+  virtual ~hiopBoundsRelaxer();
+
+  inline long long n_post()  { /*assert(xl_copy);*/ return n_vars; }
+  virtual long long n_pre () { /*assert(xl_copy);*/ return n_vars; }
+  inline long long n_post_local()  { return n_vars_local; }
+  inline long long n_pre_local()  { return n_vars_local; }
+  inline bool setup() { return true; }
+
+  void relax(const double& bound_relax_perturb,
+             hiopVector& xl,
+             hiopVector& xu,
+             hiopVector& dl,
+             hiopVector& du);
+
+private:
+  hiopVector* xl_ori;
+  hiopVector* xu_ori;
+  hiopVector* dl_ori;
+  hiopVector* du_ori;
+  long long n_vars; 
+  long long n_vars_local;
+  long long n_ineq;
 };
 
 

--- a/src/Optimization/hiopNlpTransforms.hpp
+++ b/src/Optimization/hiopNlpTransforms.hpp
@@ -487,6 +487,7 @@ private:
   hiopMatrix *Hess_scaled;
   hiopMatrix *Hess_unscaled;
 #endif // 0
+};
 
 class hiopBoundsRelaxer : public hiopNlpTransformation
 {

--- a/src/Optimization/hiopNlpTransforms.hpp
+++ b/src/Optimization/hiopNlpTransforms.hpp
@@ -348,8 +348,8 @@ public:
                         hiopVector& d, 
                         hiopVector& gradf,
                         hiopMatrix& Jac_c, 
-                        hiopMatrix& Jac_d,
-                        long long *cons_eq_mapping,
+                        hiopMatrix& Jac_d, 
+                        long long *cons_eq_mapping, 
                         long long *cons_ineq_mapping);
   ~hiopNLPObjGradScaling();
 public:
@@ -365,6 +365,8 @@ public:
 
   inline long long n_post_local()  { return n_vars_local; }
   inline long long n_pre_local()  { return n_vars_local; }
+
+  inline void apply_to_x(hiopVector& x_in, hiopVector& x_out){}
 
   /// @brief return the scaling fact for objective
   inline double get_obj_scale() const {return scale_factor_obj;}
@@ -503,6 +505,8 @@ public:
   inline long long n_post_local()  { return n_vars_local; }
   inline long long n_pre_local()  { return n_vars_local; }
   inline bool setup() { return true; }
+  
+  inline void apply_to_x(hiopVector& x_in, hiopVector& x_out){}
 
   void relax(const double& bound_relax_perturb,
              hiopVector& xl,

--- a/src/Utils/hiopOptions.cpp
+++ b/src/Utils/hiopOptions.cpp
@@ -223,6 +223,14 @@ void hiopOptions::registerOptions()
 		      "larger than the value of this option (default 100)");
   }
   
+  // relax bound
+  {
+    registerNumOption("bound_relax_perturb", 1e-8, 0.0, 1e20,
+		      "Perturbation of the lower and upper bounds for variables and constraints relative"
+		      "to its magnitude: lower/upper_bound -=/+= bound_relax_perturb*max(abs(lower/upper_bound),1)*"
+		      "bound_relax_perturb (default 1e-8)");
+  }
+
   //optimization method used
   {
     vector<string> range(2); range[0]="quasinewton_approx"; range[1]="analytical_exact";

--- a/tests/LinAlg/vectorTests.hpp
+++ b/tests/LinAlg/vectorTests.hpp
@@ -740,6 +740,61 @@ public:
   }
 
   /**
+   * @brief Test: this[i] = abs(this[i])
+   */
+  bool vector_component_abs(hiop::hiopVector& x, const int rank)
+  {
+    const local_ordinal_type N = getLocalSize(&x);
+    static const real_type x_val = -quarter;
+
+    x.setToConstant(x_val);
+
+    const real_type expected = half;
+    if(rank == 0) {
+      setLocalElement(&x, N-1, expected);
+    }
+
+    x.component_abs();
+
+    const int fail = verifyAnswer(&x,
+      [=] (local_ordinal_type i) -> real_type
+      {
+        const bool isLastElementOnRank0 = (i == N-1 && rank == 0);
+        return isLastElementOnRank0 ? fabs(expected) : fabs(x_val);
+      });
+
+    printMessage(fail, __func__, rank);
+    return reduceReturn(fail, &x);
+  }
+
+  /**
+   * @brief Test: this[i] = sgn(this[i])
+   */
+  bool vector_component_sgn(hiop::hiopVector& x, const int rank)
+  {
+    const local_ordinal_type N = getLocalSize(&x);
+    static const real_type x_val = -quarter;
+
+    x.setToConstant(x_val);
+
+    if(rank == 0) {
+      setLocalElement(&x, N-1, half);
+    }
+
+    x.component_sgn();
+
+    const int fail = verifyAnswer(&x,
+      [=] (local_ordinal_type i) -> real_type
+      {
+        const bool isLastElementOnRank0 = (i == N-1 && rank == 0);
+        return isLastElementOnRank0 ? one : -one;
+      });
+
+    printMessage(fail, __func__, rank);
+    return reduceReturn(fail, &x);
+  }
+
+  /**
    * @brief Test computing 1-norm ||v||  of vector v
    *                                   1
    */

--- a/tests/LinAlg/vectorTests.hpp
+++ b/tests/LinAlg/vectorTests.hpp
@@ -1356,12 +1356,52 @@ public:
   }
 
   /**
-   * @warning This method is not yet implemented in HIOP
+   * @brief Test: min value in a vector
    */
-  bool vectorMin(const hiop::hiopVector& x, const int rank)
+  bool vectorMin(hiop::hiopVector& x, const int rank)
   {
-    (void)x; (void) rank;
-    printMessage(SKIP_TEST, __func__, rank);
+    const local_ordinal_type N = getLocalSize(&x);
+    int fail = 0;
+
+    x.setToConstant(two);
+    if (rank == 0)
+      setLocalElement(&x, N-1, -one);
+
+    fail += (x.min()!=-one);
+
+    x.setToConstant(one);
+    if (rank == 0)
+      setLocalElement(&x, N-1, two);
+
+    fail += (x.min()!=one);
+
+    printMessage(fail, __func__, rank);
+    return 0;
+  }
+
+  /**
+   * @brief Test: min value in a vector
+   */
+  bool vectorMin_w_pattern(hiop::hiopVector& x, 
+                           hiop::hiopVector& pattern,
+                           const int rank)
+  {
+    const local_ordinal_type N = getLocalSize(&x);
+    assert(N == getLocalSize(&pattern));
+
+    int fail = 0;
+
+    x.setToConstant(one);
+    if (rank == 0)
+      setLocalElement(&x, N-1, -one);
+    pattern.setToConstant(one);
+    fail += (x.min_w_pattern(pattern)!=-one);
+
+    if (rank == 0)
+      setLocalElement(&pattern, N-1, zero);
+    fail += (x.min_w_pattern(pattern)!=one);
+
+    printMessage(fail, __func__, rank);
     return 0;
   }
 

--- a/tests/testVector.cpp
+++ b/tests/testVector.cpp
@@ -255,6 +255,8 @@ int runTests(const char* mem_space, MPI_Comm comm)
   fail += test.vector_component_min(*x, *y, rank);
   fail += test.vector_component_max(*x, rank);
   fail += test.vector_component_max(*x, *y, rank);
+  fail += test.vector_component_abs(*x, rank);
+  fail += test.vector_component_sgn(*x, rank);
   fail += test.vectorOnenorm(*x, rank);
   fail += test.vectorTwonorm(*x, rank);
   fail += test.vectorInfnorm(*x, rank);

--- a/tests/testVector.cpp
+++ b/tests/testVector.cpp
@@ -280,6 +280,7 @@ int runTests(const char* mem_space, MPI_Comm comm)
   fail += test.vectorAllPositive_w_patternSelect(*x, *y, rank);
 
   fail += test.vectorMin(*x, rank);
+  fail += test.vectorMin_w_pattern(*x, *y, rank);
   fail += test.vectorProjectIntoBounds(*x, *y, *z, *a, *b, rank);
   fail += test.vectorFractionToTheBdry(*x, *y, rank);
   fail += test.vectorFractionToTheBdry_w_pattern(*x, *y, *z, rank);


### PR DESCRIPTION
Resolve #178 : 
if a variable/constraint is too close to the bound, adjust the corresponding slack variable after each successful line search.

Resolve #179 : 
Relax variable/constraint bounds before solving the problem.

Note that this is just a draft, and it uses some functions from PR #182. 
We should use "develop" as the base, after we merge PR #182 