### PR TITLE
Using one norm instead of infinity norm to compute primal feasibilities in line search

### DIFF
--- a/src/Drivers/nlpDenseCons_ex3_driver.cpp
+++ b/src/Drivers/nlpDenseCons_ex3_driver.cpp
@@ -67,6 +67,8 @@ int main(int argc, char **argv)
   if(!parse_arguments(argc, argv, n, selfCheck)) { usage(argv[0]); return 1;}
 
   double obj_value;
+  bool do_second_round = true;
+  
   hiopSolveStatus status;
 
   Ex3 nlp_interface(n);
@@ -76,31 +78,29 @@ int main(int argc, char **argv)
   // relax var/con bounds before solving the problem
   nlp.options->SetNumericValue("bound_relax_perturb", 1e-10);
 
-  //set options before the solver is even allocated
-  nlp.options->SetStringValue("fixed_var", "relax");
-
   {
     hiopAlgFilterIPM solver(&nlp);
+    nlp.options->SetStringValue("fixed_var", "remove");
     status = solver.run();
     obj_value = solver.getObjective();
 
     //change options and resolve
-    nlp.options->SetStringValue("fixed_var", "remove");
+    nlp.options->SetStringValue("fixed_var", "relax");
     status = solver.run();
     obj_value = solver.getObjective();
 
   }
   //do the same as above but force deallocation of the solver 
-  {
+  if(do_second_round) {
     {
       hiopAlgFilterIPM solver(&nlp);
-      nlp.options->SetStringValue("fixed_var", "relax");
+      nlp.options->SetStringValue("fixed_var", "remove");
       status = solver.run();
       obj_value = solver.getObjective();
     }
     {
       hiopAlgFilterIPM solver(&nlp);
-      nlp.options->SetStringValue("fixed_var", "remove");
+      nlp.options->SetStringValue("fixed_var", "relax");
       status = solver.run();
       obj_value = solver.getObjective();
     }

--- a/src/LinAlg/hiopLinSolverIndefSparseMA57.cpp
+++ b/src/LinAlg/hiopLinSolverIndefSparseMA57.cpp
@@ -26,7 +26,7 @@ namespace hiop
     m_icntl[2-1] = 0;       // no Warning messages
     m_icntl[4-1] = 1;       // no statistics messages
     m_icntl[5-1] = 0;       // no Print messages.
-    m_icntl[6-1] = 5;        // 2 use MC47;
+    m_icntl[6-1] = 2;       // 2 use MC47;
                             // 3 min degree ordering as in MA27;
                             // 4 use Metis;
                             // 5 automatic choice(MA47 or Metis);

--- a/src/Optimization/hiopAlgFilterIPM.cpp
+++ b/src/Optimization/hiopAlgFilterIPM.cpp
@@ -266,7 +266,7 @@ void hiopAlgFilterIPMBase::reloadOptions()
   }
 
   gamma_theta = 1e-5; //sufficient progress parameters for the feasibility violation
-  gamma_phi=1e-5;     //and log barrier objective
+  gamma_phi=1e-8;     //and log barrier objective
   s_theta=1.1;        //parameters in the switch condition of
   s_phi=2.3;          // the linearsearch (equation 19) in
   delta=1.;           // the WachterBiegler paper
@@ -856,8 +856,8 @@ hiopSolveStatus hiopAlgFilterIPMQuasiNewton::run()
 
   iter_num=0; nlp->runStats.nIter=iter_num;
 
-  theta_max=1e+4*fmax(1.0,resid->getInfeasInfNorm());
-  theta_min=1e-4*fmax(1.0,resid->getInfeasInfNorm());
+  theta_max=1e+4*fmax(1.0,resid->get_theta());
+  theta_min=1e-4*fmax(1.0,resid->get_theta());
 
   hiopKKTLinSysLowRank* kkt=new hiopKKTLinSysLowRank(nlp);
 
@@ -1016,7 +1016,7 @@ hiopSolveStatus hiopAlgFilterIPMQuasiNewton::run()
 
       nlp->runStats.tmSolverInternal.start(); //---
       //compute infeasibility theta at trial point.
-      infeas_nrm_trial = theta_trial = resid->computeNlpInfeasInfNorm(*it_trial, *_c_trial, *_d_trial);
+      infeas_nrm_trial = theta_trial = resid->compute_nlp_norms(*it_trial, *_c_trial, *_d_trial);
 
       lsNum++;
 
@@ -1322,7 +1322,7 @@ hiopSolveStatus hiopAlgFilterIPMNewton::run()
 
   //update log bar
   logbar->updateWithNlpInfo(*it_curr, _mu, _f_nlp, *_c, *_d, *_grad_f, *_Jac_c, *_Jac_d);
-  nlp->log->printf(hovScalars, "log bar obj: %g", logbar->f_logbar);
+  nlp->log->printf(hovScalars, "log bar obj: %g\n", logbar->f_logbar);
   //recompute the residuals
   resid->update(*it_curr,_f_nlp, *_c, *_d,*_grad_f,*_Jac_c,*_Jac_d, *logbar);
 
@@ -1333,8 +1333,8 @@ hiopSolveStatus hiopAlgFilterIPMNewton::run()
   iter_num=0; nlp->runStats.nIter=iter_num;
   bool disableLS = nlp->options->GetString("accept_every_trial_step")=="yes";
 
-  theta_max=1e+4*fmax(1.0,resid->getInfeasInfNorm());
-  theta_min=1e-4*fmax(1.0,resid->getInfeasInfNorm());
+  theta_max=1e+4*fmax(1.0,resid->get_theta());
+  theta_min=1e-4*fmax(1.0,resid->get_theta());
 
   hiopKKTLinSys* kkt = decideAndCreateLinearSystem(nlp);
   assert(kkt != NULL);
@@ -1569,7 +1569,7 @@ hiopSolveStatus hiopAlgFilterIPMNewton::run()
 
       //maximum  step
       bret = it_curr->fractionToTheBdry(*dir, _tau, _alpha_primal, _alpha_dual); assert(bret);
-      double theta = resid->getInfeasInfNorm(); //at it_curr
+      double theta = resid->get_theta(); //at it_curr
       double theta_trial;
       nlp->runStats.tmSolverInternal.stop();
 
@@ -1620,7 +1620,7 @@ hiopSolveStatus hiopAlgFilterIPMNewton::run()
 
         nlp->runStats.tmSolverInternal.start(); //---
         //compute infeasibility theta at trial point.
-        infeas_nrm_trial = theta_trial = resid->computeNlpInfeasInfNorm(*it_trial, *_c_trial, *_d_trial);
+        infeas_nrm_trial = theta_trial = resid->compute_nlp_norms(*it_trial, *_c_trial, *_d_trial);
 
         lsNum++;
 

--- a/src/Optimization/hiopAlgFilterIPM.cpp
+++ b/src/Optimization/hiopAlgFilterIPM.cpp
@@ -1016,7 +1016,7 @@ hiopSolveStatus hiopAlgFilterIPMQuasiNewton::run()
 
       nlp->runStats.tmSolverInternal.start(); //---
       //compute infeasibility theta at trial point.
-      infeas_nrm_trial = theta_trial = resid->compute_nlp_norms(*it_trial, *_c_trial, *_d_trial);
+      infeas_nrm_trial = theta_trial = resid->compute_nlp_infeasib_onenorm(*it_trial, *_c_trial, *_d_trial);
 
       lsNum++;
 
@@ -1620,7 +1620,7 @@ hiopSolveStatus hiopAlgFilterIPMNewton::run()
 
         nlp->runStats.tmSolverInternal.start(); //---
         //compute infeasibility theta at trial point.
-        infeas_nrm_trial = theta_trial = resid->compute_nlp_norms(*it_trial, *_c_trial, *_d_trial);
+        infeas_nrm_trial = theta_trial = resid->compute_nlp_infeasib_onenorm(*it_trial, *_c_trial, *_d_trial);
 
         lsNum++;
 

--- a/src/Optimization/hiopResidual.cpp
+++ b/src/Optimization/hiopResidual.cpp
@@ -95,22 +95,25 @@ hiopResidual::~hiopResidual()
   if(rsvu) delete rsvu;
 }
 
-double hiopResidual::computeNlpInfeasInfNorm(const hiopIterate& it, 
+double hiopResidual::compute_nlp_norms(const hiopIterate& it, 
 			       const hiopVector& c, 
 			       const hiopVector& d)
 {
   nlp->runStats.tmSolverInternal.start();
   
-  double nrmInf_infeasib;
+//  double nrmInf_infeasib;
+  double nrmOne_infeasib = 0.;
   long long nx_loc=rx->get_local_size();
   //ryc
   ryc->copyFrom(nlp->get_crhs());
   ryc->axpy(-1.0,c);
-  nrmInf_infeasib = ryc->infnorm_local();
+//  nrmInf_infeasib = ryc->infnorm_local();
+  nrmOne_infeasib += ryc->onenorm_local();
   //ryd
   ryd->copyFrom(*it.d);
   ryd->axpy(-1.0, d);
-  nrmInf_infeasib = fmax(nrmInf_infeasib, ryd->infnorm_local());
+//  nrmInf_infeasib = fmax(nrmInf_infeasib, ryd->infnorm_local());
+  nrmOne_infeasib += ryd->onenorm_local();
   //rxl=x-sxl-xl
   if(nlp->n_low_local()>0) {
     rxl->copyFrom(*it.x);
@@ -119,37 +122,41 @@ double hiopResidual::computeNlpInfeasInfNorm(const hiopIterate& it,
     //zero out entries in the resid that don't correspond to a finite low bound 
     if(nlp->n_low_local()<nx_loc)
       rxl->selectPattern(nlp->get_ixl());
-    nrmInf_infeasib = fmax(nrmInf_infeasib, rxl->infnorm_local());
+//    nrmInf_infeasib = fmax(nrmInf_infeasib, rxl->infnorm_local());
   }
   //rxu=-x-sxu+xu
   if(nlp->n_upp_local()>0) {
     rxu->copyFrom(nlp->get_xu()); rxu->axpy(-1.0,*it.x); rxu->axpy(-1.0,*it.sxu);
     if(nlp->n_upp_local()<nx_loc)
       rxu->selectPattern(nlp->get_ixu());
-    nrmInf_infeasib = fmax(nrmInf_infeasib, rxu->infnorm_local());
+//    nrmInf_infeasib = fmax(nrmInf_infeasib, rxu->infnorm_local());
   }
   //rdl=d-sdl-dl
   if(nlp->m_ineq_low()>0) {
     rdl->copyFrom(*it.d); rdl->axpy(-1.0,*it.sdl); rdl->axpy(-1.0,nlp->get_dl());
     rdl->selectPattern(nlp->get_idl());
-    nrmInf_infeasib = fmax(nrmInf_infeasib, rdl->infnorm_local());
+//    nrmInf_infeasib = fmax(nrmInf_infeasib, rdl->infnorm_local());
   }
   //rdu=-d-sdu+du
   if(nlp->m_ineq_upp()>0) {
     rdu->copyFrom(nlp->get_du()); rdu->axpy(-1.0,*it.sdu); rdu->axpy(-1.0,*it.d);
     rdu->selectPattern(nlp->get_idu());
-    nrmInf_infeasib = fmax(nrmInf_infeasib, rdu->infnorm_local());
+//    nrmInf_infeasib = fmax(nrmInf_infeasib, rdu->infnorm_local());
   }
 
 #ifdef HIOP_USE_MPI
   //here we reduce each of the norm together for a total cost of 1 Allreduce of 3 doubles
   //otherwise, if calling infnorm() for each vector, there will be 12 Allreduce's, each of 1 double
-  double aux;
-  int ierr = MPI_Allreduce(&nrmInf_infeasib, &aux, 1, MPI_DOUBLE, MPI_MAX, nlp->get_comm()); assert(MPI_SUCCESS==ierr);
-  nrmInf_infeasib = aux;
+//  double aux;
+//  int ierr = MPI_Allreduce(&nrmInf_infeasib, &aux, 1, MPI_DOUBLE, MPI_MAX, nlp->get_comm()); assert(MPI_SUCCESS==ierr);
+//  nrmInf_infeasib = aux;
+
+  double sum_one_norm = 0.0;
+  int ierr = MPI_Allreduce(nrmOne_infeasib, sum_one_norm, 1, MPI_DOUBLE, MPI_SUM, nlp->get_comm()); assert(MPI_SUCCESS==ierr);
+  nrmOne_infeasib = sum_one_norm;
 #endif
   nlp->runStats.tmSolverInternal.stop();
-  return nrmInf_infeasib;
+  return nrmOne_infeasib;
 }
 
 int hiopResidual::update(const hiopIterate& it, 
@@ -161,6 +168,7 @@ int hiopResidual::update(const hiopIterate& it,
 
   nrmInf_nlp_optim = nrmInf_nlp_feasib = nrmInf_nlp_complem = 0;
   nrmInf_bar_optim = nrmInf_bar_feasib = nrmInf_bar_complem = 0;
+  nrmOne_theta = 0.;
 
   long long nx_loc=rx->get_local_size();
   const double&  mu=logprob.mu;
@@ -198,6 +206,7 @@ int hiopResidual::update(const hiopIterate& it,
   ryc->axpy(-1.0,c);
   buf = ryc->infnorm_local();
   nrmInf_nlp_feasib = fmax(nrmInf_nlp_feasib, buf);
+  nrmOne_theta += ryc->onenorm_local();
   nlp->log->printf(hovScalars,"NLP resid [update]: inf norm ryc=%22.17e\n", buf);
 
   //ryd
@@ -205,6 +214,7 @@ int hiopResidual::update(const hiopIterate& it,
   ryd->axpy(-1.0, d);
   buf = ryd->infnorm_local();
   nrmInf_nlp_feasib = fmax(nrmInf_nlp_feasib, buf);
+  nrmOne_theta += ryd->onenorm_local();
   nlp->log->printf(hovScalars,"NLP resid [update]: inf norm ryd=%22.17e\n", buf);
   
   //rxl=x-sxl-xl
@@ -320,6 +330,10 @@ int hiopResidual::update(const hiopIterate& it,
   int ierr = MPI_Allreduce(aux, aux_g, 6, MPI_DOUBLE, MPI_MAX, nlp->get_comm()); assert(MPI_SUCCESS==ierr);
   nrmInf_nlp_optim=aux_g[0]; nrmInf_nlp_feasib=aux_g[1]; nrmInf_nlp_complem=aux_g[2];
   nrmInf_bar_optim=aux_g[3]; nrmInf_bar_feasib=aux_g[4]; nrmInf_bar_complem=aux_g[5];
+  
+  double sum_one_norm = 0.0;
+  int ierr = MPI_Allreduce(nrmOne_theta, sum_one_norm, 1, MPI_DOUBLE, MPI_SUM, nlp->get_comm()); assert(MPI_SUCCESS==ierr);
+  nrmOne_theta = sum_one_norm;
 #endif
   nlp->runStats.tmSolverInternal.stop();
   return true;

--- a/src/Optimization/hiopResidual.cpp
+++ b/src/Optimization/hiopResidual.cpp
@@ -226,7 +226,7 @@ int hiopResidual::update(const hiopIterate& it,
     if(nlp->n_low_local()<nx_loc)
       rxl->selectPattern(nlp->get_ixl());
     buf = rxl->infnorm_local();
-    nrmInf_nlp_feasib = fmax(nrmInf_nlp_feasib, buf);
+//    nrmInf_nlp_feasib = fmax(nrmInf_nlp_feasib, buf);
     nlp->log->printf(hovScalars,"NLP resid [update]: inf norm rxl=%22.17e\n", buf);
   }
   //printf("  %10.4e (xl)", nrmInf_nlp_feasib);
@@ -238,7 +238,7 @@ int hiopResidual::update(const hiopIterate& it,
     if(nlp->n_upp_local()<nx_loc)
       rxu->selectPattern(nlp->get_ixu());
     buf = rxu->infnorm_local();
-    nrmInf_nlp_feasib = fmax(nrmInf_nlp_feasib, buf);
+//    nrmInf_nlp_feasib = fmax(nrmInf_nlp_feasib, buf);
     nlp->log->printf(hovScalars,"NLP resid [update]: inf norm rxu=%22.17e\n", buf);
   }  
   //printf("  %10.4e (xu)", nrmInf_nlp_feasib);
@@ -247,7 +247,7 @@ int hiopResidual::update(const hiopIterate& it,
     rdl->copyFrom(*it.d); rdl->axpy(-1.0,*it.sdl); rdl->axpy(-1.0,nlp->get_dl());
     rdl->selectPattern(nlp->get_idl());
     buf = rdl->infnorm_local();
-    nrmInf_nlp_feasib = fmax(nrmInf_nlp_feasib, buf);
+//    nrmInf_nlp_feasib = fmax(nrmInf_nlp_feasib, buf);
     nlp->log->printf(hovScalars,"NLP resid [update]: inf norm rdl=%22.17e\n", buf);
   }
   //printf("  %10.4e (dl)", nrmInf_nlp_feasib);
@@ -258,7 +258,7 @@ int hiopResidual::update(const hiopIterate& it,
     rdu->axpy(-1.0,*it.d);
     rdu->selectPattern(nlp->get_idu());
     buf = rdu->infnorm_local();
-    nrmInf_nlp_feasib = fmax(nrmInf_nlp_feasib, buf);
+//    nrmInf_nlp_feasib = fmax(nrmInf_nlp_feasib, buf);
     nlp->log->printf(hovScalars,"NLP resid [update]: inf norm rdl=%22.17e\n", buf);
   }
   //printf("  %10.4e (du)\n", nrmInf_nlp_feasib);

--- a/src/Optimization/hiopResidual.hpp
+++ b/src/Optimization/hiopResidual.hpp
@@ -78,11 +78,16 @@ public:
   inline double getInfeasInfNorm() const {
     return nrmInf_nlp_feasib;
   }
+  /* get the previously computed Infeasibility */
+  inline double get_theta() const {
+    return nrmOne_theta;
+  } 
   /* evaluate the Infeasibility at the new iterate, which has eq and ineq functions
    * computed in c_eval and d_eval, respectively.
    * The method modifies 'this', in particular ryd,ryc, rxl,rxu, rdl, rdu in an attempt
-   * to reuse storage/buffers, but does not update the cached nrmInf_XXX members. */
-  double computeNlpInfeasInfNorm(const hiopIterate& iter,
+   * to reuse storage/buffers, but does not update the cached nrmInf_XXX members. 
+   * It computes and returns the one norm of [ryc ryd] */
+  double compute_nlp_norms(const hiopIterate& iter,
 				 const hiopVector& c_eval,
 				 const hiopVector& d_eval);
 
@@ -109,6 +114,9 @@ private:
    *  for the barrier subproblem
    */
   double nrmInf_bar_optim, nrmInf_bar_feasib, nrmInf_bar_complem;
+  /** storage for the one norm of [ryc,ryd]. This is the one norm of constraint violations.
+  */ 
+  double nrmOne_theta;
   // and associated info from problem formulation
   hiopNlpFormulation * nlp;
 private:

--- a/src/Optimization/hiopResidual.hpp
+++ b/src/Optimization/hiopResidual.hpp
@@ -87,9 +87,9 @@ public:
    * The method modifies 'this', in particular ryd,ryc, rxl,rxu, rdl, rdu in an attempt
    * to reuse storage/buffers, but does not update the cached nrmInf_XXX members. 
    * It computes and returns the one norm of [ryc ryd] */
-  double compute_nlp_norms(const hiopIterate& iter,
-				 const hiopVector& c_eval,
-				 const hiopVector& d_eval);
+  double compute_nlp_infeasib_onenorm (const hiopIterate& iter,
+                                       const hiopVector& c_eval,
+                                       const hiopVector& d_eval);
 
   /* residual printing function - calls hiopVector::print
    * prints up to max_elems (by default all), on rank 'rank' (by default on all) */


### PR DESCRIPTION
Using one norm instead of infinity norm to measure primal infeasibilities.
Only evaluate the primal infeasibilities from the equality constraints (c) and inequality constraints (d), i.e., var/con boundary constraints doesn't contribute the the primal infeasibility computation in line search. 