### PR TITLE
fix the bug in assembling the full (non-symmetric) KKT system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Ignore files that are generated from the repository sources
 build
-src/Drivers/ipopt.opt
+build_*
+.vscode
+.DS_Store
 _dist-default-build
 _dist-DEBUG

--- a/src/LinAlg/hiopMatrixRajaSparseTriplet.hpp
+++ b/src/LinAlg/hiopMatrixRajaSparseTriplet.hpp
@@ -155,14 +155,16 @@ public:
 
   virtual void copySubmatrixFrom(const hiopMatrix& src_gen,
                                    const long long& dest_row_st, const long long& dest_col_st,
-                                   const long long& dest_nnz_st)
+                                   const long long& dest_nnz_st,
+                                   const bool offdiag_only = false)
   {
     assert(false && "not needed / implemented");
   }
     
   virtual void copySubmatrixFromTrans(const hiopMatrix& src_gen,
                                    const long long& dest_row_st, const long long& dest_col_st,
-                                   const long long& dest_nnz_st)
+                                   const long long& dest_nnz_st,
+                                   const bool offdiag_only = false)
   {
     assert(false && "not needed / implemented");
   }  

--- a/src/LinAlg/hiopMatrixSparseTriplet.cpp
+++ b/src/LinAlg/hiopMatrixSparseTriplet.cpp
@@ -841,8 +841,8 @@ void hiopMatrixSymSparseTriplet::startingAtAddSubDiagonalToStartingAt(int diag_s
 
 void hiopMatrixSparseTriplet::copySubmatrixFrom(const hiopMatrix& src_gen,
                                    const long long& dest_row_st, const long long& dest_col_st,
-                                   const long long& dest_nnz_st)
-//                                   bool firstCall, std::map<int,int> &ValIdxMap )
+                                   const long long& dest_nnz_st,
+                                   const bool offdiag_only)
 {
   const hiopMatrixSparseTriplet& src = dynamic_cast<const hiopMatrixSparseTriplet&>(src_gen);
   auto m_rows = src.m();
@@ -860,17 +860,22 @@ void hiopMatrixSparseTriplet::copySubmatrixFrom(const hiopMatrix& src_gen,
   int dest_k = dest_nnz_st;
 
   // FIXME: irow and jcol only need to be assigned once; should we save a map for the indexes?
-  for(auto src_k = 0; src_k < src_nnz; ++src_k,++dest_k) {
+  for(auto src_k = 0; src_k < src_nnz; ++src_k) {
+    if(offdiag_only && src_iRow[src_k]==src_jCol[src_k]) {
+      continue;
+    }
     iRow_[dest_k] = dest_row_st + src_iRow[src_k];
     jCol_[dest_k] = dest_col_st + src_jCol[src_k];
     values_[dest_k] = src_val[src_k];
+    dest_k++;
   }
   assert(dest_k <= this->numberOfNonzeros());
 }
 
 void hiopMatrixSparseTriplet::copySubmatrixFromTrans(const hiopMatrix& src_gen,
                                    const long long& dest_row_st, const long long& dest_col_st,
-                                   const long long& dest_nnz_st)
+                                   const long long& dest_nnz_st,
+                                   const bool offdiag_only)
 {
   const hiopMatrixSparseTriplet& src = dynamic_cast<const hiopMatrixSparseTriplet&>(src_gen);
   auto m_rows = src.n();
@@ -888,10 +893,14 @@ void hiopMatrixSparseTriplet::copySubmatrixFromTrans(const hiopMatrix& src_gen,
   int dest_k = dest_nnz_st;
 
   // FIXME: irow and jcol only need to be assigned once; should we save a map for the indexes?
-  for(auto src_k = 0; src_k < src_nnz; ++src_k,++dest_k) {
+  for(auto src_k = 0; src_k < src_nnz; ++src_k) {
+    if(offdiag_only && src_iRow[src_k]==src_jCol[src_k]) {
+      continue;
+    }
     iRow_[dest_k] = dest_row_st + src_iRow[src_k];
     jCol_[dest_k] = dest_col_st + src_jCol[src_k];
     values_[dest_k] = src_val[src_k];
+    dest_k++;
   }
   assert(dest_k <= this->numberOfNonzeros());
 }

--- a/src/LinAlg/hiopMatrixSparseTriplet.hpp
+++ b/src/LinAlg/hiopMatrixSparseTriplet.hpp
@@ -121,7 +121,8 @@ public:
 
   /**
   * @brief Copy matrix 'src_gen', into 'this' as a submatrix from corner 'dest_row_st' and 'dest_col_st'
-  * The non-zero elements start from 'dest_nnz_st' will be replaced by the new elements.
+  * The non-zero elements start from 'dest_nnz_st' will be replaced by the new elements. 
+  * When `offdiag_only` is set to true, only the off-diagonal part of `src_gen` is copied.
   *
   * @pre 'this' must have enough rows and cols after row 'dest_row_st' and col 'dest_col_st'
   * @pre 'dest_nnz_st' + the number of non-zeros in the copied matrix must be less or equal to 
@@ -139,6 +140,7 @@ public:
   * @brief Copy the transpose of matrix 'src_gen', into 'this' as a submatrix from corner 
   * 'dest_row_st' and 'dest_col_st'.
   * The non-zero elements start from 'dest_nnz_st' will be replaced by the new elements.
+  * When `offdiag_only` is set to true, only the off-diagonal part of `src_gen` is copied.
   */
   virtual void copySubmatrixFromTrans(const hiopMatrix& src_gen,
                                    const long long& dest_row_st, const long long& dest_col_st,

--- a/src/LinAlg/hiopMatrixSparseTriplet.hpp
+++ b/src/LinAlg/hiopMatrixSparseTriplet.hpp
@@ -132,7 +132,8 @@ public:
   */
   virtual void copySubmatrixFrom(const hiopMatrix& src_gen,
                                    const long long& dest_row_st, const long long& dest_col_st,
-                                   const long long& dest_nnz_st);
+                                   const long long& dest_nnz_st,
+                                   const bool offdiag_only = false);
   
   /**
   * @brief Copy the transpose of matrix 'src_gen', into 'this' as a submatrix from corner 
@@ -141,7 +142,8 @@ public:
   */
   virtual void copySubmatrixFromTrans(const hiopMatrix& src_gen,
                                    const long long& dest_row_st, const long long& dest_col_st,
-                                   const long long& dest_nnz_st);
+                                   const long long& dest_nnz_st,
+                                   const bool offdiag_only = false);
 
   /**
   * @brief Copy the selected cols/rows of a diagonal matrix (a constant 'scalar' times identity),

--- a/src/Optimization/hiopKKTLinSysSparse.cpp
+++ b/src/Optimization/hiopKKTLinSysSparse.cpp
@@ -606,7 +606,8 @@ namespace hiop
 
       // H is triangular
       // [   H   Jc^T  Jd^T | 0 |  0   0  -I   I   |  0   0   0   0  ] [  dx]   [    rx    ]
-      Msys.copySubmatrixFrom(*HessSp_, 0, 0, dest_nnz_st); dest_nnz_st += HessSp_->numberOfNonzeros();
+      Msys.copySubmatrixFrom(*HessSp_, 0, 0, dest_nnz_st, true); dest_nnz_st += HessSp_->numberOfOffDiagNonzeros();
+      Msys.copySubmatrixFromTrans(*HessSp_, 0, 0, dest_nnz_st); dest_nnz_st += HessSp_->numberOfNonzeros();
 
       Msys.copySubmatrixFromTrans(*Jac_cSp_, 0, nx, dest_nnz_st); dest_nnz_st += Jac_cSp_->numberOfNonzeros();
       Msys.copySubmatrixFromTrans(*Jac_dSp_, 0, nx+neq, dest_nnz_st); dest_nnz_st += Jac_dSp_->numberOfNonzeros();


### PR DESCRIPTION
Fix the bug when copying the full symmetric Hessian into the full KKT system.
Previously only a triangular part is copied into the full KKT system.