### PR TITLE
Fix CI for Intel systems

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,6 +44,11 @@
       touch output
       tail -f output &
       tailpid=$!
+
+      if [[ $MY_CLUSTER -eq "marianas" ]]; then
+        export SLURM_Q=`perl $WORKDIR/scripts/findIdleDLNodes.pl`
+      fi
+
       sbatch -A EXASGD -p $SLURM_Q -t $TIMELIMIT --gres=gpu:1 -o output -e output $WORKDIR/BUILD.sh
       res=1
       set +xv

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,7 +45,7 @@
       tail -f output &
       tailpid=$!
 
-      if [[ $MY_CLUSTER -eq "marianas" ]]; then
+      if [[ $MY_CLUSTER == "marianas" ]]; then
         export SLURM_Q=`perl $WORKDIR/scripts/findIdleDLNodes.pl`
       fi
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,22 @@ if(HIOP_DEVELOPER_MODE)
   target_link_libraries(hiop_math INTERFACE hiop_options hiop_warnings)
 endif()
 
+find_package(OpenMP)
+target_link_libraries(hiop_math INTERFACE OpenMP::OpenMP_CXX)
+
+if(NOT DEFINED BLAS_LIBRARIES)
+  find_package(BLAS REQUIRED)
+  target_link_libraries(hiop_math INTERFACE ${BLAS_LIBRARIES})
+  message(STATUS "Found BLAS libraries: ${BLAS_LIBRARIES}")
+endif(NOT DEFINED BLAS_LIBRARIES)
+
+if(NOT DEFINED LAPACK_LIBRARIES)
+  # in case the toolchain defines them
+  find_package(LAPACK REQUIRED)
+endif(NOT DEFINED LAPACK_LIBRARIES)
+target_link_libraries(hiop_math INTERFACE ${LAPACK_LIBRARIES})
+message(STATUS "Using LAPACK libraries: ${LAPACK_LIBRARIES}")
+
 if(HIOP_USE_GPU)
   include(CheckLanguage)
   enable_language(CUDA)
@@ -162,22 +178,6 @@ if(HIOP_WITH_KRON_REDUCTION)
   include(FindHiopMETIS)
   target_link_libraries(hiop_math INTERFACE METIS)
 endif(HIOP_WITH_KRON_REDUCTION)
-
-find_package(OpenMP)
-target_link_libraries(hiop_math INTERFACE OpenMP::OpenMP_CXX)
-
-if(NOT DEFINED BLAS_LIBRARIES)
-  find_package(BLAS REQUIRED)
-  target_link_libraries(hiop_math INTERFACE ${BLAS_LIBRARIES})
-  message(STATUS "Found BLAS libraries: ${BLAS_LIBRARIES}")
-endif(NOT DEFINED BLAS_LIBRARIES)
-
-if(NOT DEFINED LAPACK_LIBRARIES)
-  # in case the toolchain defines them
-  find_package(LAPACK REQUIRED)
-endif(NOT DEFINED LAPACK_LIBRARIES)
-target_link_libraries(hiop_math INTERFACE ${LAPACK_LIBRARIES})
-message(STATUS "Using LAPACK libraries: ${LAPACK_LIBRARIES}")
 
 if(HIOP_USE_RAJA)
   target_link_libraries(hiop_math INTERFACE umpire RAJA)

--- a/scripts/findIdleDLNodes.pl
+++ b/scripts/findIdleDLNodes.pl
@@ -1,0 +1,19 @@
+#!/usr/bin/env perl
+
+use warnings;
+use strict;
+use feature 'say';
+
+# All DL partitions
+my @partitions = grep /^dl/, `sinfo`;
+
+# Idle nodes
+my @idle_parts = grep /idle/, @partitions;
+
+if (scalar @idle_parts eq 0) {
+  # No idle dl parititons... Just choose the shared one.
+  print "dl_shared";
+} else {
+  my @parts = split / /, $idle_parts[0];
+  print $parts[0];
+}

--- a/scripts/marianasVariables.sh
+++ b/scripts/marianasVariables.sh
@@ -16,25 +16,13 @@ module use -a $MODULESHOME/modulefiles/development/tools
 module use -a $MODULESHOME/modulefiles/apps
 module use -a $MODULESHOME/modulefiles/libs
 module use -a $PROJ_DIR/src/spack/share/spack/modules/$SPACK_ARCH/
-export MY_GCC_VERSION=7.3.0
-export MY_CUDA_VERSION=10.2.89
-export MY_OPENMPI_VERSION=3.1.3
-export MY_CMAKE_VERSION=3.15.3
-export MY_MAGMA_VERSION=2.5.4-gcc-7.3.0-bwwsayw
-export MY_METIS_VERSION=5.1.0
+source $PROJ_DIR/src/spack/share/spack/setup-env.sh
+
 export MY_NVCC_ARCH="sm_60"
-
 export NVBLAS_CONFIG_FILE=$PROJ_DIR/$MY_CLUSTER/nvblas.conf
-module load gcc/$MY_GCC_VERSION
-module load cuda/$MY_CUDA_VERSION
-module load openmpi/$MY_OPENMPI_VERSION
-module load cmake/$MY_CMAKE_VERSION
-module load magma/$MY_MAGMA_VERSION
+module load gcc/7.3.0
+module load cuda/10.2.89
+module load openmpi/3.1.3
+module load cmake-3.18.4-gcc-7.3.0-fuktvvh
 
-export MY_RAJA_DIR=$PROJ_DIR/$MY_CLUSTER/raja
-export MY_UMPIRE_DIR=$PROJ_DIR/$MY_CLUSTER/umpire
-export MY_UMFPACK_DIR=$PROJ_DIR/$MY_CLUSTER/suitesparse
-export MY_METIS_DIR=$APPS_DIR/metis/$MY_METIS_VERSION
-export MY_HIOP_MAGMA_DIR=$APPS_DIR/magma/2.5.2/cuda10.2
-export MY_COINHSL_DIR=$PROJ_DIR/$MY_CLUSTER/ipopt
-EXTRA_CMAKE_ARGS="$EXTRA_CMAKE_ARGS -DBLAS_LIBRARIES=/usr/lib64/libopenblas.so"
+spack env activate exago-v0-99-2-hiop-v0-3-99-2-marianas --with-view


### PR DESCRIPTION
Link against host blas *before* nvblas. Use spack environment for dependencies on Intel system.

@pelesh can you see if this resolves #210 as well?

CC @cnpetra @nychiang 