### PR TITLE
MPI error - fixes Issue#205

### DIFF
--- a/src/Drivers/nlpDenseCons_ex3.hpp
+++ b/src/Drivers/nlpDenseCons_ex3.hpp
@@ -40,11 +40,19 @@ public:
   
     // set up vector distribution for primal variables - easier to store it as a member in this simple example
     col_partition = new long long[comm_size+1];
-    long long quotient=n_vars/comm_size, remainder=n_vars-comm_size*quotient;
-    //if(my_rank==0) printf("reminder=%llu quotient=%llu\n", remainder, quotient);
-    int i=0; col_partition[i]=0; i++;
-    while(i<=remainder) { col_partition[i] = col_partition[i-1]+quotient+1; i++; }
-    while(i<=comm_size) { col_partition[i] = col_partition[i-1]+quotient;   i++; }
+    long long quotient=n_vars/comm_size;
+    long long remainder=n_vars-comm_size*quotient;
+
+    int i=0;
+    col_partition[i++]=0;
+    while(i<=remainder) {
+      col_partition[i] = col_partition[i-1]+quotient+1;
+      i++;
+    }
+    while(i<=comm_size) {
+      col_partition[i] = col_partition[i-1]+quotient;
+      i++;
+    }
   };
 
   virtual ~Ex3()
@@ -179,10 +187,14 @@ public:
 
   virtual bool get_vecdistrib_info(long long global_n, long long* cols)
   {
-    if(global_n==n_vars)
-      for(int i=0; i<=comm_size; i++) cols[i]=col_partition[i];
-    else 
+    if(global_n==n_vars) {
+      for(int i=0; i<=comm_size; i++) {
+        cols[i]=col_partition[i];
+      }
+    } else { 
       assert(false && "You shouldn't need distrib info for this size.");
+      return false;
+    }
     return true;
   }
 

--- a/src/LinAlg/hiopVectorPar.cpp
+++ b/src/LinAlg/hiopVectorPar.cpp
@@ -273,7 +273,10 @@ void hiopVectorPar::copyTo(double* dest) const
 double hiopVectorPar::twonorm() const 
 {
   int one=1; int n=n_local_;
-  double nrm = DNRM2(&n,data_,&one); 
+  double nrm = 0.;
+  if(n>0) {
+    nrm = DNRM2(&n,data_,&one);
+  }
 
 #ifdef HIOP_USE_MPI
   nrm *= nrm;
@@ -284,14 +287,18 @@ double hiopVectorPar::twonorm() const
   return nrm;
 }
 
-double hiopVectorPar::dotProductWith( const hiopVector& v_ ) const
+double hiopVectorPar::dotProductWith(const hiopVector& v_) const
 {
   const hiopVectorPar& v = dynamic_cast<const hiopVectorPar&>(v_);
   int one=1; int n=n_local_;
   assert(this->n_local_==v.n_local_);
 
-  double dotprod=DDOT(&n, this->data_, &one, v.data_, &one);
-
+  double dotprod;
+  if(n>0) {
+    dotprod = DDOT(&n, this->data_, &one, v.data_, &one);
+  } else {
+    dotprod = 0.;
+  }
 #ifdef HIOP_USE_MPI
   double dotprodG;
   int ierr = MPI_Allreduce(&dotprod, &dotprodG, 1, MPI_DOUBLE, MPI_SUM, comm_); assert(MPI_SUCCESS==ierr);
@@ -342,10 +349,14 @@ double hiopVectorPar::infnorm_local() const
 
 double hiopVectorPar::onenorm() const
 {
-  double nrm1=0.; for(int i=0; i<n_local_; i++) nrm1 += fabs(data_[i]);
+  double nrm1=0.;
+  for(int i=0; i<n_local_; i++) {
+    nrm1 += fabs(data_[i]);
+  }
 #ifdef HIOP_USE_MPI
   double nrm1_global;
-  int ierr = MPI_Allreduce(&nrm1, &nrm1_global, 1, MPI_DOUBLE, MPI_SUM, comm_); assert(MPI_SUCCESS==ierr);
+  int ierr = MPI_Allreduce(&nrm1, &nrm1_global, 1, MPI_DOUBLE, MPI_SUM, comm_);
+  assert(MPI_SUCCESS==ierr);
   return nrm1_global;
 #endif
   return nrm1;
@@ -353,7 +364,10 @@ double hiopVectorPar::onenorm() const
 
 double hiopVectorPar::onenorm_local() const
 {
-  double nrm1=0.; for(int i=0; i<n_local_; i++) nrm1 += fabs(data_[i]);
+  double nrm1=0.;
+  for(int i=0; i<n_local_; i++) {
+    nrm1 += fabs(data_[i]);
+  }
   return nrm1;
 }
 
@@ -361,8 +375,9 @@ void hiopVectorPar::componentMult( const hiopVector& v_ )
 {
   const hiopVectorPar& v = dynamic_cast<const hiopVectorPar&>(v_);
   assert(n_local_==v.n_local_);
-  for(int i=0; i<n_local_; ++i)
+  for(int i=0; i<n_local_; ++i) {
     data_[i] *= v.data_[i];
+  }
 }
 
 void hiopVectorPar::componentDiv ( const hiopVector& v_ )
@@ -559,7 +574,8 @@ double hiopVectorPar::min() const
   }
 #ifdef HIOP_USE_MPI
   double ret_val_g;
-  int ierr=MPI_Allreduce(&ret_val, &ret_val_g, 1, MPI_DOUBLE, MPI_MIN, comm_); assert(MPI_SUCCESS==ierr);
+  int ierr=MPI_Allreduce(&ret_val, &ret_val_g, 1, MPI_DOUBLE, MPI_MIN, comm_);
+  assert(MPI_SUCCESS==ierr);
   ret_val = ret_val_g;
 #endif
   return ret_val;
@@ -683,8 +699,13 @@ void hiopVectorPar::addLinearDampingTerm(const hiopVector& ixleft,
 
 int hiopVectorPar::allPositive()
 {
-  int allPos=true, i=0;
-  while(i<n_local_ && allPos) if(data_[i++]<=0) allPos=false;
+  int allPos=true;
+  int i=0;
+  while(i<n_local_ && allPos) {
+    if(data_[i++]<=0) {
+      allPos=false;
+    }
+  }
 
 #ifdef HIOP_USE_MPI
   int allPosG;
@@ -811,12 +832,15 @@ bool hiopVectorPar::matchesPattern(const hiopVector& ix_)
   const double* ix = (dynamic_cast<const hiopVectorPar&>(ix_) ).local_data_const();
   int bmatches=true;
   double* x=data_;
-  for(int i=0; (i<n_local_) && bmatches; i++) 
-    if(ix[i]==0.0 && x[i]!=0.0) bmatches=false; 
-
+  for(int i=0; (i<n_local_) && bmatches; i++) {
+    if(ix[i]==0.0 && x[i]!=0.0) {
+      bmatches=false;
+    }
+  }
 #ifdef HIOP_USE_MPI
   int bmatches_glob=bmatches;
-  int ierr=MPI_Allreduce(&bmatches, &bmatches_glob, 1, MPI_INT, MPI_LAND, comm_); assert(MPI_SUCCESS==ierr);
+  int ierr=MPI_Allreduce(&bmatches, &bmatches_glob, 1, MPI_INT, MPI_LAND, comm_);
+  assert(MPI_SUCCESS==ierr);
   return bmatches_glob;
 #endif
   return bmatches;
@@ -830,18 +854,24 @@ int hiopVectorPar::allPositive_w_patternSelect(const hiopVector& w_)
   const double* w = (dynamic_cast<const hiopVectorPar&>(w_) ).local_data_const();
   const double* x=data_;
   int allPos=1; 
-  for(int i=0; i<n_local_ && allPos; i++) 
-    if(w[i]!=0.0 && x[i]<=0.) allPos=0;
-  
+  for(int i=0; i<n_local_ && allPos; i++) {
+    if(w[i]!=0.0 && x[i]<=0.) {
+      allPos=0;
+    }
+  }
 #ifdef HIOP_USE_MPI
   int allPosG=allPos;
-  int ierr = MPI_Allreduce(&allPos, &allPosG, 1, MPI_INT, MPI_MIN, comm_); assert(MPI_SUCCESS==ierr);
+  int ierr = MPI_Allreduce(&allPos, &allPosG, 1, MPI_INT, MPI_MIN, comm_);
+  assert(MPI_SUCCESS==ierr);
   return allPosG;
 #endif  
   return allPos;
 }
 
-void hiopVectorPar::adjustDuals_plh(const hiopVector& x_, const hiopVector& ix_, const double& mu, const double& kappa)
+void hiopVectorPar::adjustDuals_plh(const hiopVector& x_,
+                                    const hiopVector& ix_,
+                                    const double& mu,
+                                    const double& kappa)
 {
 #ifdef HIOP_DEEPCHECKS
   assert((dynamic_cast<const hiopVectorPar&>(x_) ).n_local_==n_local_);
@@ -923,17 +953,16 @@ void hiopVectorPar::print(FILE* file, const char* msg/*=NULL*/, int max_elems/*=
 long long hiopVectorPar::numOfElemsLessThan(const double &val) const
 {
   long long ret_num = 0;
-  for(long long i=0; i<n_local_; i++)
-  {
-    if(data_[i]<val)
-    {
+  for(long long i=0; i<n_local_; i++) {
+    if(data_[i]<val) {
       ret_num++;
     }
   }
 
 #ifdef HIOP_USE_MPI
   long long ret_num_global;
-  int ierr=MPI_Allreduce(&ret_num, &ret_num_global, 1, MPI_LONG_LONG, MPI_SUM, comm_); assert(MPI_SUCCESS==ierr);
+  int ierr=MPI_Allreduce(&ret_num, &ret_num_global, 1, MPI_LONG_LONG, MPI_SUM, comm_);
+  assert(MPI_SUCCESS==ierr);
   ret_num = ret_num_global;
 #endif
 
@@ -943,17 +972,16 @@ long long hiopVectorPar::numOfElemsLessThan(const double &val) const
 long long hiopVectorPar::numOfElemsAbsLessThan(const double &val) const
 {
   long long ret_num = 0;
-  for(long long i=0; i<n_local_; i++)
-  {
-    if(fabs(data_[i])<val)
-    {
+  for(long long i=0; i<n_local_; i++) {
+    if(fabs(data_[i])<val) {
       ret_num++;
     }
   }
 
 #ifdef HIOP_USE_MPI
   long long ret_num_global;
-  int ierr=MPI_Allreduce(&ret_num, &ret_num_global, 1, MPI_LONG_LONG, MPI_SUM, comm_); assert(MPI_SUCCESS==ierr);
+  int ierr=MPI_Allreduce(&ret_num, &ret_num_global, 1, MPI_LONG_LONG, MPI_SUM, comm_);
+  assert(MPI_SUCCESS==ierr);
   ret_num = ret_num_global;
 #endif
 

--- a/src/Optimization/hiopIterate.cpp
+++ b/src/Optimization/hiopIterate.cpp
@@ -403,7 +403,8 @@ int hiopIterate::adjust_small_slacks(hiopVector& slack,
   int num_adjusted_slack = 0;
   double zero=0.0;
 
-  if(slack.get_local_size() > 0) {
+  //if(slack.get_local_size() > 0)
+  {
     double slack_min;
     double small_val = std::numeric_limits<double>::epsilon()* fmin(1., mu);
     double scale_fact = pow(std::numeric_limits<double>::epsilon(), 0.75);

--- a/src/Optimization/hiopResidual.cpp
+++ b/src/Optimization/hiopResidual.cpp
@@ -96,11 +96,11 @@ hiopResidual::~hiopResidual()
 }
 
 double hiopResidual::compute_nlp_infeasib_onenorm (const hiopIterate& it, 
-			       const hiopVector& c, 
-			       const hiopVector& d)
+                                                   const hiopVector& c, 
+                                                   const hiopVector& d)
 {
+
   nlp->runStats.tmSolverInternal.start();
-  
 //  double nrmInf_infeasib;
   double nrmOne_infeasib = 0.;
   long long nx_loc=rx->get_local_size();
@@ -321,11 +321,21 @@ int hiopResidual::update(const hiopIterate& it,
 #ifdef HIOP_USE_MPI
   //here we reduce each of the norm together for a total cost of 1 Allreduce of 3 doubles
   //otherwise, if calling infnorm() for each vector, there will be 12 Allreduce's, each of 1 double
-  double aux[6]={nrmInf_nlp_optim,nrmInf_nlp_feasib,nrmInf_nlp_complem,nrmInf_bar_optim,nrmInf_bar_feasib,nrmInf_bar_complem}, aux_g[6];
+  double aux[6]={nrmInf_nlp_optim,
+                 nrmInf_nlp_feasib,
+                 nrmInf_nlp_complem,
+                 nrmInf_bar_optim,
+                 nrmInf_bar_feasib,
+                 nrmInf_bar_complem};
+  double aux_g[6];
   int ierr = MPI_Allreduce(aux, aux_g, 6, MPI_DOUBLE, MPI_MAX, nlp->get_comm()); 
   assert(MPI_SUCCESS==ierr);
-  nrmInf_nlp_optim=aux_g[0]; nrmInf_nlp_feasib=aux_g[1]; nrmInf_nlp_complem=aux_g[2];
-  nrmInf_bar_optim=aux_g[3]; nrmInf_bar_feasib=aux_g[4]; nrmInf_bar_complem=aux_g[5];  
+  nrmInf_nlp_optim=aux_g[0];
+  nrmInf_nlp_feasib=aux_g[1];
+  nrmInf_nlp_complem=aux_g[2];
+  nrmInf_bar_optim=aux_g[3];
+  nrmInf_bar_feasib=aux_g[4];
+  nrmInf_bar_complem=aux_g[5];  
 #endif
   nlp->runStats.tmSolverInternal.stop();
   return true;


### PR DESCRIPTION
The issue #205 occurs when MPI ranks with zero variables exist. On such rank(s), the code skips pieces of the [code](
https://github.com/LLNL/hiop/pull/214/files#diff-be01a9630ee9dd9a93b9a5677a2c3fdd16e4c06119ec2e5c19e60b6d0bcd01ccR406) that involve MPI calls, which result in unmatched MPI calls (and errors) accross MPI communicator. 


