### PR TITLE
CUDA as a first class language update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,7 @@ if (POLICY CMP0074)
   cmake_policy(SET CMP0074 NEW)
 endif ()
 
-project (hiop VERSION "0.4.1"
-  LANGUAGES C CXX CUDA)
+project (hiop VERSION "0.4.1")
 
 string(TIMESTAMP HIOP_RELEASE_DATE "%Y-%m-%d")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,8 @@ if (POLICY CMP0074)
   cmake_policy(SET CMP0074 NEW)
 endif ()
 
-project (hiop VERSION "0.4.1")
+project (hiop VERSION "0.4.1"
+  LANGUAGES C CXX CUDA)
 
 string(TIMESTAMP HIOP_RELEASE_DATE "%Y-%m-%d")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.15)
+cmake_minimum_required (VERSION 3.18)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/cmake/FindHiopCudaLibraries.cmake
+++ b/cmake/FindHiopCudaLibraries.cmake
@@ -6,47 +6,13 @@ Exports target `hiop_cuda` which finds all cuda libraries needed by hiop.
 ]]
 
 add_library(hiop_cuda INTERFACE)
+target_link_libraries(hiop_cuda INTERFACE culibos)
+target_link_libraries(hiop_cuda INTERFACE cublasLt)
+target_link_libraries(hiop_cuda INTERFACE nvblas)
+target_link_libraries(hiop_cuda INTERFACE cusparse)
+target_link_libraries(hiop_cuda INTERFACE cudart)
 
-find_package(CUDA REQUIRED)
-
-find_library(CUDA_culibos_LIBRARY
-  NAMES
-  culibos
-  PATHS
-  ${CUDA_TOOLKIT_ROOT_DIR} $ENV{CUDA_TOOLKIT_ROOT_DIR}
-  PATH_SUFFIXES
-  lib64 lib
-  )
-
-find_library(CUDA_cublasLt_LIBRARY
-  NAMES
-  cublasLt
-  PATHS
-  ${CUDA_TOOLKIT_ROOT_DIR} $ENV{CUDA_TOOLKIT_ROOT_DIR}
-  PATH_SUFFIXES
-  lib64 lib
-  )
-
-find_library(CUDA_nvblas_LIBRARY
-  NAMES
-  nvblas
-  PATHS
-  ${CUDA_TOOLKIT_ROOT_DIR} $ENV{CUDA_TOOLKIT_ROOT_DIR}
-  PATH_SUFFIXES
-  lib64 lib
-  )
-
-target_link_libraries(hiop_cuda INTERFACE
-  ${CUDA_cublas_LIBRARY}
-  ${CUDA_CUDART_LIBRARY}
-  ${CUDA_cudadevrt_LIBRARY}
-  ${CUDA_cusparse_LIBRARY}
-  ${CUDA_cublasLt_LIBRARY}
-  ${CUDA_nvblas_LIBRARY}
-  ${CUDA_culibos_LIBRARY}
-  )
-
-target_include_directories(hiop_cuda INTERFACE ${CUDA_TOOLKIT_INCLUDE})
+target_include_directories(hiop_cuda INTERFACE ${CUDAToolkit_INCLUDE_DIRS})
 
 # for now we rely on MAGMA for GPUs computations
 include(FindHiopMagma)

--- a/scripts/newellVariables.sh
+++ b/scripts/newellVariables.sh
@@ -15,7 +15,7 @@ module use -a $PROJ_DIR/src/spack/share/spack/modules/$SPACK_ARCH/
 export MY_GCC_VERSION=7.4.0
 export MY_CUDA_VERSION=10.2
 export MY_OPENMPI_VERSION=3.1.5
-export MY_CMAKE_VERSION=3.16.4
+export MY_CMAKE_VERSION=3.19.6
 export MY_MAGMA_VERSION=2.5.4-gcc-7.4.0-jss5aen
 export MY_METIS_VERSION=5.1.0
 export MY_NVCC_ARCH="sm_70"

--- a/src/Drivers/nlpMDS_raja_ex4.cpp
+++ b/src/Drivers/nlpMDS_raja_ex4.cpp
@@ -200,8 +200,9 @@ bool Ex4::get_vars_info(const long long& n, double *xlow, double* xupp, Nonlinea
     });
 
   /// Using OpenMP execution policy for nonlinearity type setting
-  RAJA::forall<RAJA::omp_parallel_for_exec>(RAJA::RangeSegment(0, n),
-    [=](RAJA::Index_type i)
+  /// Switching back to global raja exec for portability...
+  RAJA::forall<ex4_raja_exec>(RAJA::RangeSegment(0, n),
+    RAJA_LAMBDA(RAJA::Index_type i)
     {
       type[i] = hiopNonlinear;
     });
@@ -239,8 +240,9 @@ bool Ex4::get_cons_info(const long long& m, double* clow, double* cupp, Nonlinea
     });
 
   /// Using OpenMP execution policy for nonlinearity type setting
-  RAJA::forall<RAJA::omp_parallel_for_exec>(RAJA::RangeSegment(0, m),
-    [=](RAJA::Index_type i)
+  /// Switching backing to global raja exec for portability
+  RAJA::forall<ex4_raja_exec>(RAJA::RangeSegment(0, m),
+    RAJA_LAMBDA(RAJA::Index_type i)
     {
       type[i] = hiopNonlinear;
     });

--- a/src/Drivers/nlpMDS_raja_ex4.cpp
+++ b/src/Drivers/nlpMDS_raja_ex4.cpp
@@ -200,8 +200,8 @@ bool Ex4::get_vars_info(const long long& n, double *xlow, double* xupp, Nonlinea
     });
 
   /// Using OpenMP execution policy for nonlinearity type setting
-  /// Switching back to global raja exec for portability...
-  RAJA::forall<ex4_raja_exec>(RAJA::RangeSegment(0, n),
+  /// Switching to sequential raja exec for portability
+  RAJA::forall<RAJA::seq_exec>(RAJA::RangeSegment(0, n),
     RAJA_LAMBDA(RAJA::Index_type i)
     {
       type[i] = hiopNonlinear;
@@ -240,8 +240,8 @@ bool Ex4::get_cons_info(const long long& m, double* clow, double* cupp, Nonlinea
     });
 
   /// Using OpenMP execution policy for nonlinearity type setting
-  /// Switching backing to global raja exec for portability
-  RAJA::forall<ex4_raja_exec>(RAJA::RangeSegment(0, m),
+  /// Switching to sequential raja exec for portability
+  RAJA::forall<RAJA::seq_exec>(RAJA::RangeSegment(0, m),
     RAJA_LAMBDA(RAJA::Index_type i)
     {
       type[i] = hiopNonlinear;

--- a/src/Drivers/nlpMDS_raja_ex4.cpp
+++ b/src/Drivers/nlpMDS_raja_ex4.cpp
@@ -200,9 +200,8 @@ bool Ex4::get_vars_info(const long long& n, double *xlow, double* xupp, Nonlinea
     });
 
   /// Using OpenMP execution policy for nonlinearity type setting
-  /// Switching to sequential raja exec for portability
-  RAJA::forall<RAJA::seq_exec>(RAJA::RangeSegment(0, n),
-    RAJA_LAMBDA(RAJA::Index_type i)
+  RAJA::forall<RAJA::omp_parallel_for_exec>(RAJA::RangeSegment(0, n),
+    [=](RAJA::Index_type i)
     {
       type[i] = hiopNonlinear;
     });
@@ -240,9 +239,8 @@ bool Ex4::get_cons_info(const long long& m, double* clow, double* cupp, Nonlinea
     });
 
   /// Using OpenMP execution policy for nonlinearity type setting
-  /// Switching to sequential raja exec for portability
-  RAJA::forall<RAJA::seq_exec>(RAJA::RangeSegment(0, m),
-    RAJA_LAMBDA(RAJA::Index_type i)
+  RAJA::forall<RAJA::omp_parallel_for_exec>(RAJA::RangeSegment(0, m),
+    [=](RAJA::Index_type i)
     {
       type[i] = hiopNonlinear;
     });


### PR DESCRIPTION
Since we have adopted CMake 3.18: as a requirement for this project (see HiOp's spack package [here](https://github.com/spack/spack/blob/develop/var/spack/repos/builtin/packages/hiop/package.py#L55)), we should adopt CUDA as a first class language per [best practices](https://cliutils.gitlab.io/modern-cmake/chapters/packages/CUDA.html).

Closes #230.

cc @pelesh