### PR TITLE
Issue 232 233 237 fix

### DIFF
--- a/src/LinAlg/hiopLinAlgFactory.cpp
+++ b/src/LinAlg/hiopLinAlgFactory.cpp
@@ -109,7 +109,7 @@ hiopVector* LinearAlgebraFactory::createVector(
  * Creates int vector with operator new by default, RAJA vector when memory space
  * is specified.
  */
-hiopVectorInt* LinearAlgebraFactory::createVectorInt(int size)
+hiopVectorInt* LinearAlgebraFactory::createVectorInt(hiopInt size)
 {
   if(mem_space_ == "DEFAULT")
   {

--- a/src/LinAlg/hiopLinAlgFactory.hpp
+++ b/src/LinAlg/hiopLinAlgFactory.hpp
@@ -78,7 +78,7 @@ public:
   /**
    * @brief Static method to create local int vector.
    */
-  static hiopVectorInt* createVectorInt(int size);
+  static hiopVectorInt* createVectorInt(hiopInt size);
 
   /**
    * @brief Static method to create a dense matrix.

--- a/src/LinAlg/hiopMatrixRajaSparseTriplet.hpp
+++ b/src/LinAlg/hiopMatrixRajaSparseTriplet.hpp
@@ -246,7 +246,7 @@ public:
                           const hiopMatrixSparse& Jac_d,
                           int* iJacS,
                           int* jJacS,
-                          double* MJacS);
+                          double* MJacS) {assert("not implemented"&&0);}
 
   virtual void set_Hess_FR(const hiopMatrixSparse& Hess,
                            int* iHSS,
@@ -401,7 +401,7 @@ public:
                            int* iHSS,
                            int* jHSS,
                            double* MHSS,
-                           const hiopVector& add_diag);
+                           const hiopVector& add_diag){assert("not implemented"&&0);}
 
 };
 } //end of namespace

--- a/src/LinAlg/hiopMatrixRajaSparseTriplet.hpp
+++ b/src/LinAlg/hiopMatrixRajaSparseTriplet.hpp
@@ -241,8 +241,22 @@ public:
     assert(false && "not needed / implemented");
   }
 
-  virtual long long numberOfOffDiagNonzeros() {assert("not implemented"&&0);return 0;};
-      
+  virtual long long numberOfOffDiagNonzeros() const {assert("not implemented"&&0);return 0;};
+  virtual void set_Jac_FR(const hiopMatrixSparse& Jac_c,
+                          const hiopMatrixSparse& Jac_d,
+                          int* iJacS,
+                          int* jJacS,
+                          double* MJacS);
+
+  virtual void set_Hess_FR(const hiopMatrixSparse& Hess,
+                           int* iHSS,
+                           int* jHSS,
+                           double* MHSS,
+                           const hiopVector& add_diag)
+  {
+    assert(false && "not needed / implemented");
+  }
+
   virtual hiopMatrixSparse* alloc_clone() const;
   virtual hiopMatrixSparse* new_copy() const;
 
@@ -372,10 +386,22 @@ public:
     return true;
   }
   
-  virtual long long numberOfOffDiagNonzeros() {
+  virtual long long numberOfOffDiagNonzeros() const {
     assert(false && "not needed / implemented");
     return 0;
   }
+
+  virtual void set_Jac_FR(const hiopMatrixSparse& Jac_c,
+                          const hiopMatrixSparse& Jac_d,
+                          int* iJacS,
+                          int* jJacS,
+                          double* MJacS) {assert("not implemented"&&0);};
+
+  virtual void set_Hess_FR(const hiopMatrixSparse& Hess,
+                           int* iHSS,
+                           int* jHSS,
+                           double* MHSS,
+                           const hiopVector& add_diag);
 
 };
 } //end of namespace

--- a/src/LinAlg/hiopMatrixSparse.hpp
+++ b/src/LinAlg/hiopMatrixSparse.hpp
@@ -198,7 +198,21 @@ public:
   virtual const int* i_row() const = 0;
   virtual const int* j_col() const = 0;
   virtual const double* M()  const = 0;
-  virtual long long numberOfOffDiagNonzeros() = 0;
+  virtual long long numberOfOffDiagNonzeros() const = 0;
+  
+  /// @brief build Jac for FR problem, from the base problem `Jac_c` and `Jac_d`. Set sparsity if `task`=0, otherwise set values
+  virtual void set_Jac_FR(const hiopMatrixSparse& Jac_c,
+                          const hiopMatrixSparse& Jac_d,
+                          int* iJacS,
+                          int* jJacS,
+                          double* MJacS) = 0;
+
+  /// @brief build Hess for FR problem, from the base problem `Hess`. Set sparsity if `task`=0, otherwise set values
+  virtual void set_Hess_FR(const hiopMatrixSparse& Hess,
+                           int* iHSS,
+                           int* jHSS,
+                           double* MHSS,
+                           const hiopVector& add_diag) = 0;
 
   inline long long m() const
   {

--- a/src/LinAlg/hiopMatrixSparseTriplet.cpp
+++ b/src/LinAlg/hiopMatrixSparseTriplet.cpp
@@ -732,7 +732,145 @@ void hiopMatrixSparseTriplet::print(FILE* file, const char* msg/*=NULL*/,
   }
 }
 
+/*
+*  extend original Jac to [Jac -I I]
+*/
+void hiopMatrixSparseTriplet::set_Jac_FR(const hiopMatrixSparse& Jac_c,
+                                         const hiopMatrixSparse& Jac_d,
+                                         int* iJacS,
+                                         int* jJacS,
+                                         double* MJacS)
+{
+  const auto& J_c = dynamic_cast<const hiopMatrixSparseTriplet&>(Jac_c);
+  const auto& J_d = dynamic_cast<const hiopMatrixSparseTriplet&>(Jac_d);
+    
+  // shortcut to the original Jac
+  const int *irow_c = J_c.i_row();
+  const int *jcol_c = J_c.j_col();
+  const int *irow_d = J_d.i_row();
+  const int *jcol_d = J_d.j_col();
 
+  // assuming original Jac is sorted!
+  int nnz_Jac_c = J_c.numberOfNonzeros();
+  int nnz_Jac_d = J_d.numberOfNonzeros();
+  int m_c = J_c.m();
+  int m_d = J_d.m();
+  int n_c = J_c.n();
+  int n_d = J_d.n();
+  assert(n_c == n_d);
+
+  int nnz_Jac_c_new = nnz_Jac_c + 2*m_c;
+  int nnz_Jac_d_new = nnz_Jac_d + 2*m_d;
+
+  assert(nnz_ == nnz_Jac_c_new + nnz_Jac_d_new);
+  
+  if(J_c.row_starts_ == nullptr){
+    J_c.row_starts_ = J_c.allocAndBuildRowStarts();
+  }
+  assert(J_c.row_starts_);
+  
+  if(J_d.row_starts_ == nullptr){
+    J_d.row_starts_ = J_d.allocAndBuildRowStarts();
+  }
+  assert(J_d.row_starts_);
+    
+  // extend Jac to the p and n parts --- sparsity
+  if(iJacS != nullptr && jJacS != nullptr) {
+    int k = 0;
+  
+    // Jac for c(x) - p + n
+    const int* J_c_col = J_c.j_col();
+    for(int i = 0; i < m_c; ++i) {
+      int k_base = J_c.row_starts_->idx_start_[i];
+    
+      // copy from base Jac_c
+      while(k_base < J_c.row_starts_->idx_start_[i+1]) {
+        iRow_[k] = iJacS[k] = i;
+        jCol_[k] = jJacS[k] = J_c_col[k_base];
+        k++;
+        k_base++;
+      }
+      
+      // extra parts for p and n
+      iRow_[k] = iJacS[k] = i;
+      jCol_[k] = jJacS[k] = n_c + i;
+      k++;
+      
+      iRow_[k] = iJacS[k] = i;
+      jCol_[k] = jJacS[k] = n_c + m_c + i;
+      k++;
+    }
+
+    // Jac for d(x) - p + n
+    const int* J_d_col = J_d.j_col();
+    for(int i = 0; i < m_d; ++i) {
+      int k_base = J_d.row_starts_->idx_start_[i];
+    
+      // copy from base Jac_d
+      while(k_base < J_d.row_starts_->idx_start_[i+1]) {
+        iRow_[k] = iJacS[k] = i + m_c;
+        jCol_[k] = jJacS[k] = J_d_col[k_base];
+        k++;
+        k_base++;
+      }
+      
+      // extra parts for p and n
+      iRow_[k] = iJacS[k] = i + m_c;
+      jCol_[k] = jJacS[k] = n_d + 2*m_c + i;
+      k++;
+      
+      iRow_[k] = iJacS[k] = i + m_c;
+      jCol_[k] = jJacS[k] = n_d + 2*m_c + m_d + i;
+      k++;
+    }
+    assert(k == nnz_);
+  }
+  
+  // extend Jac to the p and n parts --- element
+  if(MJacS != nullptr) {    
+    int k = 0;
+
+    // Jac for c(x) - p + n
+    const double* J_c_val = J_c.M();
+    for(int i = 0; i < m_c; ++i) {
+      int k_base = J_c.row_starts_->idx_start_[i];
+    
+      // copy from base Jac_c
+      while(k_base < J_c.row_starts_->idx_start_[i+1]) {
+        values_[k] = MJacS[k] = J_c_val[k_base];
+        k++;
+        k_base++;
+      }
+      
+      // extra parts for p and n
+      values_[k] = MJacS[k] = -1.0;
+      k++;
+      values_[k] = MJacS[k] =  1.0;
+      k++;
+    }
+
+    // Jac for d(x) - p + n
+    const double* J_d_val = J_d.M();
+    for(int i = 0; i < m_d; ++i) {
+      int k_base = J_d.row_starts_->idx_start_[i];
+      int nnz_in_row = J_d.row_starts_->idx_start_[i+1] - k_base;
+    
+      // copy from base Jac_d
+      while(k_base < J_d.row_starts_->idx_start_[i+1]) {
+        values_[k] = MJacS[k] = J_d_val[k_base];
+        k++;
+        k_base++;
+      }
+      
+      // extra parts for p and n
+      values_[k] = MJacS[k] = -1.0;
+      k++;
+      values_[k] = MJacS[k] =  1.0;
+      k++;
+    }
+    assert(k == nnz_);
+  }
+}
 
 /**********************************************************************************
   * Sparse symmetric matrix in triplet format. Only the lower triangle is stored
@@ -985,7 +1123,7 @@ void hiopMatrixSparseTriplet::setSubmatrixToConstantDiag_w_rowpattern(const doub
 }
 
 
-long long hiopMatrixSymSparseTriplet::numberOfOffDiagNonzeros()
+long long hiopMatrixSymSparseTriplet::numberOfOffDiagNonzeros() const
 {
   if(-1==nnz_offdiag_){
     nnz_offdiag_= nnz_;
@@ -1137,6 +1275,102 @@ void hiopMatrixSparseTriplet::convertToCSR(int &csr_nnz,
   delete [] diag_defined; diag_defined = nullptr;
   delete [] index_covert_extra_Diag2CSR_temp; index_covert_extra_Diag2CSR_temp = nullptr;
 
+}
+
+/*
+*  extend original Jac to [Jac -I I]
+*/
+void hiopMatrixSymSparseTriplet::set_Hess_FR(const hiopMatrixSparse& Hess,
+                                             int* iHSS,
+                                             int* jHSS,
+                                             double* MHSS,
+                                             const hiopVector& add_diag)
+{
+  const auto& Hess_base = dynamic_cast<const hiopMatrixSymSparseTriplet&>(Hess);
+
+  // assuming original Hess is sorted, and in upper-triangle format
+  int nnz_h = Hess_base.numberOfNonzeros();
+
+  int m_h = Hess.m();
+  int n_h = Hess.n();
+  assert(n_h == m_h);
+
+  int nnz_h_FR = n_h + Hess_base.numberOfOffDiagNonzeros() ;
+
+  assert(nnz_ == nnz_h_FR);
+  
+  if(Hess_base.row_starts_ == nullptr){
+    Hess_base.row_starts_ = Hess_base.allocAndBuildRowStarts();
+  }
+  assert(Hess_base.row_starts_);
+
+  // extend Hess to the p and n parts --- sparsity
+  // sparsity may change due to te new obj term zeta*DR^2.*(x-x_ref)
+  if(iHSS != nullptr && jHSS != nullptr) {
+    int k = 0;
+  
+    const int* Hess_col = Hess_base.j_col();
+    for(int i = 0; i < m_h; ++i) {
+      int k_base = Hess_base.row_starts_->idx_start_[i];
+      int nnz_in_row = Hess_base.row_starts_->idx_start_[i+1] - k_base;
+    
+      // insert diagonal entry due to the new obj term
+      iRow_[k] = iHSS[k] = i;
+      jCol_[k] = jHSS[k] = i;
+      k++;
+      
+      if(nnz_in_row > 0 && iHSS[k_base] == jHSS[k_base]) {
+        // first nonzero in this row is a diagonal term 
+        // skip it since we have already defined the diagonal nonezero
+        k_base++;
+      }
+
+      // copy from base Hess
+      while(k_base < Hess_base.row_starts_->idx_start_[i+1]) {
+        iRow_[k] = iHSS[k] = i;
+        jCol_[k] = jHSS[k] = Hess_col[k_base];
+        k++;
+        k_base++;
+      }
+    }
+    assert(k == nnz_);
+  }
+  
+  // extend Hess to the p and n parts --- element
+  if(MHSS != nullptr) {    
+    int k = 0;
+  
+    const double* Hess_val = Hess_base.M();
+    const hiopVectorPar& diag_x = dynamic_cast<const hiopVectorPar&>(add_diag);
+    assert(m_h == diag_x.get_size());
+    const double* diag_data = diag_x.local_data_const();
+
+    for(int i = 0; i < m_h; ++i) {
+      int k_base = Hess_base.row_starts_->idx_start_[i];
+      int nnz_in_row = Hess_base.row_starts_->idx_start_[i+1] - k_base;
+    
+      // add diagonal entry due to the new obj term
+      values_[k] = MHSS[k] = diag_data[k];
+      
+      if(nnz_in_row > 0 && iHSS[k_base] == jHSS[k_base]) {
+        // first nonzero in this row is a diagonal term 
+        // add this element to the existing diag term
+        values_[k] += Hess_val[k_base];
+        MHSS[k] = values_[k];
+        k++;
+        k_base++;
+      }
+      k++;
+
+      // copy off-diag entries from base Hess
+      while(k_base < Hess_base.row_starts_->idx_start_[i+1]) {
+        values_[k] = MHSS[k] = Hess_val[k_base];
+        k++;
+        k_base++;
+      }
+    }
+    assert(k == nnz_);
+  }
 }
 
 

--- a/src/LinAlg/hiopMatrixSparseTriplet.cpp
+++ b/src/LinAlg/hiopMatrixSparseTriplet.cpp
@@ -1309,6 +1309,7 @@ void hiopMatrixSymSparseTriplet::set_Hess_FR(const hiopMatrixSparse& Hess,
   if(iHSS != nullptr && jHSS != nullptr) {
     int k = 0;
   
+    const int* Hess_row = Hess_base.i_row();
     const int* Hess_col = Hess_base.j_col();
     for(int i = 0; i < m_h; ++i) {
       int k_base = Hess_base.row_starts_->idx_start_[i];
@@ -1319,7 +1320,7 @@ void hiopMatrixSymSparseTriplet::set_Hess_FR(const hiopMatrixSparse& Hess,
       jCol_[k] = jHSS[k] = i;
       k++;
       
-      if(nnz_in_row > 0 && iHSS[k_base] == jHSS[k_base]) {
+      if(nnz_in_row > 0 && Hess_row[k_base] == Hess_col[k_base]) {
         // first nonzero in this row is a diagonal term 
         // skip it since we have already defined the diagonal nonezero
         k_base++;
@@ -1340,6 +1341,8 @@ void hiopMatrixSymSparseTriplet::set_Hess_FR(const hiopMatrixSparse& Hess,
   if(MHSS != nullptr) {    
     int k = 0;
   
+    const int* Hess_row = Hess_base.i_row();
+    const int* Hess_col = Hess_base.j_col();
     const double* Hess_val = Hess_base.M();
     const hiopVectorPar& diag_x = dynamic_cast<const hiopVectorPar&>(add_diag);
     assert(m_h == diag_x.get_size());
@@ -1352,12 +1355,11 @@ void hiopMatrixSymSparseTriplet::set_Hess_FR(const hiopMatrixSparse& Hess,
       // add diagonal entry due to the new obj term
       values_[k] = MHSS[k] = diag_data[k];
       
-      if(nnz_in_row > 0 && iHSS[k_base] == jHSS[k_base]) {
+      if(nnz_in_row > 0 && Hess_row[k_base] == Hess_col[k_base]) {
         // first nonzero in this row is a diagonal term 
         // add this element to the existing diag term
         values_[k] += Hess_val[k_base];
         MHSS[k] = values_[k];
-        k++;
         k_base++;
       }
       k++;

--- a/src/LinAlg/hiopMatrixSparseTriplet.hpp
+++ b/src/LinAlg/hiopMatrixSparseTriplet.hpp
@@ -230,7 +230,18 @@ public:
                             int **index_covert_extra_Diag2CSR,
                             std::unordered_map<int,int> &extra_diag_nnz_map);
 
-  virtual long long numberOfOffDiagNonzeros() {assert("not implemented"&&0);return 0;};
+  virtual long long numberOfOffDiagNonzeros() const {assert("not implemented"&&0);return 0;};
+  virtual void set_Jac_FR(const hiopMatrixSparse& Jac_c,
+                          const hiopMatrixSparse& Jac_d,
+                          int* iJacS,
+                          int* jJacS,
+                          double* MJacS);
+
+  virtual void set_Hess_FR(const hiopMatrixSparse& Hess,
+                           int* iHSS,
+                           int* jHSS,
+                           double* MHSS,
+                           const hiopVector& add_diag) {assert("not implemented"&&0);}
 
   virtual hiopMatrixSparse* alloc_clone() const;
   virtual hiopMatrixSparse* new_copy() const;
@@ -270,7 +281,7 @@ protected:
     }
   };
   mutable RowStartsInfo* row_starts_;
-private:
+protected:
   RowStartsInfo* allocAndBuildRowStarts() const;
 private:
   hiopMatrixSparseTriplet()
@@ -335,10 +346,22 @@ public:
     return true;
   }
 
-  virtual long long numberOfOffDiagNonzeros();
+  virtual long long numberOfOffDiagNonzeros() const;
+
+  virtual void set_Jac_FR(const hiopMatrixSparse& Jac_c,
+                          const hiopMatrixSparse& Jac_d,
+                          int* iJacS,
+                          int* jJacS,
+                          double* MJacS){assert("not implemented"&&0);};
+
+  virtual void set_Hess_FR(const hiopMatrixSparse& Hess,
+                           int* iHSS,
+                           int* jHSS,
+                           double* MHSS,
+                           const hiopVector& add_diag);
 
 protected:
-  int nnz_offdiag_;     ///< number of nonzero entries
+  mutable int nnz_offdiag_;     ///< number of nonzero entries
 
 };
 

--- a/src/LinAlg/hiopVector.hpp
+++ b/src/LinAlg/hiopVector.hpp
@@ -50,6 +50,7 @@
 
 #include <cstdio>
 #include <cassert>
+#include "hiopInterface.hpp"
 
 namespace hiop
 {
@@ -256,6 +257,16 @@ public:
   /// @brief get number of values whose absolute value are less than the given value 'val'
   virtual long long numOfElemsAbsLessThan(const double &val) const = 0;  
 
+  /// @brief set int array 'arr', starting at `start` and ending at `end`, to the values in `arr_src` from 'start_src`
+  virtual void set_array_from_to(hiopInterfaceBase::NonlinearityType* arr, 
+                                 const int start, 
+                                 const int end, 
+                                 const hiopInterfaceBase::NonlinearityType* arr_src,
+                                 const int start_src) const = 0;
+  virtual void set_array_from_to(hiopInterfaceBase::NonlinearityType* arr, 
+                                 const int start, 
+                                 const int end, 
+                                 const hiopInterfaceBase::NonlinearityType arr_src) const = 0;
 protected:
   long long n_; //we assume sequential data
 

--- a/src/LinAlg/hiopVector.hpp
+++ b/src/LinAlg/hiopVector.hpp
@@ -51,6 +51,7 @@
 #include <cstdio>
 #include <cassert>
 #include "hiopInterface.hpp"
+#include "hiopVectorInt.hpp"
 
 namespace hiop
 {
@@ -99,6 +100,18 @@ public:
   /// @brief Copy the entries in 'this' where corresponding 'ix' is nonzero, to v starting at start_index in 'v'.
   virtual void copyToStartingAt_w_pattern(hiopVector& v, int start_index_in_dest, const hiopVector& ix) const = 0;
   
+  /// @brief Copy the entries in `c` and `d` to `this`, according to the mapping in `c_map` and `d_map`
+  virtual void copy_from_two_vec_w_pattern(const hiopVector& c, 
+                                           const hiopVectorInt& c_map, 
+                                           const hiopVector& d, 
+                                           const hiopVectorInt& d_map) = 0;
+
+  /// @brief Copy the entries in `this` to `c` and `d`, according to the mapping `c_map` and `d_map`
+  virtual void copy_to_two_vec_w_pattern(hiopVector& c, 
+                                         const hiopVectorInt& c_map, 
+                                         hiopVector& d, 
+                                         const hiopVectorInt& d_map) const = 0;
+
   /**
    * copy 'this' (source) starting at 'start_idx_in_src' to 'dest' starting at index 'int start_idx_dest' 
    * If num_elems>=0, 'num_elems' will be copied; if num_elems<0, elements will be copied till the end of

--- a/src/LinAlg/hiopVectorInt.hpp
+++ b/src/LinAlg/hiopVectorInt.hpp
@@ -57,23 +57,32 @@
 
 namespace hiop
 {
+typedef long long hiopInt;
 
 class hiopVectorInt
 {
 protected:
-  int sz_;
+  hiopInt sz_;
 
 public:
-  hiopVectorInt(int sz) : sz_(sz) { }
+  hiopVectorInt(hiopInt sz) : sz_(sz) { }
   virtual ~hiopVectorInt() { }
 
-  virtual int size() const
+  virtual hiopInt size() const
   {
     return sz_;
   }
 
-  virtual const int& operator[] (int i) const = 0;
-  virtual int& operator[] (int i) = 0;
+  virtual hiopInt* local_data() = 0;
+  virtual const hiopInt* local_data_const() const = 0;
+  virtual hiopInt* local_data_host() = 0;
+  virtual const hiopInt* local_data_host_const() const = 0;
+
+  virtual void copyToDev() const = 0;
+  virtual void copyFromDev() const = 0;
+  
+  virtual const hiopInt& operator[] (hiopInt i) const = 0;
+  virtual hiopInt& operator[] (hiopInt i) = 0;
 };
 
 } // namespace hiop

--- a/src/LinAlg/hiopVectorIntRaja.cpp
+++ b/src/LinAlg/hiopVectorIntRaja.cpp
@@ -94,7 +94,7 @@ hiopVectorIntRaja::~hiopVectorIntRaja()
   buf_ = nullptr;
 }
 
-const int& hiopVectorIntRaja::operator[] (int i) const
+const hiopInt& hiopVectorIntRaja::operator[] (hiopInt i) const
 {
   return buf_host_[i];
 }

--- a/src/LinAlg/hiopVectorIntRaja.cpp
+++ b/src/LinAlg/hiopVectorIntRaja.cpp
@@ -58,7 +58,7 @@
 namespace hiop
 {
 
-hiopVectorIntRaja::hiopVectorIntRaja(int sz, std::string mem_space)
+hiopVectorIntRaja::hiopVectorIntRaja(hiopInt sz, std::string mem_space)
   : hiopVectorInt(sz)
   , mem_space_(mem_space)
 {
@@ -68,11 +68,11 @@ hiopVectorIntRaja::hiopVectorIntRaja(int sz, std::string mem_space)
 
   auto& resmgr = umpire::ResourceManager::getInstance();
   umpire::Allocator devalloc = resmgr.getAllocator(mem_space_);
-  buf_ = static_cast<int*>(devalloc.allocate(sz_*sizeof(int)));
+  buf_ = static_cast<hiopInt*>(devalloc.allocate(sz_*sizeof(hiopInt)));
   if(mem_space_ == "DEVICE")
   {
     umpire::Allocator hostalloc = resmgr.getAllocator("HOST");
-    buf_host_ = static_cast<int*>(hostalloc.allocate(sz_*sizeof(int)));
+    buf_host_ = static_cast<hiopInt*>(hostalloc.allocate(sz_*sizeof(hiopInt)));
   }
   else
   {
@@ -99,7 +99,7 @@ const int& hiopVectorIntRaja::operator[] (int i) const
   return buf_host_[i];
 }
 
-int& hiopVectorIntRaja::operator[] (int i)
+hiopInt& hiopVectorIntRaja::operator[] (hiopInt i)
 {
   return buf_host_[i];
 }

--- a/src/LinAlg/hiopVectorIntRaja.hpp
+++ b/src/LinAlg/hiopVectorIntRaja.hpp
@@ -67,13 +67,8 @@ namespace hiop
 class hiopVectorIntRaja : public hiopVectorInt
 {
 private:
-<<<<<<< HEAD
-  int *buf_host_;
-  int *buf_;
-=======
   hiopInt *buf_host_;
-  hiopInt *buf_dev_;
->>>>>>> fix issue 233
+  hiopInt *buf_;
   std::string mem_space_;
 
 public:
@@ -111,9 +106,9 @@ public:
 
   inline const hiopInt* local_data_host_const() const { return buf_host_; }
 
-  inline hiopInt* local_data() { return buf_dev_; }
+  inline hiopInt* local_data() { return buf_; }
 
-  inline const hiopInt* local_data_const() const { return buf_dev_; }
+  inline const hiopInt* local_data_const() const { return buf_; }
 
 };
 

--- a/src/LinAlg/hiopVectorIntRaja.hpp
+++ b/src/LinAlg/hiopVectorIntRaja.hpp
@@ -67,12 +67,17 @@ namespace hiop
 class hiopVectorIntRaja : public hiopVectorInt
 {
 private:
+<<<<<<< HEAD
   int *buf_host_;
   int *buf_;
+=======
+  hiopInt *buf_host_;
+  hiopInt *buf_dev_;
+>>>>>>> fix issue 233
   std::string mem_space_;
 
 public:
-  hiopVectorIntRaja(int sz, std::string mem_space="HOST");
+  hiopVectorIntRaja(hiopInt sz, std::string mem_space="HOST");
 
   ~hiopVectorIntRaja();
 
@@ -80,13 +85,13 @@ public:
    * @brief Access constant data at element _i_ on the _host_. To access data
    * on the device, you must first call _copyFromDev_.
    */
-  const int& operator[] (int i) const override;
+  const hiopInt& operator[] (hiopInt i) const override;
 
   /**
    * @brief Access data at element _i_ on the _host_. To access data on the
    * device, you must first call _copyFromDev_.
    */
-  int& operator[] (int i) override;
+  hiopInt& operator[] (hiopInt i) override;
 
   /**
    * @brief Copy array data from the device.
@@ -101,6 +106,14 @@ public:
    * @note This is a no-op if the memory space is _host_ or _uvm_.
    */
   void copyToDev() const;
+
+  inline hiopInt* local_data_host() { return buf_host_; }
+
+  inline const hiopInt* local_data_host_const() const { return buf_host_; }
+
+  inline hiopInt* local_data() { return buf_dev_; }
+
+  inline const hiopInt* local_data_const() const { return buf_dev_; }
 
 };
 

--- a/src/LinAlg/hiopVectorIntSeq.cpp
+++ b/src/LinAlg/hiopVectorIntSeq.cpp
@@ -58,9 +58,9 @@
 namespace hiop
 {
 
-hiopVectorIntSeq::hiopVectorIntSeq(int sz) : hiopVectorInt(sz)
+hiopVectorIntSeq::hiopVectorIntSeq(hiopInt sz) : hiopVectorInt(sz)
 {
-  buf_ = new int[sz_];
+  buf_ = new hiopInt[sz_];
 }
 
 hiopVectorIntSeq::~hiopVectorIntSeq()
@@ -68,12 +68,12 @@ hiopVectorIntSeq::~hiopVectorIntSeq()
   delete[] buf_;
 }
 
-const int& hiopVectorIntSeq::operator[] (int i) const
+const hiopInt& hiopVectorIntSeq::operator[] (hiopInt i) const
 {
   return buf_[i];
 }
 
-int& hiopVectorIntSeq::operator[] (int i)
+hiopInt& hiopVectorIntSeq::operator[] (hiopInt i)
 {
   return buf_[i];
 }

--- a/src/LinAlg/hiopVectorIntSeq.hpp
+++ b/src/LinAlg/hiopVectorIntSeq.hpp
@@ -63,16 +63,28 @@ namespace hiop
 class hiopVectorIntSeq : public hiopVectorInt
 {
 private:
-  int *buf_;
+  hiopInt *buf_;
 
 public:
-  hiopVectorIntSeq(int sz);
+  hiopVectorIntSeq(hiopInt sz);
+  ~hiopVectorIntSeq() {delete [] buf_;}
 
   ~hiopVectorIntSeq();
 
-  const int& operator[] (int i) const override;
+  virtual void copyToDev() const {}
+  virtual void copyFromDev() const {}
 
-  int& operator[] (int i) override;
+  virtual hiopInt* local_data() { return buf_; }
+
+  virtual const hiopInt* local_data_const() const { return buf_; }
+
+  virtual inline hiopInt* local_data_host() { return local_data(); }
+
+  virtual inline const hiopInt* local_data_host_const() const { return local_data_const(); }
+
+  const hiopInt& operator[] (hiopInt i) const override;
+
+  hiopInt& operator[] (hiopInt i) override;
 };
 
 } // namespace hiop

--- a/src/LinAlg/hiopVectorIntSeq.hpp
+++ b/src/LinAlg/hiopVectorIntSeq.hpp
@@ -67,7 +67,6 @@ private:
 
 public:
   hiopVectorIntSeq(hiopInt sz);
-  ~hiopVectorIntSeq() {delete [] buf_;}
 
   ~hiopVectorIntSeq();
 

--- a/src/LinAlg/hiopVectorPar.cpp
+++ b/src/LinAlg/hiopVectorPar.cpp
@@ -1010,4 +1010,38 @@ long long hiopVectorPar::numOfElemsAbsLessThan(const double &val) const
   return ret_num;
 }
 
+void hiopVectorPar::set_array_from_to(hiopInterfaceBase::NonlinearityType* arr, 
+                                      const int start, 
+                                      const int end, 
+                                      const hiopInterfaceBase::NonlinearityType* arr_src,
+                                      const int start_src) const
+{
+  assert(end <= n_local_ && start <= end && start >= 0 && start_src >= 0);
+
+  // If there is nothing to copy, return.
+  if(end - start == 0)
+    return;
+
+  memcpy(arr+start, arr_src+start_src, (end-start)*sizeof(hiopInterfaceBase::NonlinearityType));
+}
+
+void hiopVectorPar::set_array_from_to(hiopInterfaceBase::NonlinearityType* arr, 
+                                      const int start, 
+                                      const int end, 
+                                      const hiopInterfaceBase::NonlinearityType arr_src) const
+{
+  assert(end <= n_local_ && start <= end);
+
+  // If there is nothing to copy, return.
+  if(end - start == 0)
+    return;
+
+  for(int i=start; i<end; i++) {
+    arr[i] = arr_src;
+  }
+}
+
+
+
+
 };

--- a/src/LinAlg/hiopVectorPar.cpp
+++ b/src/LinAlg/hiopVectorPar.cpp
@@ -213,6 +213,65 @@ void hiopVectorPar::copyToStartingAt_w_pattern(hiopVector& v_, int start_index/*
   assert(find_nnz + start_index <= v.n_local_);
 }
 
+/* copy 'c' and `d` into `this`, according to the map 'c_map` and `d_map`, respectively.
+*  e.g., this[c_map[i]] = c[i];
+*
+*  @pre: the size of `this` = the size of `c` + the size of `d`.
+*  @pre: `c_map` \Union `d_map` = {0, ..., size_of_this_vec-1}
+*/
+void hiopVectorPar::copy_from_two_vec_w_pattern(const hiopVector& c, 
+                                                const hiopVectorInt& c_map, 
+                                                const hiopVector& d, 
+                                                const hiopVectorInt& d_map)
+{
+  const double* c_arr = c.local_data_const();
+  const double* d_arr = d.local_data_const();
+  double* arr = local_data();
+  const int c_size = c.get_size();
+  assert( c_size == c_map.size() );
+  const int d_size = d.get_size();
+  assert( d_size == d_map.size() );
+  assert( c_size + d_size == n_local_);
+
+  //concatanate multipliers -> copy into whole lambda array 
+  for(int i=0; i<c_size; ++i) {
+    arr[c_map[i]] = c_arr[i];
+  }
+  for(int i=0; i<d_size; ++i) {
+    arr[d_map[i]] = d_arr[i];
+  }                                               
+}
+
+/* split `this` to `c` and `d`, according to the map 'c_map` and `d_map`, respectively.
+*
+*  @pre: the size of `this` = the size of `c` + the size of `d`.
+*  @pre: `c_map` \Union `d_map` = {0, ..., size_of_this_vec-1}
+*/
+void hiopVectorPar::copy_to_two_vec_w_pattern(hiopVector& c, 
+                                              const hiopVectorInt& c_map, 
+                                              hiopVector& d, 
+                                              const hiopVectorInt& d_map) const
+{
+  double* c_arr = c.local_data();
+  double* d_arr = d.local_data();
+  const double* arr = local_data_const();
+  const int c_size = c.get_size();
+  assert( c_size == c_map.size() );
+  const int d_size = d.get_size();
+  assert( d_size == d_map.size() );
+  assert( c_size + d_size == n_local_);
+
+  //concatanate multipliers -> copy into whole lambda array 
+  for(int i=0; i<c_size; ++i) {
+    c_arr[i] = arr[c_map[i]];
+  }
+  for(int i=0; i<d_size; ++i) {
+    d_arr[i] = arr[d_map[i]];
+  }                                               
+}
+
+
+
 /* copy 'this' (source) starting at 'start_idx_in_src' to 'dest' starting at index 'int start_idx_dest' 
  * If num_elems>=0, 'num_elems' will be copied; if num_elems<0, elements will be copied till the end of
  * either source ('this') or destination ('dest') is reached */

--- a/src/LinAlg/hiopVectorPar.hpp
+++ b/src/LinAlg/hiopVectorPar.hpp
@@ -51,6 +51,7 @@
 #include <string>
 #include <hiopMPI.hpp>
 #include "hiopVector.hpp"
+#include "hiopVectorInt.hpp"
 
 #include <cstdio>
 
@@ -96,6 +97,18 @@ public:
   virtual void copyToStarting(hiopVector& v, int start_index_in_dest) const;
   /// @brief Copy the entries in 'this' where corresponding 'ix' is nonzero, to v starting at start_index in 'v'.
   virtual void copyToStartingAt_w_pattern(hiopVector& v, int start_index_in_dest, const hiopVector& ix) const;
+
+  /// @brief Copy the entries in `c` and `d` to `this`, according to the mapping in `c_map` and `d_map`
+  virtual void copy_from_two_vec_w_pattern(const hiopVector& c, 
+                                           const hiopVectorInt& c_map, 
+                                           const hiopVector& d, 
+                                           const hiopVectorInt& d_map);
+
+  /// @brief Copy the entries in `this` to `c` and `d`, according to the mapping `c_map` and `d_map`
+  virtual void copy_to_two_vec_w_pattern(hiopVector& c, 
+                                         const hiopVectorInt& c_map, 
+                                         hiopVector& d, 
+                                         const hiopVectorInt& d_map) const;
 
   /**
    * @brief copy 'this' (source) starting at 'start_idx_in_src' to 'dest' starting at index 'start_idx_dest' 

--- a/src/LinAlg/hiopVectorPar.hpp
+++ b/src/LinAlg/hiopVectorPar.hpp
@@ -209,6 +209,16 @@ public:
   virtual long long numOfElemsLessThan(const double &val) const;
   virtual long long numOfElemsAbsLessThan(const double &val) const;    
 
+  virtual void set_array_from_to(hiopInterfaceBase::NonlinearityType* arr, 
+                                 const int start, 
+                                 const int end, 
+                                 const hiopInterfaceBase::NonlinearityType* arr_src,
+                                 const int start_src) const;
+  virtual void set_array_from_to(hiopInterfaceBase::NonlinearityType* arr, 
+                                 const int start, 
+                                 const int end, 
+                                 const hiopInterfaceBase::NonlinearityType arr_src) const;
+ 
 protected:
   MPI_Comm comm_;
   double* data_;

--- a/src/LinAlg/hiopVectorRajaPar.cpp
+++ b/src/LinAlg/hiopVectorRajaPar.cpp
@@ -56,6 +56,7 @@
  *
  */
 #include "hiopVectorRajaPar.hpp"
+#include "hiopVectorIntRaja.hpp"
 
 #include <cmath>
 #include <cstring> //for memcpy
@@ -486,12 +487,44 @@ void hiopVectorRajaPar::copyToStartingAt_w_pattern(hiopVector& vec, int start_in
 *  @pre: the size of `this` = the size of `c` + the size of `d`.
 *  @pre: `c_map` \Union `d_map` = {0, ..., size_of_this_vec-1}
 */
-void hiopVectorRajaPar::copy_from_two_vec_w_pattern(const hiopVector& c, 
-                                                const hiopVectorInt& c_map, 
-                                                const hiopVector& d, 
-                                                const hiopVectorInt& d_map)
+void hiopVectorRajaPar::copy_from_two_vec_w_pattern(const hiopVector& c,
+                                                    const hiopVectorInt& c_map,
+                                                    const hiopVector& d,
+                                                    const hiopVectorInt& d_map)
 {
-  assert("not yet" && 0);
+  const hiopVectorRajaPar& v1 = dynamic_cast<const hiopVectorRajaPar&>(c);
+  const hiopVectorRajaPar& v2 = dynamic_cast<const hiopVectorRajaPar&>(d);
+  const hiopVectorIntRaja& ix1 = dynamic_cast<const hiopVectorIntRaja&>(c_map);
+  const hiopVectorIntRaja& ix2 = dynamic_cast<const hiopVectorIntRaja&>(d_map);
+  
+  hiopInt n1_local = v1.n_local;
+  hiopInt n2_local = v2.n_local;
+
+#ifdef HIOP_DEEPCHECKS
+  assert(n1_local + n2_local == n_local_);
+  assert(n_local_ == ix1.size() + ix2.size());
+#endif
+  double*   dd = data_dev_;
+  double*  vd1 = v1.data_dev_;
+  double*  vd2 = v2.data_dev_;
+  hiopInt* id1 = ix1.buf_dev_;
+  hiopInt* id2 = ix2.buf_dev_;
+  
+  RAJA::forall< hiop_raja_exec >(
+    RAJA::RangeSegment(0, n1_local),
+    RAJA_LAMBDA(RAJA::Index_type i)
+    {
+      dd[id1[i]] = vd1[i];
+    }
+  );
+
+  RAJA::forall< hiop_raja_exec >(
+    RAJA::RangeSegment(0, n2_local),
+    RAJA_LAMBDA(RAJA::Index_type i)
+    {
+      dd[id2[i]] = vd2[i];
+    }
+  );
 }
 
 /* split `this` to `c` and `d`, according to the map 'c_map` and `d_map`, respectively.
@@ -499,12 +532,44 @@ void hiopVectorRajaPar::copy_from_two_vec_w_pattern(const hiopVector& c,
 *  @pre: the size of `this` = the size of `c` + the size of `d`.
 *  @pre: `c_map` \Union `d_map` = {0, ..., size_of_this_vec-1}
 */
-void hiopVectorRajaPar::copy_to_two_vec_w_pattern(hiopVector& c, 
-                                              const hiopVectorInt& c_map, 
-                                              hiopVector& d, 
-                                              const hiopVectorInt& d_map) const
+void hiopVectorRajaPar::copy_to_two_vec_w_pattern(hiopVector& c,
+                                                  const hiopVectorInt& c_map,
+                                                  hiopVector& d,
+                                                  const hiopVectorInt& d_map) const
 {
-  assert("not yet" && 0);                                              
+  const hiopVectorRajaPar& v1 = dynamic_cast<const hiopVectorRajaPar&>(c);
+  const hiopVectorRajaPar& v2 = dynamic_cast<const hiopVectorRajaPar&>(d);
+  const hiopVectorIntRaja& ix1 = dynamic_cast<const hiopVectorIntRaja&>(c_map);
+  const hiopVectorIntRaja& ix2 = dynamic_cast<const hiopVectorIntRaja&>(d_map);
+  
+  hiopInt n1_local = v1.n_local;
+  hiopInt n2_local = v2.n_local;
+
+#ifdef HIOP_DEEPCHECKS
+  assert(n1_local + n2_local == n_local_);
+  assert(n_local_ == ix1.size() + ix2.size());
+#endif
+  double*   dd = data_dev_;
+  double*  vd1 = v1.data_dev_;
+  double*  vd2 = v2.data_dev_;
+  hiopInt* id1 = ix1.buf_dev_;
+  hiopInt* id2 = ix2.buf_dev_;
+  
+  RAJA::forall< hiop_raja_exec >(
+    RAJA::RangeSegment(0, n1_local),
+    RAJA_LAMBDA(RAJA::Index_type i)
+    {
+      vd1[i] = dd[id1[i]];
+    }
+  );
+
+  RAJA::forall< hiop_raja_exec >(
+    RAJA::RangeSegment(0, n2_local),
+    RAJA_LAMBDA(RAJA::Index_type i)
+    {
+      vd2[i] = dd[id2[i]];
+    }
+  );                                           
 }
 
 /**

--- a/src/LinAlg/hiopVectorRajaPar.cpp
+++ b/src/LinAlg/hiopVectorRajaPar.cpp
@@ -497,8 +497,8 @@ void hiopVectorRajaPar::copy_from_two_vec_w_pattern(const hiopVector& c,
   const hiopVectorIntRaja& ix1 = dynamic_cast<const hiopVectorIntRaja&>(c_map);
   const hiopVectorIntRaja& ix2 = dynamic_cast<const hiopVectorIntRaja&>(d_map);
   
-  hiopInt n1_local = v1.n_local;
-  hiopInt n2_local = v2.n_local;
+  hiopInt n1_local = v1.size();
+  hiopInt n2_local = v2.size();
 
 #ifdef HIOP_DEEPCHECKS
   assert(n1_local + n2_local == n_local_);
@@ -507,8 +507,8 @@ void hiopVectorRajaPar::copy_from_two_vec_w_pattern(const hiopVector& c,
   double*   dd = data_dev_;
   double*  vd1 = v1.data_dev_;
   double*  vd2 = v2.data_dev_;
-  hiopInt* id1 = ix1.buf_dev_;
-  hiopInt* id2 = ix2.buf_dev_;
+  const hiopInt* id1 = ix1.local_data_const();
+  const hiopInt* id2 = ix2.local_data_const();
   
   RAJA::forall< hiop_raja_exec >(
     RAJA::RangeSegment(0, n1_local),
@@ -552,8 +552,8 @@ void hiopVectorRajaPar::copy_to_two_vec_w_pattern(hiopVector& c,
   double*   dd = data_dev_;
   double*  vd1 = v1.data_dev_;
   double*  vd2 = v2.data_dev_;
-  hiopInt* id1 = ix1.buf_dev_;
-  hiopInt* id2 = ix2.buf_dev_;
+  const hiopInt* id1 = ix1.local_data_const();
+  const hiopInt* id2 = ix2.local_data_const();
   
   RAJA::forall< hiop_raja_exec >(
     RAJA::RangeSegment(0, n1_local),

--- a/src/LinAlg/hiopVectorRajaPar.cpp
+++ b/src/LinAlg/hiopVectorRajaPar.cpp
@@ -510,8 +510,11 @@ void hiopVectorRajaPar::copy_from_two_vec_w_pattern(const hiopVector& c,
   const hiopInt* id1 = ix1.local_data_const();
   const hiopInt* id2 = ix2.local_data_const();
   
+  int n1_local_int = (int) n1_local;
+  int n2_local_int = (int) n2_local
+
   RAJA::forall< hiop_raja_exec >(
-    RAJA::RangeSegment(0, (int)n1_local),
+    RAJA::RangeSegment(0, n1_local_int),
     RAJA_LAMBDA(RAJA::Index_type i)
     {
       int idx = id1[i];
@@ -520,7 +523,7 @@ void hiopVectorRajaPar::copy_from_two_vec_w_pattern(const hiopVector& c,
   );
 
   RAJA::forall< hiop_raja_exec >(
-    RAJA::RangeSegment(0, (int)n2_local),
+    RAJA::RangeSegment(0, n2_local_int),
     RAJA_LAMBDA(RAJA::Index_type i)
     {
       int idx = id2[i];

--- a/src/LinAlg/hiopVectorRajaPar.cpp
+++ b/src/LinAlg/hiopVectorRajaPar.cpp
@@ -480,6 +480,33 @@ void hiopVectorRajaPar::copyToStartingAt_w_pattern(hiopVector& vec, int start_in
 #endif    
 }
 
+/* copy 'c' and `d` into `this`, according to the map 'c_map` and `d_map`, respectively.
+*  e.g., this[c_map[i]] = c[i];
+*
+*  @pre: the size of `this` = the size of `c` + the size of `d`.
+*  @pre: `c_map` \Union `d_map` = {0, ..., size_of_this_vec-1}
+*/
+void hiopVectorRajaPar::copy_from_two_vec_w_pattern(const hiopVector& c, 
+                                                const hiopVectorInt& c_map, 
+                                                const hiopVector& d, 
+                                                const hiopVectorInt& d_map)
+{
+  assert("not yet" && 0);
+}
+
+/* split `this` to `c` and `d`, according to the map 'c_map` and `d_map`, respectively.
+*
+*  @pre: the size of `this` = the size of `c` + the size of `d`.
+*  @pre: `c_map` \Union `d_map` = {0, ..., size_of_this_vec-1}
+*/
+void hiopVectorRajaPar::copy_to_two_vec_w_pattern(hiopVector& c, 
+                                              const hiopVectorInt& c_map, 
+                                              hiopVector& d, 
+                                              const hiopVectorInt& d_map) const
+{
+  assert("not yet" && 0);                                              
+}
+
 /**
  * @brief Copy elements of `this` vector to `destination` with offsets.
  * 

--- a/src/LinAlg/hiopVectorRajaPar.cpp
+++ b/src/LinAlg/hiopVectorRajaPar.cpp
@@ -511,10 +511,10 @@ void hiopVectorRajaPar::copy_from_two_vec_w_pattern(const hiopVector& c,
   const hiopInt* id2 = ix2.local_data_const();
   
   RAJA::forall< hiop_raja_exec >(
-    RAJA::RangeSegment(0, n1_local),
+    RAJA::RangeSegment(0, (int)n1_local),
     RAJA_LAMBDA(RAJA::Index_type i)
     {
-      dd[id1[i]] = vd1[i];
+      dd[(int)id1[i]] = vd1[i];
     }
   );
 
@@ -522,7 +522,7 @@ void hiopVectorRajaPar::copy_from_two_vec_w_pattern(const hiopVector& c,
     RAJA::RangeSegment(0, n2_local),
     RAJA_LAMBDA(RAJA::Index_type i)
     {
-      dd[id2[i]] = vd2[i];
+      dd[(int)id2[i]] = vd2[i];
     }
   );
 }
@@ -556,18 +556,18 @@ void hiopVectorRajaPar::copy_to_two_vec_w_pattern(hiopVector& c,
   const hiopInt* id2 = ix2.local_data_const();
   
   RAJA::forall< hiop_raja_exec >(
-    RAJA::RangeSegment(0, n1_local),
+    RAJA::RangeSegment(0, (int)n1_local),
     RAJA_LAMBDA(RAJA::Index_type i)
     {
-      vd1[i] = dd[id1[i]];
+      vd1[i] = dd[(int)id1[i]];
     }
   );
 
   RAJA::forall< hiop_raja_exec >(
-    RAJA::RangeSegment(0, n2_local),
+    RAJA::RangeSegment(0, (int)n2_local),
     RAJA_LAMBDA(RAJA::Index_type i)
     {
-      vd2[i] = dd[id2[i]];
+      vd2[i] = dd[(int)id2[i]];
     }
   );                                           
 }

--- a/src/LinAlg/hiopVectorRajaPar.cpp
+++ b/src/LinAlg/hiopVectorRajaPar.cpp
@@ -514,15 +514,17 @@ void hiopVectorRajaPar::copy_from_two_vec_w_pattern(const hiopVector& c,
     RAJA::RangeSegment(0, (int)n1_local),
     RAJA_LAMBDA(RAJA::Index_type i)
     {
-      dd[(int)id1[i]] = vd1[i];
+      int idx = id1[i];
+      dd[idx] = vd1[i];
     }
   );
 
   RAJA::forall< hiop_raja_exec >(
-    RAJA::RangeSegment(0, n2_local),
+    RAJA::RangeSegment(0, (int)n2_local),
     RAJA_LAMBDA(RAJA::Index_type i)
     {
-      dd[(int)id2[i]] = vd2[i];
+      int idx = id2[i];
+      dd[idx] = vd2[i];
     }
   );
 }
@@ -559,7 +561,8 @@ void hiopVectorRajaPar::copy_to_two_vec_w_pattern(hiopVector& c,
     RAJA::RangeSegment(0, (int)n1_local),
     RAJA_LAMBDA(RAJA::Index_type i)
     {
-      vd1[i] = dd[(int)id1[i]];
+      int idx = id1[i];
+      vd1[i] = dd[idx];
     }
   );
 
@@ -567,7 +570,8 @@ void hiopVectorRajaPar::copy_to_two_vec_w_pattern(hiopVector& c,
     RAJA::RangeSegment(0, (int)n2_local),
     RAJA_LAMBDA(RAJA::Index_type i)
     {
-      vd2[i] = dd[(int)id2[i]];
+      int idx = id2[i];
+      vd2[i] = dd[idx];
     }
   );                                           
 }

--- a/src/LinAlg/hiopVectorRajaPar.cpp
+++ b/src/LinAlg/hiopVectorRajaPar.cpp
@@ -1830,7 +1830,7 @@ void hiopVectorRajaPar::set_array_from_to(hiopInterfaceBase::NonlinearityType* a
   
   auto& rm = umpire::ResourceManager::getInstance();
   hiopInterfaceBase::NonlinearityType* vv = const_cast<hiopInterfaceBase::NonlinearityType*>(arr_src); // <- cast away const
-  rm.copy(arc+start, vv+start+start_src, (end-start)*sizeof(hiopInterfaceBase::NonlinearityType));
+  rm.copy(arr+start, vv+start+start_src, (end-start)*sizeof(hiopInterfaceBase::NonlinearityType));
 }
 
 void hiopVectorRajaPar::set_array_from_to(hiopInterfaceBase::NonlinearityType* arr, 

--- a/src/LinAlg/hiopVectorRajaPar.cpp
+++ b/src/LinAlg/hiopVectorRajaPar.cpp
@@ -497,8 +497,8 @@ void hiopVectorRajaPar::copy_from_two_vec_w_pattern(const hiopVector& c,
   const hiopVectorIntRaja& ix1 = dynamic_cast<const hiopVectorIntRaja&>(c_map);
   const hiopVectorIntRaja& ix2 = dynamic_cast<const hiopVectorIntRaja&>(d_map);
   
-  hiopInt n1_local = v1.size();
-  hiopInt n2_local = v2.size();
+  hiopInt n1_local = v1.n_local_);
+  hiopInt n2_local = v2.n_local_;
 
 #ifdef HIOP_DEEPCHECKS
   assert(n1_local + n2_local == n_local_);
@@ -542,8 +542,8 @@ void hiopVectorRajaPar::copy_to_two_vec_w_pattern(hiopVector& c,
   const hiopVectorIntRaja& ix1 = dynamic_cast<const hiopVectorIntRaja&>(c_map);
   const hiopVectorIntRaja& ix2 = dynamic_cast<const hiopVectorIntRaja&>(d_map);
   
-  hiopInt n1_local = v1.n_local;
-  hiopInt n2_local = v2.n_local;
+  hiopInt n1_local = v1.n_local_;
+  hiopInt n2_local = v2.n_local_;
 
 #ifdef HIOP_DEEPCHECKS
   assert(n1_local + n2_local == n_local_);

--- a/src/LinAlg/hiopVectorRajaPar.cpp
+++ b/src/LinAlg/hiopVectorRajaPar.cpp
@@ -1816,6 +1816,42 @@ long long hiopVectorRajaPar::numOfElemsAbsLessThan(const double &val) const
   return nrm;
 }
  
+void hiopVectorRajaPar::set_array_from_to(hiopInterfaceBase::NonlinearityType* arr, 
+                                          const int start, 
+                                          const int end, 
+                                          const hiopInterfaceBase::NonlinearityType* arr_src,
+                                          const int start_src) const
+{
+  assert(end <= n_local_ && start <= end && start >= 0 && start_src >= 0);
 
+  // If there is nothing to copy, return.
+  if(end - start == 0)
+    return;
+  
+  auto& rm = umpire::ResourceManager::getInstance();
+  hiopInterfaceBase::NonlinearityType* vv = const_cast<hiopInterfaceBase::NonlinearityType*>(arr_src); // <- cast away const
+  rm.copy(arc+start, vv+start+start_src, (end-start)*sizeof(hiopInterfaceBase::NonlinearityType));
+}
+
+void hiopVectorRajaPar::set_array_from_to(hiopInterfaceBase::NonlinearityType* arr, 
+                                          const int start, 
+                                          const int end, 
+                                          const hiopInterfaceBase::NonlinearityType arr_src) const
+{
+  assert(end <= n_local_ && start <= end && start >= 0);
+
+  // If there is nothing to copy, return.
+  if(end - start == 0)
+    return;
+
+  auto& rm = umpire::ResourceManager::getInstance();
+  RAJA::forall< hiop_raja_exec >(
+    RAJA::RangeSegment(start, end),
+    RAJA_LAMBDA(RAJA::Index_type i)
+    {
+      arr[i] = arr_src;
+    }
+  );      
+}
 
 } // namespace hiop

--- a/src/LinAlg/hiopVectorRajaPar.cpp
+++ b/src/LinAlg/hiopVectorRajaPar.cpp
@@ -497,7 +497,7 @@ void hiopVectorRajaPar::copy_from_two_vec_w_pattern(const hiopVector& c,
   const hiopVectorIntRaja& ix1 = dynamic_cast<const hiopVectorIntRaja&>(c_map);
   const hiopVectorIntRaja& ix2 = dynamic_cast<const hiopVectorIntRaja&>(d_map);
   
-  hiopInt n1_local = v1.n_local_);
+  hiopInt n1_local = v1.n_local_;
   hiopInt n2_local = v2.n_local_;
 
 #ifdef HIOP_DEEPCHECKS

--- a/src/LinAlg/hiopVectorRajaPar.hpp
+++ b/src/LinAlg/hiopVectorRajaPar.hpp
@@ -63,6 +63,7 @@
 
 #include <hiopMPI.hpp>
 #include "hiopVector.hpp"
+#include "hiopVectorInt.hpp"
 
 namespace hiop
 {

--- a/src/LinAlg/hiopVectorRajaPar.hpp
+++ b/src/LinAlg/hiopVectorRajaPar.hpp
@@ -193,6 +193,16 @@ public:
   virtual long long numOfElemsLessThan(const double &val) const;
   virtual long long numOfElemsAbsLessThan(const double &val) const;      
 
+  virtual void set_array_from_to(hiopInterfaceBase::NonlinearityType* arr, 
+                                 const int start, 
+                                 const int end, 
+                                 const hiopInterfaceBase::NonlinearityType* arr_src,
+                                 const int start_src) const;
+  virtual void set_array_from_to(hiopInterfaceBase::NonlinearityType* arr, 
+                                 const int start, 
+                                 const int end, 
+                                 const hiopInterfaceBase::NonlinearityType arr_src) const;
+
 private:
   std::string mem_space_;
   MPI_Comm comm_;

--- a/src/LinAlg/hiopVectorRajaPar.hpp
+++ b/src/LinAlg/hiopVectorRajaPar.hpp
@@ -92,6 +92,19 @@ public:
   /* Copy 'this' to v starting at start_index in 'v'. */
   virtual void copyToStarting(hiopVector& v, int start_index_in_dest) const;
   virtual void copyToStartingAt_w_pattern(hiopVector& v, int start_index_in_dest, const hiopVector& ix) const;
+
+  /// @brief Copy the entries in `c` and `d` to `this`, according to the mapping in `c_map` and `d_map`
+  virtual void copy_from_two_vec_w_pattern(const hiopVector& c, 
+                                           const hiopVectorInt& c_map, 
+                                           const hiopVector& d, 
+                                           const hiopVectorInt& d_map);
+
+  /// @brief Copy the entries in `this` to `c` and `d`, according to the mapping `c_map` and `d_map`
+  virtual void copy_to_two_vec_w_pattern(hiopVector& c, 
+                                         const hiopVectorInt& c_map, 
+                                         hiopVector& d, 
+                                         const hiopVectorInt& d_map) const;
+
   /* copy 'this' (source) starting at 'start_idx_in_src' to 'dest' starting at index 'int start_idx_dest' 
    * If num_elems>=0, 'num_elems' will be copied; if num_elems<0, elements will be copied till the end of
    * either source ('this') or destination ('dest') is reached

--- a/src/Optimization/hiopFRProb.cpp
+++ b/src/Optimization/hiopFRProb.cpp
@@ -101,12 +101,15 @@ hiopFRProbSparse::hiopFRProbSparse(hiopAlgFilterIPMBase& solver_base)
   // nnz for sparse matrices;
   nnz_Jac_c_ = nlp_base_->get_nnz_Jaceq() + 2 * m_eq_;
   nnz_Jac_d_ = nlp_base_->get_nnz_Jacineq() + 2 * m_ineq_;
-
+  
   // not sure i Hess has diagonal terms, compute nnz_hess here
   // assuming hess is in upper_triangular form
-  hiopMatrixSparse* Hess = dynamic_cast<hiopMatrixSparse*>(solver_base_.get_Hess_Lagr());
-  nnz_Hess_Lag_ = n_x_ + Hess->numberOfOffDiagNonzeros();
-
+  hiopMatrixSparse* Hess_base = dynamic_cast<hiopMatrixSparse*>(solver_base_.get_Hess_Lagr());
+  nnz_Hess_Lag_ = n_x_ + Hess_base->numberOfOffDiagNonzeros();
+  
+  Jac_cd_ = LinearAlgebraFactory::createMatrixSparse(m_, n_, nnz_Jac_c_ + nnz_Jac_d_);
+  Hess_cd_ = LinearAlgebraFactory::createMatrixSymSparse(n_, nnz_Hess_Lag_);
+  
   // set mu0 to be the maximun of the current barrier parameter mu and norm_inf(|c|)*/
   theta_ref_ = solver_base_.get_resid()->get_theta(); //at current point, i.e., reference point
   mu_ = solver_base.get_mu();
@@ -128,6 +131,8 @@ hiopFRProbSparse::~hiopFRProbSparse()
   delete wrk_primal_;
   delete wrk_dual_;
   delete DR_;
+  delete Jac_cd_;
+  delete Hess_cd_;
 }
 
 bool hiopFRProbSparse::get_prob_sizes(long long& n, long long& m)
@@ -154,14 +159,9 @@ bool hiopFRProbSparse::get_vars_info(const long long& n, double *xlow, double* x
   xu.copyToStarting(*wrk_primal_,0);
   wrk_primal_->copyTo(xupp);
 
-  // x
-  for(long long i = 0; i < n_x_; ++i) {
-    type[i] = var_type[i];
-  }
-  // p and n
-  for(long long i = n_x_; i < n_; ++i) {
-    type[i] = hiopLinear;
-  }
+  wrk_primal_->set_array_from_to(type, 0, n_x_, var_type, 0);
+  wrk_primal_->set_array_from_to(type, n_x_, n_, hiopLinear);
+
   return true;
 }
 
@@ -186,12 +186,9 @@ bool hiopFRProbSparse::get_cons_info(const long long& m, double* clow, double* c
   du.copyToStarting(*wrk_dual_, (int)m_eq_);
   wrk_dual_->copyTo(cupp);
 
-  for(long long i = 0; i < m_eq_; ++i) {
-    type[i] = cons_eq_type[i];
-  }
-  for(long long i = m_eq_; i < m_; ++i) {
-    type[i] = cons_ineq_type[i-m_eq_];
-  }
+  wrk_dual_->set_array_from_to(type, 0, m_eq_, cons_eq_type, 0);
+  wrk_dual_->set_array_from_to(type, m_eq_, m_, cons_ineq_type, 0);
+
   return true;
 }
 
@@ -212,14 +209,13 @@ bool hiopFRProbSparse::eval_f(const long long& n, const double* x, bool new_x, d
   assert(n == n_);
   obj_value = 0.;
 
+  wrk_primal_->copy_from_starting_at(x, 0, n_); // [x pe ne pi ni]
+  wrk_x_->copy_from_starting_at(x, 0, n_x_);    // [x]
+  
   // rho*sum(p+n)
-  for(auto i = n_x_; i < n_; ++i) {
-    obj_value += x[i];
-  }
-  obj_value *= rho_;
+  obj_value += rho_ * (wrk_primal_->sum_local() - wrk_x_->sum_local());
 
   // zeta/2*[DR*(x-x_ref)]^2
-  wrk_x_->copy_from_starting_at(x, 0, n_x_);
   wrk_x_->axpy(-1.0, *x_ref_);
   wrk_x_->componentMult(*DR_);
   double wrk_db = wrk_x_->twonorm();
@@ -319,133 +315,20 @@ bool hiopFRProbSparse::eval_Jac_cons(const long long& n,
 
   assert(nnzJacS == nlp_base_->get_nnz_Jaceq() + nlp_base_->get_nnz_Jacineq() + 2 * (m_));
 
-  hiopMatrixSparse* Jac_c = dynamic_cast<hiopMatrixSparse*>(solver_base_.get_Jac_c());
-  hiopMatrixSparse* Jac_d = dynamic_cast<hiopMatrixSparse*>(solver_base_.get_Jac_d());
-
-  // shortcut to the original Jac
-  int *irow_c = Jac_c->i_row();
-  int *jcol_c = Jac_c->j_col();
-  int *irow_d = Jac_d->i_row();
-  int *jcol_d = Jac_d->j_col();
-
-  // assuming Jac is sorted!
-  int nnz_Jac_c_base = nlp_base_->get_nnz_Jaceq();
-  int nnz_Jac_d_base = nlp_base_->get_nnz_Jacineq();
-
-  int k;
-  int k_base;
-  int last_row_idx;
+  hiopMatrixSparse& Jac_c = dynamic_cast<hiopMatrixSparse&>(*solver_base_.get_Jac_c());
+  hiopMatrixSparse& Jac_d = dynamic_cast<hiopMatrixSparse&>(*solver_base_.get_Jac_d());
 
   // extend Jac to the p and n parts
-  if(iJacS != NULL && jJacS != NULL){
-    // Jac for d(x) - p + n
-    last_row_idx = m_;
-    k_base = nnz_Jac_d_base - 1;
-    for(k = nnz_Jac_c_ + nnz_Jac_d_ - 1; k >= nnz_Jac_c_ && k_base >= 0; ) {
-      int row_in_jac_d = irow_d[k_base];
-      int row_idx = row_in_jac_d + m_eq_;
-      if(row_idx != last_row_idx) {
-        // n
-        iJacS[k] = row_idx;
-        jJacS[k] = ni_st_ + row_in_jac_d;
-        // p
-        iJacS[k-1] = row_idx;
-        jJacS[k-1] = pi_st_ + row_in_jac_d;
-
-        last_row_idx = row_idx;
-        k = k-2;
-      } else {
-        // x
-        iJacS[k] = row_idx;
-        jJacS[k] = jcol_d[k_base];
-        k--;
-        k_base--;
-      }
-    }
-    assert( k == nnz_Jac_c_ - 1 && k_base == -1 );
-
-    // Jac for c(x) - p + n
-    last_row_idx = m_eq_;
-    k_base = nnz_Jac_c_base - 1;
-    for(k = nnz_Jac_c_ - 1; k >= 0 && k_base >= 0; ) {
-      int row_idx = irow_c[k_base];
-      if(row_idx != last_row_idx) {
-        // n
-        iJacS[k] = row_idx;
-        jJacS[k] = ne_st_ + row_idx;
-        // p
-        iJacS[k-1] = row_idx;
-        jJacS[k-1] = pe_st_ + row_idx;
-
-        last_row_idx = row_idx;
-        k = k-2;
-      } else {
-        // x
-        iJacS[k] = row_idx;
-        jJacS[k] = jcol_c[k_base];
-        k--;
-        k_base--;
-      }
-    }
-    assert( k == -1 && k_base == -1 );
-  }
-
-  //values for sparse Jacobian if requested by the solver
-  if(MJacS != NULL) {
+  if(MJacS != nullptr) {
     // get x for the original problem
     wrk_x_->copy_from_starting_at(x, 0, n_x_);
 
     // get Jac_c and Jac_d for the x part --- use original Jac_c/Jac_d as buffers
-    nlp_base_->eval_Jac_c_d(*wrk_x_, new_x, *Jac_c, *Jac_d);
-
-    // shortcut to the original Jac
-    double *M_c = Jac_c->M();
-    double *M_d = Jac_d->M();
-
-    // Jac for d(x) - p + n
-    last_row_idx = m_;
-    k_base = nnz_Jac_d_base - 1;
-    for(k = nnz_Jac_c_ + nnz_Jac_d_ - 1; k >= nnz_Jac_c_ && k_base >= 0; ) {
-      int row_idx = irow_d[k_base] + m_eq_;
-      if(row_idx != last_row_idx) {
-        // n
-        MJacS[k] = 1.0;
-        // p
-        MJacS[k-1] = -1.0;
-
-        last_row_idx = row_idx;
-        k = k-2;
-      } else {
-        // x
-        MJacS[k] = M_d[k_base];
-        k--;
-        k_base--;
-      }
-    }
-    assert( k == nnz_Jac_c_ - 1 && k_base == -1 );
-
-    // Jac for c(x) - p + n
-    last_row_idx = m_eq_;
-    k_base = nnz_Jac_c_base - 1;
-    for(k = nnz_Jac_c_ - 1; k >= 0 && k_base >= 0; ) {
-      int row_idx = irow_c[k_base];
-      if(row_idx != last_row_idx) {
-        // n
-        MJacS[k] = 1.0;
-        // p
-        MJacS[k-1] = -1.0;
-
-        last_row_idx = row_idx;
-        k = k-2;
-      } else {
-        // x
-        MJacS[k] = M_c[k_base];
-        k--;
-        k_base--;
-      }
-    }
-    assert( k == -1 && k_base == -1 );
+    nlp_base_->eval_Jac_c_d(*wrk_x_, new_x, Jac_c, Jac_d); 
   }
+
+  Jac_cd_->set_Jac_FR(Jac_c, Jac_d, iJacS, jJacS, MJacS);
+  
   return true;
 }
 
@@ -464,66 +347,9 @@ bool hiopFRProbSparse::eval_Hess_Lagr(const long long& n,
   assert(nnzHSS == nnz_Hess_Lag_);
 
   // shortcut to the original Hess
-  hiopMatrixSparse* Hess = dynamic_cast<hiopMatrixSparse*>(solver_base_.get_Hess_Lagr());
-  int *irow_h = Hess->i_row();
-  int *jcol_h = Hess->j_col();
+  hiopMatrixSparse& Hess = dynamic_cast<hiopMatrixSparse&>(*solver_base_.get_Hess_Lagr());
 
-  // assuming Hess is sorted, and in upper-triangle format
-  int nnz_Hess_base = nlp_base_->get_nnz_Hess_Lagr();
-
-  // extend Jac to the p and n parts
-  if(iHSS != NULL && jHSS != NULL) {
-    int k = 0;
-    int k_base = 0;
-    int row_idx = 0;
-
-    // Hess for x:  zeta*DR^2.*(x-x_ref)
-    for(k_base = 0; k_base < nnz_Hess_base; ) {
-      int row_base = irow_h[k_base];
-      int col_base = jcol_h[k_base];
-      if(row_idx < row_base) {
-        // find empty row, insert diagonal entries
-        iHSS[k] = row_idx;
-        jHSS[k] = row_idx;
-        k++;
-        row_idx++;
-        continue;
-      }
-
-      // now we are on a non-empty row
-      if(col_base == row_base) {
-        // find a diagonal nonzero in the original hess
-        iHSS[k] = row_base;
-        jHSS[k] = col_base;
-        k++;
-        k_base++;
-        row_idx++;
-      } else {
-        if(row_idx == row_base) {
-          // insert diagonal nonzero into the beginning of this row
-          iHSS[k] = row_idx;
-          jHSS[k] = row_idx;
-          k++;
-          row_idx++;
-        }
-
-        // copy original off-diag nonzero
-        iHSS[k] = row_base;
-        jHSS[k] = col_base;
-        k++;
-        k_base++;
-      }
-    }
-    assert(row_idx == n_x_);
-    assert(k_base == nnz_Hess_base);
-    assert(k == nnz_Hess_Lag_);
-  }
-
-  if(MHSS != NULL) {
-    int k = 0;
-    int k_base = 0;
-    int row_idx = 0;
-
+  if(MHSS != nullptr) {
     // get x for the original problem
     wrk_x_->copy_from_starting_at(x, 0, n_x_);
 
@@ -533,56 +359,18 @@ bool hiopFRProbSparse::eval_Hess_Lagr(const long long& n,
 
     double obj_factor = 0.0;
     // get Jac_c and Jac_d for the x part --- use original Jac_c/Jac_d as buffers
-    nlp_base_->eval_Hess_Lagr(*wrk_x_, new_x, obj_factor, *wrk_eq_, *wrk_ineq_, new_lambda, *Hess);
-
-    // shortcut to the original Jac
-    double *M_h = Hess->M();
-
-    // Hess for x:  zeta*DR^2.*(x-x_ref)
+    nlp_base_->eval_Hess_Lagr(*wrk_x_, new_x, obj_factor, *wrk_eq_, *wrk_ineq_, new_lambda, Hess);
+    
+    // additional diag Hess for x:  zeta*DR^2.*(x-x_ref)
     wrk_x_->axpy(-1.0, *x_ref_);
     wrk_x_->componentMult(*DR_);
     wrk_x_->componentMult(*DR_);
-    wrk_x_->scale(zeta_);
-
-    double* x_db = wrk_x_->local_data();
-
-    row_idx = 0;
-    for(k_base = 0; k_base < nnz_Hess_base; ) {
-      int row_base = irow_h[k_base];
-      int col_base = jcol_h[k_base];
-      if(row_idx < row_base) {
-        // find empty row, insert diagonal entries
-        MHSS[k] = x_db[row_idx];
-        k++;
-        row_idx++;
-        continue;
-      }
-
-      // now we are on a non-empty row
-      if(col_base == row_base) {
-        // find a diagonal nonzero in the original hess
-        MHSS[k] = M_h[k_base] + x_db[row_idx];
-        k++;
-        k_base++;
-        row_idx++;
-      } else {
-        if(row_idx == row_base) {
-          // insert diagonal nonzero into the beginning of this row
-          MHSS[k] = x_db[row_idx];
-          k++;
-          row_idx++;
-        }
-
-        // copy original off-diag nonzero
-        MHSS[k] = M_h[k_base];
-        k++;
-        k_base++;
-      }
-    }
-    assert(row_idx == n_x_);
-    assert(k_base == nnz_Hess_base);
-    assert(k == nnz_Hess_Lag_);
+    wrk_x_->scale(zeta_);    
   }
+
+  // extend Hes to the p and n parts
+  Hess_cd_->set_Hess_FR(Hess, iHSS, jHSS, MHSS, *wrk_x_);
+  
   return true;
 }
 

--- a/src/Optimization/hiopFRProb.cpp
+++ b/src/Optimization/hiopFRProb.cpp
@@ -358,7 +358,7 @@ bool hiopFRProbSparse::eval_Hess_Lagr(const long long& n,
     wrk_ineq_->copy_from_starting_at(lambda, m_eq_, m_ineq_);
 
     double obj_factor = 0.0;
-    // get Jac_c and Jac_d for the x part --- use original Jac_c/Jac_d as buffers
+    // get Hess for the x part --- use original Hess as buffers
     nlp_base_->eval_Hess_Lagr(*wrk_x_, new_x, obj_factor, *wrk_eq_, *wrk_ineq_, new_lambda, Hess);
     
     // additional diag Hess for x:  zeta*DR^2.*(x-x_ref)

--- a/src/Optimization/hiopFRProb.hpp
+++ b/src/Optimization/hiopFRProb.hpp
@@ -203,6 +203,9 @@ private:
   hiopVector* wrk_primal_;  // [x pe ne pi ni]
   hiopVector* wrk_dual_;  // [c d]
 
+  hiopMatrixSparse* Jac_cd_;
+  hiopMatrixSparse* Hess_cd_;
+
   double zeta_;
   double theta_ref_;
   double mu_;

--- a/src/Optimization/hiopNlpFormulation.cpp
+++ b/src/Optimization/hiopNlpFormulation.cpp
@@ -638,7 +638,7 @@ bool hiopNlpFormulation::eval_c(hiopVector& x, bool new_x, hiopVector& c)
   runStats.tmEvalCons.start();
   bool bret = interface_base.eval_cons(nlp_transformations.n_pre(),
 				       n_cons,n_cons_eq,
-				       (const long long*) cons_eq_mapping_->local_data_const(),
+				       cons_eq_mapping_->local_data_const(),
 				       xx->local_data_const(), new_x,
 				       cc->local_data());
   runStats.tmEvalCons.stop(); runStats.nEvalCons_eq++;
@@ -655,7 +655,7 @@ bool hiopNlpFormulation::eval_d(hiopVector& x, bool new_x, hiopVector& d)
 
   runStats.tmEvalCons.start();
   bool bret = interface_base.eval_cons(nlp_transformations.n_pre(),
-				       n_cons, n_cons_ineq, (const long long*) cons_ineq_mapping_->local_data_const(),
+				       n_cons, n_cons_ineq, cons_ineq_mapping_->local_data_const(),
 				       xx->local_data_const(), new_x, dd->local_data());
   runStats.tmEvalCons.stop(); runStats.nEvalCons_ineq++;
 
@@ -1087,7 +1087,7 @@ bool hiopNlpDenseConstraints::eval_Jac_c(hiopVector& x, bool new_x, hiopMatrix& 
 
     runStats.tmEvalJac_con.start();
     bool bret = interface.eval_Jac_cons(nlp_transformations.n_pre(), n_cons,
-                                        n_cons_eq, (const long long*) cons_eq_mapping_->local_data_const(),
+                                        n_cons_eq, cons_eq_mapping_->local_data_const(),
                                         x_user->local_data_const(), new_x, Jac_c_user_de->local_data());
     runStats.tmEvalJac_con.stop(); runStats.nEvalJac_con_eq++;
 
@@ -1121,7 +1121,7 @@ bool hiopNlpDenseConstraints::eval_Jac_d(hiopVector& x, bool new_x, hiopMatrix& 
 
     runStats.tmEvalJac_con.start();
     bool bret = interface.eval_Jac_cons(nlp_transformations.n_pre(), n_cons,
-                                        n_cons_ineq, (const long long*) cons_ineq_mapping_->local_data_const(),
+                                        n_cons_ineq, cons_ineq_mapping_->local_data_const(),
                                         x_user->local_data_const(), new_x,Jac_d_user_de->local_data());
     runStats.tmEvalJac_con.stop(); runStats.nEvalJac_con_ineq++;
 
@@ -1215,7 +1215,7 @@ bool hiopNlpMDS::eval_Jac_c(hiopVector& x, bool new_x, hiopMatrix& Jac_c)
     
     int nnz = pJac_c->sp_nnz();
     bool bret = interface.eval_Jac_cons(n_vars, n_cons, 
-					n_cons_eq, (const long long*) cons_eq_mapping_->local_data_const(), 
+					n_cons_eq, cons_eq_mapping_->local_data_const(), 
 					x_user->local_data_const(), new_x,
 					pJac_c->n_sp(), pJac_c->n_de(), 
 					nnz, pJac_c->sp_irow(), pJac_c->sp_jcol(), pJac_c->sp_M(),
@@ -1247,7 +1247,7 @@ bool hiopNlpMDS::eval_Jac_d(hiopVector& x, bool new_x, hiopMatrix& Jac_d)
   
     int nnz = pJac_d->sp_nnz();
     bool bret =  interface.eval_Jac_cons(n_vars, n_cons, 
-					 n_cons_ineq, (const long long*) cons_ineq_mapping_->local_data_const(), 
+					 n_cons_ineq, cons_ineq_mapping_->local_data_const(), 
 					 x_user->local_data_const(), new_x,
 					 pJac_d->n_sp(), pJac_d->n_de(), 
 					 nnz, pJac_d->sp_irow(), pJac_d->sp_jcol(), pJac_d->sp_M(),
@@ -1295,8 +1295,8 @@ bool hiopNlpMDS::eval_Jac_c_d_interface_impl(hiopVector& x,
 					cons_Jac->de_local_data());
     
     //copy back to Jac_c and Jac_d
-    pJac_c->copyRowsFrom(*cons_Jac, (const long long*) cons_eq_mapping_->local_data_const(), n_cons_eq);
-    pJac_d->copyRowsFrom(*cons_Jac, (const long long*) cons_ineq_mapping_->local_data_const(), n_cons_ineq);
+    pJac_c->copyRowsFrom(*cons_Jac, cons_eq_mapping_->local_data_const(), n_cons_eq);
+    pJac_d->copyRowsFrom(*cons_Jac, cons_ineq_mapping_->local_data_const(), n_cons_ineq);
     
     // scale the matrices
     Jac_c = *(nlp_transformations.apply_to_jacob_eq(Jac_c, n_cons_eq));
@@ -1468,8 +1468,8 @@ bool hiopNlpSparse::eval_Jac_c_d_interface_impl(hiopVector& x,
                                    nnz, nullptr, nullptr, cons_Jac->M());
 
     //copy back to Jac_c and Jac_d
-    pJac_c->copyRowsFrom(*cons_Jac, (const long long*) cons_eq_mapping_->local_data_const(), n_cons_eq);
-    pJac_d->copyRowsFrom(*cons_Jac, (const long long*) cons_ineq_mapping_->local_data_const(), n_cons_ineq);
+    pJac_c->copyRowsFrom(*cons_Jac, cons_eq_mapping_->local_data_const(), n_cons_eq);
+    pJac_d->copyRowsFrom(*cons_Jac, cons_ineq_mapping_->local_data_const(), n_cons_ineq);
 
     // scale the matrix
     Jac_c = *(nlp_transformations.apply_to_jacob_eq(Jac_c, n_cons_eq));

--- a/src/Optimization/hiopNlpFormulation.cpp
+++ b/src/Optimization/hiopNlpFormulation.cpp
@@ -53,6 +53,8 @@
 #include "hiopLogger.hpp"
 #include "hiopDualsUpdater.hpp"
 
+#include "hiopVectorInt.hpp"
+
 #ifdef HIOP_USE_MPI
 #include "mpi.h"
 #else 
@@ -147,8 +149,8 @@ hiopNlpFormulation::~hiopNlpFormulation()
   if(cons_ineq_type) delete[] cons_ineq_type;
   if(cons_eq_type)   delete[] cons_eq_type;
 
-  if(cons_eq_mapping_)   delete[] cons_eq_mapping_;
-  if(cons_ineq_mapping_) delete[] cons_ineq_mapping_;
+  if(cons_eq_mapping_)   delete cons_eq_mapping_;
+  if(cons_ineq_mapping_) delete cons_ineq_mapping_;
 #ifdef HIOP_USE_MPI
   if(vec_distrib) delete[] vec_distrib;
 #endif
@@ -384,10 +386,11 @@ bool hiopNlpFormulation::finalizeInitialization()
   if(du) delete du;
   if(cons_ineq_type)
     delete[] cons_ineq_type;
-  if(cons_eq_mapping_)
-    delete[] cons_eq_mapping_;
-  if(cons_ineq_mapping_)
-    delete[] cons_ineq_mapping_;
+  if(cons_eq_mapping_) 
+    delete cons_eq_mapping_;
+  if(cons_ineq_mapping_) 
+    delete cons_ineq_mapping_;
+  
   
   /* allocate c_rhs, dl, and du (all serial in this formulation) */
   c_rhs = LinearAlgebraFactory::createVector(n_cons_eq);
@@ -395,18 +398,20 @@ bool hiopNlpFormulation::finalizeInitialization()
   dl    = LinearAlgebraFactory::createVector(n_cons_ineq);
   du    = LinearAlgebraFactory::createVector(n_cons_ineq);
   cons_ineq_type = new  hiopInterfaceBase::NonlinearityType[n_cons_ineq];
-  cons_eq_mapping_   = new long long[n_cons_eq];
-  cons_ineq_mapping_ = new long long[n_cons_ineq];
+  cons_eq_mapping_   = LinearAlgebraFactory::createVectorInt(n_cons_eq);
+  cons_ineq_mapping_ = LinearAlgebraFactory::createVectorInt(n_cons_ineq);
 
   /* copy lower and upper bounds - constraints */
   double *dlvec=dl->local_data_host(), *duvec=du->local_data_host();
   double *c_rhsvec=c_rhs->local_data_host();
+  hiopInt *cons_eq_mapping = cons_eq_mapping_->local_data_host();
+  hiopInt *cons_ineq_mapping = cons_ineq_mapping_->local_data_host();
   int it_eq=0, it_ineq=0;
   for(int i=0;i<n_cons; i++) {
     if(gl_vec[i]==gu_vec[i]) {
       cons_eq_type[it_eq]=cons_type[i]; 
       c_rhsvec[it_eq] = gl_vec[i]; 
-      cons_eq_mapping_[it_eq]=i;
+      cons_eq_mapping[it_eq]=i;
       it_eq++;
     } else {
 #ifdef HIOP_DEEPCHECKS
@@ -415,7 +420,7 @@ bool hiopNlpFormulation::finalizeInitialization()
 #endif
       cons_ineq_type[it_ineq]=cons_type[i];
       dlvec[it_ineq]=gl_vec[i]; duvec[it_ineq]=gu_vec[i]; 
-      cons_ineq_mapping_[it_ineq]=i;
+      cons_ineq_mapping[it_ineq]=i;
       it_ineq++;
     }
   }
@@ -504,7 +509,8 @@ bool hiopNlpFormulation::apply_scaling(hiopVector& c, hiopVector& d, hiopVector&
     return false;
   }
   
-  nlp_scaling = new hiopNLPObjGradScaling(max_grad, c, d, gradf, Jac_c, Jac_d, cons_eq_mapping_, cons_ineq_mapping_);
+  nlp_scaling = new hiopNLPObjGradScaling(max_grad, c, d, gradf, Jac_c, Jac_d,
+                                          cons_eq_mapping_->local_data(), cons_ineq_mapping_->local_data());
   
   // FIXME NY: scale the constraint lb and ub  
   c_rhs = nlp_scaling->apply_to_cons_eq(*c_rhs, n_cons_eq);
@@ -605,12 +611,7 @@ bool hiopNlpFormulation::get_starting_point(hiopVector& x0_for_hiop,
     assert(n_cons_eq+n_cons_ineq == n_cons);
     
     //copy back 
-    for(int i=0; i<n_cons_eq; ++i) {
-      yc0d[i] = lambda_for_user[cons_eq_mapping_[i]];
-    }
-    for(int i=0; i<n_cons_ineq; ++i) {
-      yd0d[i] = lambda_for_user[cons_ineq_mapping_[i]];
-    }
+    lambdas->copy_to_two_vec_w_pattern(yc0_for_hiop, *cons_eq_mapping_, yd0_for_hiop, *cons_ineq_mapping_);
   }
   
   if(!bret) {
@@ -637,7 +638,7 @@ bool hiopNlpFormulation::eval_c(hiopVector& x, bool new_x, hiopVector& c)
   runStats.tmEvalCons.start();
   bool bret = interface_base.eval_cons(nlp_transformations.n_pre(),
 				       n_cons,n_cons_eq,
-				       cons_eq_mapping_,
+				       (const long long*) cons_eq_mapping_->local_data_const(),
 				       xx->local_data_const(), new_x,
 				       cc->local_data());
   runStats.tmEvalCons.stop(); runStats.nEvalCons_eq++;
@@ -654,7 +655,7 @@ bool hiopNlpFormulation::eval_d(hiopVector& x, bool new_x, hiopVector& d)
 
   runStats.tmEvalCons.start();
   bool bret = interface_base.eval_cons(nlp_transformations.n_pre(),
-				       n_cons, n_cons_ineq, cons_ineq_mapping_,
+				       n_cons, n_cons_ineq, (const long long*) cons_ineq_mapping_->local_data_const(),
 				       xx->local_data_const(), new_x, dd->local_data());
   runStats.tmEvalCons.stop(); runStats.nEvalCons_ineq++;
 
@@ -707,16 +708,11 @@ bool hiopNlpFormulation::eval_c_d(hiopVector& x, bool new_x, hiopVector& c, hiop
 					 n_cons, 
 					 xx->local_data_const(), new_x, cons_body_->local_data());
     //copy back to c and d
-    double* body = cons_body_->local_data();
-    for(int i=0; i<n_cons_eq; ++i) {
-      c.local_data()[i] = body[cons_eq_mapping_[i]];
-    }
+    cons_body_->copy_to_two_vec_w_pattern(c, *cons_eq_mapping_, d, *cons_ineq_mapping_);
+    
     // scale c
     c = *(nlp_transformations.apply_to_cons_eq(c, n_cons_eq));
     
-    for(int i=0; i<n_cons_ineq; ++i) {
-      d.local_data()[i] = body[cons_ineq_mapping_[i]];
-    }
     // scale d
     d = *(nlp_transformations.apply_to_cons_ineq(d, n_cons_ineq));
     
@@ -774,62 +770,12 @@ get_dual_solutions(const hiopIterate& it, double* zl_a, double* zu_a, double* la
   const hiopVector& zu = *it.get_zu();
   zl.copyTo(zl_a);
   zu.copyTo(zu_a);
-
-  copy_EqIneq_to_cons(*it.get_yc(), *it.get_yd(), n_cons, lambda_a);
-}
-
-void hiopNlpFormulation::copy_EqIneq_to_cons(const hiopVector& yc_in,
-					     const hiopVector& yd_in,
-					     int num_cons, //size of 'cons'
-					     double* cons)
-{
-  const double* yc_arr = yc_in.local_data_const();
-  const double* yd_arr = yd_in.local_data_const();
-  assert(num_cons == n_cons);
-  assert(yc_in.get_size() + yd_in.get_size() == n_cons);
-    //concatanate multipliers -> copy into whole lambda array 
-  for(int i=0; i<n_cons_eq; ++i) {
-    cons[cons_eq_mapping_[i]] = yc_arr[i];
+  
+  if(cons_lambdas_ == nullptr) {
+    cons_lambdas_ = hiop::LinearAlgebraFactory::createVector(n_cons);
   }
-  for(int i=0; i<n_cons_ineq; ++i) {
-    cons[cons_ineq_mapping_[i]] = yd_arr[i];
-  }
-}
-
-void hiopNlpFormulation::copy_EqIneq_to_cons(const hiopVector& yc_in,
-					     const hiopVector& yd_in,
-					     hiopVector& cons)
-{
-  const double* yc_arr = yc_in.local_data_const();
-  const double* yd_arr = yd_in.local_data_const();
-  double* cons_arr = cons.local_data();
-  assert(cons.get_size() == n_cons);
-  assert(yc_in.get_size() + yd_in.get_size() == n_cons);
-    //concatanate multipliers -> copy into whole lambda array 
-  for(int i=0; i<n_cons_eq; ++i) {
-    cons_arr[cons_eq_mapping_[i]] = yc_arr[i];
-  }
-  for(int i=0; i<n_cons_ineq; ++i) {
-    cons_arr[cons_ineq_mapping_[i]] = yd_arr[i];
-  }
-}
-
-void hiopNlpFormulation::copy_cons_to_EqIneq(hiopVector& yc_in,
-                                             hiopVector& yd_in,
-                                             const hiopVector& cons)
-{
-  double* yc_arr = yc_in.local_data();
-  double* yd_arr = yd_in.local_data();
-  const double* cons_arr = cons.local_data_const();
-  assert(cons.get_size() == n_cons);
-  assert(yc_in.get_size() + yd_in.get_size() == n_cons);
-  //split whole lambda array to eq/ineq
-  for(int i=0; i<n_cons_eq; ++i) {
-    yc_arr[i] = cons_arr[cons_eq_mapping_[i]];
-  }
-  for(int i=0; i<n_cons_ineq; ++i) {
-    yd_arr[i] = cons_arr[cons_ineq_mapping_[i]];
-  }
+  cons_lambdas_->copy_from_two_vec_w_pattern(*it.get_yc(), *cons_eq_mapping_, *it.get_yd(), *cons_ineq_mapping_);
+  cons_lambdas_->copyTo(lambda_a);
 }
 
 void hiopNlpFormulation::user_callback_solution(hiopSolveStatus status,
@@ -849,8 +795,8 @@ void hiopNlpFormulation::user_callback_solution(hiopSolveStatus status,
   if(cons_lambdas_ == nullptr) {
     cons_lambdas_ = hiop::LinearAlgebraFactory::createVector(n_cons);
   }
-  copy_EqIneq_to_cons(y_c, y_d, *cons_lambdas_);
-  
+  cons_lambdas_->copy_from_two_vec_w_pattern(y_c, *cons_eq_mapping_, y_d, *cons_ineq_mapping_);
+
   //concatenate 'c' and 'd' into user's constraint body
   if(cons_body_ == nullptr) {
     cons_body_ = hiop::LinearAlgebraFactory::createVector(n_cons);
@@ -859,7 +805,7 @@ void hiopNlpFormulation::user_callback_solution(hiopSolveStatus status,
     c = *(nlp_transformations.apply_to_cons_eq(c, n_cons_eq));
     d = *(nlp_transformations.apply_to_cons_ineq(d, n_cons_ineq));
   }
-  copy_EqIneq_to_cons(c, d, *cons_body_);
+  cons_body_->copy_from_two_vec_w_pattern(c, *cons_eq_mapping_, d, *cons_ineq_mapping_);
 
   //! todo -> test this when fixed variables are removed -> the internal
   //! zl and zu may have different sizes than what user expects since HiOp removes
@@ -900,13 +846,13 @@ bool hiopNlpFormulation::user_callback_iterate(int iter,
   if(cons_lambdas_ == NULL) {
     cons_lambdas_ = hiop::LinearAlgebraFactory::createVector(n_cons);
   }
-  copy_EqIneq_to_cons(y_c, y_d, *cons_lambdas_);
-  
+  cons_lambdas_->copy_from_two_vec_w_pattern(y_c, *cons_eq_mapping_, y_d, *cons_ineq_mapping_);
+
   //concatenate 'c' and 'd' into user's constrainty body
   if(cons_body_ == NULL) {
     cons_body_ = hiop::LinearAlgebraFactory::createVector(n_cons);
   }
-  copy_EqIneq_to_cons(c, d, *cons_body_);
+  cons_body_->copy_from_two_vec_w_pattern(c, *cons_eq_mapping_, d, *cons_ineq_mapping_);
 
   //! todo -> test this when fixed variables are removed -> the internal
   //! zl and zu may have different sizes than what user expects since HiOp removes
@@ -944,13 +890,13 @@ bool hiopNlpFormulation::user_force_update(int iter,
   if(cons_lambdas_ == NULL) {
     cons_lambdas_ = hiop::LinearAlgebraFactory::createVector(n_cons);
   }
-  copy_EqIneq_to_cons(y_c, y_d, *cons_lambdas_);
+  cons_lambdas_->copy_from_two_vec_w_pattern(y_c, *cons_eq_mapping_, y_d, *cons_ineq_mapping_);
 
   //concatenate 'c' and 'd' into user's constrainty body
   if(cons_body_ == NULL) {
     cons_body_ = hiop::LinearAlgebraFactory::createVector(n_cons);
   }
-  copy_EqIneq_to_cons(c, d, *cons_body_);
+  cons_body_->copy_from_two_vec_w_pattern(c, *cons_eq_mapping_, d, *cons_ineq_mapping_);
 
   //! todo -> test this when fixed variables are removed -> the internal
   //! zl and zu may have different sizes than what user expects since HiOp removes
@@ -970,9 +916,8 @@ bool hiopNlpFormulation::user_force_update(int iter,
   assert(retval);
 
   // unpack the full size vector
-  copy_cons_to_EqIneq(c, d, *cons_body_);
-  copy_cons_to_EqIneq(y_c, y_d, *cons_lambdas_);
-
+  cons_body_->copy_to_two_vec_w_pattern(c, *cons_eq_mapping_, d, *cons_ineq_mapping_);
+  cons_lambdas_->copy_to_two_vec_w_pattern(y_c, *cons_eq_mapping_, y_d, *cons_ineq_mapping_);
 }
 
 void hiopNlpFormulation::print(FILE* f, const char* msg, int rank) const
@@ -1108,8 +1053,8 @@ bool hiopNlpDenseConstraints::eval_Jac_c_d_interface_impl(hiopVector& x, bool ne
   assert(cons_Jac_de->local_data() == Jac_consde &&
 	 "mismatch between Jacobian mem adress pre- and post-transformations should not happen");
 
-  Jac_cde->copyRowsFrom(*cons_Jac_, cons_eq_mapping_, n_cons_eq);
-  Jac_dde->copyRowsFrom(*cons_Jac_, cons_ineq_mapping_, n_cons_ineq);
+  Jac_cde->copyRowsFrom(*cons_Jac_, cons_eq_mapping_->local_data_const(), n_cons_eq);
+  Jac_dde->copyRowsFrom(*cons_Jac_, cons_ineq_mapping_->local_data_const(), n_cons_ineq);
   
   // scale Jacobian matrices
   Jac_c = *(nlp_transformations.apply_inv_to_jacob_eq(Jac_c, n_cons_eq));
@@ -1142,7 +1087,7 @@ bool hiopNlpDenseConstraints::eval_Jac_c(hiopVector& x, bool new_x, hiopMatrix& 
 
     runStats.tmEvalJac_con.start();
     bool bret = interface.eval_Jac_cons(nlp_transformations.n_pre(), n_cons,
-                                        n_cons_eq, cons_eq_mapping_,
+                                        n_cons_eq, (const long long*) cons_eq_mapping_->local_data_const(),
                                         x_user->local_data_const(), new_x, Jac_c_user_de->local_data());
     runStats.tmEvalJac_con.stop(); runStats.nEvalJac_con_eq++;
 
@@ -1176,7 +1121,7 @@ bool hiopNlpDenseConstraints::eval_Jac_d(hiopVector& x, bool new_x, hiopMatrix& 
 
     runStats.tmEvalJac_con.start();
     bool bret = interface.eval_Jac_cons(nlp_transformations.n_pre(), n_cons,
-                                        n_cons_ineq, cons_ineq_mapping_,
+                                        n_cons_ineq, (const long long*) cons_ineq_mapping_->local_data_const(),
                                         x_user->local_data_const(), new_x,Jac_d_user_de->local_data());
     runStats.tmEvalJac_con.stop(); runStats.nEvalJac_con_ineq++;
 
@@ -1270,7 +1215,7 @@ bool hiopNlpMDS::eval_Jac_c(hiopVector& x, bool new_x, hiopMatrix& Jac_c)
     
     int nnz = pJac_c->sp_nnz();
     bool bret = interface.eval_Jac_cons(n_vars, n_cons, 
-					n_cons_eq, cons_eq_mapping_, 
+					n_cons_eq, (const long long*) cons_eq_mapping_->local_data_const(), 
 					x_user->local_data_const(), new_x,
 					pJac_c->n_sp(), pJac_c->n_de(), 
 					nnz, pJac_c->sp_irow(), pJac_c->sp_jcol(), pJac_c->sp_M(),
@@ -1302,7 +1247,7 @@ bool hiopNlpMDS::eval_Jac_d(hiopVector& x, bool new_x, hiopMatrix& Jac_d)
   
     int nnz = pJac_d->sp_nnz();
     bool bret =  interface.eval_Jac_cons(n_vars, n_cons, 
-					 n_cons_ineq, cons_ineq_mapping_, 
+					 n_cons_ineq, (const long long*) cons_ineq_mapping_->local_data_const(), 
 					 x_user->local_data_const(), new_x,
 					 pJac_d->n_sp(), pJac_d->n_de(), 
 					 nnz, pJac_d->sp_irow(), pJac_d->sp_jcol(), pJac_d->sp_M(),
@@ -1350,8 +1295,8 @@ bool hiopNlpMDS::eval_Jac_c_d_interface_impl(hiopVector& x,
 					cons_Jac->de_local_data());
     
     //copy back to Jac_c and Jac_d
-    pJac_c->copyRowsFrom(*cons_Jac, cons_eq_mapping_, n_cons_eq);
-    pJac_d->copyRowsFrom(*cons_Jac, cons_ineq_mapping_, n_cons_ineq);
+    pJac_c->copyRowsFrom(*cons_Jac, (const long long*) cons_eq_mapping_->local_data_const(), n_cons_eq);
+    pJac_d->copyRowsFrom(*cons_Jac, (const long long*) cons_ineq_mapping_->local_data_const(), n_cons_ineq);
     
     // scale the matrices
     Jac_c = *(nlp_transformations.apply_to_jacob_eq(Jac_c, n_cons_eq));
@@ -1448,7 +1393,7 @@ bool hiopNlpSparse::eval_Jac_c(hiopVector& x, bool new_x, hiopMatrix& Jac_c)
 
     int nnz = pJac_c->numberOfNonzeros();
     bool bret = interface.eval_Jac_cons(n_vars, n_cons,
-                                      n_cons_eq, cons_eq_mapping_,
+                                      n_cons_eq, (const long long *) cons_eq_mapping_->local_data_const(),
                                       x_user->local_data_const(), new_x,
                                       nnz, pJac_c->i_row(), pJac_c->j_col(), pJac_c->M());
 
@@ -1474,7 +1419,7 @@ bool hiopNlpSparse::eval_Jac_d(hiopVector& x, bool new_x, hiopMatrix& Jac_d)
 
     int nnz = pJac_d->numberOfNonzeros();
     bool bret =  interface.eval_Jac_cons(n_vars, n_cons,
-                                       n_cons_ineq, cons_ineq_mapping_,
+                                       n_cons_ineq, (const long long *) cons_ineq_mapping_->local_data_const(),
                                        x_user->local_data_const(), new_x,
                                        nnz, pJac_d->i_row(), pJac_d->j_col(), pJac_d->M());
 
@@ -1523,8 +1468,8 @@ bool hiopNlpSparse::eval_Jac_c_d_interface_impl(hiopVector& x,
                                    nnz, nullptr, nullptr, cons_Jac->M());
 
     //copy back to Jac_c and Jac_d
-    pJac_c->copyRowsFrom(*cons_Jac, cons_eq_mapping_, n_cons_eq);
-    pJac_d->copyRowsFrom(*cons_Jac, cons_ineq_mapping_, n_cons_ineq);
+    pJac_c->copyRowsFrom(*cons_Jac, (const long long*) cons_eq_mapping_->local_data_const(), n_cons_eq);
+    pJac_d->copyRowsFrom(*cons_Jac, (const long long*) cons_ineq_mapping_->local_data_const(), n_cons_ineq);
 
     // scale the matrix
     Jac_c = *(nlp_transformations.apply_to_jacob_eq(Jac_c, n_cons_eq));
@@ -1563,12 +1508,7 @@ bool hiopNlpSparse::eval_Hess_Lagr(const hiopVector&  x, bool new_x, const doubl
     const double* lambda_ineq_arr = lambda_ineq.local_data_const();
     double* _buf_lambda_arr = _buf_lambda->local_data();
 
-    for(int i=0; i<n_cons_eq; ++i) {
-      _buf_lambda_arr[cons_eq_mapping_[i]] = lambda_eq_arr[i];
-    }
-    for(int i=0; i<n_cons_ineq; ++i) {
-      _buf_lambda_arr[cons_ineq_mapping_[i]] = lambda_ineq_arr[i];
-    }
+    _buf_lambda->copy_from_two_vec_w_pattern(lambda_eq, *cons_eq_mapping_, lambda_ineq, *cons_ineq_mapping_);
 
     // scale lambda before passing it to user interface to compute Hess
     int n_cons_eq_ineq = n_cons_eq + n_cons_ineq;

--- a/src/Optimization/hiopNlpFormulation.hpp
+++ b/src/Optimization/hiopNlpFormulation.hpp
@@ -4,7 +4,7 @@
 //
 // This file is part of HiOp. For details, see https://github.com/LLNL/hiop. HiOp 
 // is released under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause). 
-// Please also read ?Additional BSD Notice? below.
+// Please also read "Additional BSD Notice" below.
 //
 // Redistribution and use in source and binary forms, with or without modification, 
 // are permitted provided that the following conditions are met:

--- a/src/Optimization/hiopNlpFormulation.hpp
+++ b/src/Optimization/hiopNlpFormulation.hpp
@@ -71,6 +71,8 @@
 #include "hiopLogger.hpp"
 #include "hiopOptions.hpp"
 
+#include "hiopVectorInt.hpp"
+
 #include <cstring>
 
 namespace hiop
@@ -240,25 +242,6 @@ public:
 			  double* zl_a,
 			  double* zu_a,
 			  double* lambda_a);
-  
-  /* packs constraint rhs or constraint multipliers into one array based on the internal mappings 
-   * 'cons_eq_mapping_'and 'cons_ineq_mapping_ */
-  void copy_EqIneq_to_cons(const hiopVector& yc,
-			   const hiopVector& yd,
-			   int num_cons, //size of 'cons'
-			   double* cons);
-  
-  /* packs constraint rhs or constraint multipliers into hiopVector based on the internal mappings 
-   * 'cons_eq_mapping_'and 'cons_ineq_mapping_ */
-  void copy_EqIneq_to_cons(const hiopVector& yc,
-			   const hiopVector& yd,
-			   hiopVector& cons);
-
-  /* unpacks constraint rhs or constraint multipliers into hiopVector based on the internal mappings
-   * 'cons_eq_mapping_'and 'cons_ineq_mapping_ */
-  void copy_cons_to_EqIneq(hiopVector& yc_in,
-                           hiopVector& yd_in,
-                           const hiopVector& cons);
 
   /// @brief return the scaling fact for objective
   double get_obj_scale() const;
@@ -296,7 +279,7 @@ protected:
   hiopInterfaceBase::NonlinearityType* cons_ineq_type;
   
   // keep track of the constraints indexes in the original, user's formulation
-  long long *cons_eq_mapping_, *cons_ineq_mapping_; 
+  hiopVectorInt *cons_eq_mapping_, *cons_ineq_mapping_; 
 
   //options for which this class was setup
   std::string strFixedVars; //"none", "fixed", "relax"

--- a/src/Optimization/hiopNlpTransforms.cpp
+++ b/src/Optimization/hiopNlpTransforms.cpp
@@ -5,7 +5,7 @@
 //
 // This file is part of HiOp. For details, see https://github.com/LLNL/hiop. HiOp 
 // is released under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause). 
-// Please also read “Additional BSD Notice” below.
+// Please also read "Additional BSD Notice" below.
 //
 // Redistribution and use in source and binary forms, with or without modification, 
 // are permitted provided that the following conditions are met:

--- a/src/Optimization/hiopNlpTransforms.cpp
+++ b/src/Optimization/hiopNlpTransforms.cpp
@@ -377,8 +377,8 @@ hiopNLPObjGradScaling::hiopNLPObjGradScaling(const double max_grad,
                                              hiopVector& gradf,
                                              hiopMatrix& Jac_c, 
                                              hiopMatrix& Jac_d, 
-                                             long long *cons_eq_mapping, 
-                                             long long *cons_ineq_mapping)
+                                             hiopInt* cons_eq_mapping, 
+                                             hiopInt* cons_ineq_mapping)
       : n_vars(gradf.get_size()), n_vars_local(gradf.get_local_size()),
         scale_factor_obj(1.),
         n_eq(c.get_size()), n_ineq(d.get_size())

--- a/src/Optimization/hiopNlpTransforms.hpp
+++ b/src/Optimization/hiopNlpTransforms.hpp
@@ -4,7 +4,7 @@
 //
 // This file is part of HiOp. For details, see https://github.com/LLNL/hiop. HiOp 
 // is released under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause). 
-// Please also read “Additional BSD Notice” below.
+// Please also read ï¿½Additional BSD Noticeï¿½ below.
 //
 // Redistribution and use in source and binary forms, with or without modification, 
 // are permitted provided that the following conditions are met:
@@ -349,8 +349,8 @@ public:
                         hiopVector& gradf,
                         hiopMatrix& Jac_c, 
                         hiopMatrix& Jac_d, 
-                        long long *cons_eq_mapping, 
-                        long long *cons_ineq_mapping);
+                        hiopInt* cons_eq_mapping, 
+                        hiopInt* cons_ineq_mapping);
   ~hiopNLPObjGradScaling();
 public:
   /** inherited from the parent class */

--- a/tests/LinAlg/vectorTests.hpp
+++ b/tests/LinAlg/vectorTests.hpp
@@ -64,6 +64,7 @@
 #include <functional>
 
 #include <hiopVector.hpp>
+#include <hiopVectorInt.hpp>
 #include <hiopLinAlgFactory.hpp>
 #include "testBase.hpp"
 
@@ -372,6 +373,99 @@ public:
 
     printMessage(fail, __func__, rank);
     return reduceReturn(fail, &from);
+  }
+
+  /**
+   * @brief Test vector method for copying data from another two vectors
+   * 
+   * @pre Vectors are not distributed.
+   * @pre Memory space for hiop::LinearAlgebraFactory is set appropriately
+   */  
+  bool vector_copy_from_two_vec( hiop::hiopVector& cd,
+                                 hiop::hiopVector& c,
+                                 hiop::hiopVectorInt& c_map,
+                                 hiop::hiopVector& d,
+                                 hiop::hiopVectorInt& d_map,
+                                 const int rank=0)
+  {
+    const local_ordinal_type cd_size = getLocalSize(&cd);
+    const local_ordinal_type c_size = getLocalSize(&c);
+    const local_ordinal_type d_size = getLocalSize(&d);
+    const hiopInt c_map_size = c_map.size();
+    const hiopInt d_map_size = d_map.size();
+    assert(c_size == c_map_size && "size doesn't match");
+    assert(d_size == d_map_size && "size doesn't match");
+    assert(c_size + d_size == cd_size && "size doesn't match");
+
+    const real_type c_val = one;
+    const real_type d_val = two;
+ 
+    c.setToConstant(c_val);
+    d.setToConstant(d_val);
+    for(hiopInt i = 0; i < c_size; ++i) {
+      c_map[i] = (hiopInt) i;
+    }
+    for(hiopInt i = 0; i < d_size; ++i) {
+      d_map[i] = (hiopInt) (i + c_size);
+    }
+    c_map.copyToDev();
+    d_map.copyToDev();
+
+    cd.copy_from_two_vec_w_pattern(c, c_map, d, d_map);
+
+    int fail = verifyAnswer(&cd,
+      [=] (local_ordinal_type i) -> real_type
+      {
+        return i < c_size ? c_val : d_val;
+      });
+
+    printMessage(fail, __func__, rank);
+    return reduceReturn(fail, &cd);
+  }
+
+  /**
+   * @brief Test vector method for copying data to another two vectors
+   * 
+   * @pre Vectors are not distributed.
+   * @pre Memory space for hiop::LinearAlgebraFactory is set appropriately
+   */  
+  bool vector_copy_to_two_vec( hiop::hiopVector& cd,
+                               hiop::hiopVector& c,
+                               hiop::hiopVectorInt& c_map,
+                               hiop::hiopVector& d,
+                               hiop::hiopVectorInt& d_map,
+                               const int rank=0)
+  {
+    const local_ordinal_type cd_size = getLocalSize(&cd);
+    const local_ordinal_type c_size = getLocalSize(&c);
+    const local_ordinal_type d_size = getLocalSize(&d);
+    const hiopInt c_map_size = c_map.size();
+    const hiopInt d_map_size = d_map.size();
+    assert(c_size == c_map_size && "size doesn't match");
+    assert(d_size == d_map_size && "size doesn't match");
+    assert(c_size + d_size == cd_size && "size doesn't match");
+
+    const real_type cd_val = two;
+ 
+    c.setToZero();
+    d.setToZero();
+    for(hiopInt i = 0; i < c_size; ++i) {
+      c_map[i] = (hiopInt) i;
+    }
+    for(hiopInt i = 0; i < d_size; ++i) {
+      d_map[i] = (hiopInt) (i + c_size);
+    }
+    c_map.copyToDev();
+    d_map.copyToDev();
+
+    cd.setToConstant(cd_val);
+    cd.copy_to_two_vec_w_pattern(c, c_map, d, d_map);
+
+    int fail = verifyAnswer(&c, cd_val);
+    fail += verifyAnswer(&d, cd_val);
+
+    printMessage(fail, __func__, rank);
+    return reduceReturn(fail, &cd);
   }
 
   /**

--- a/tests/testVector.cpp
+++ b/tests/testVector.cpp
@@ -224,10 +224,14 @@ int runTests(const char* mem_space, MPI_Comm comm)
   hiopVector* a = LinearAlgebraFactory::createVector(Nglobal, n_partition, comm);
   hiopVector* b = LinearAlgebraFactory::createVector(Nglobal, n_partition, comm);
   hiopVector* v_smaller = LinearAlgebraFactory::createVector(Mlocal);
+  hiopVector* v2_smaller = LinearAlgebraFactory::createVector(Mlocal);
   hiopVector* v = LinearAlgebraFactory::createVector(Nlocal);
   hiopVector* x = LinearAlgebraFactory::createVector(Nglobal, n_partition, comm);
   hiopVector* y = LinearAlgebraFactory::createVector(Nglobal, n_partition, comm);
   hiopVector* z = LinearAlgebraFactory::createVector(Nglobal, n_partition, comm);
+  
+  hiopVectorInt* v_map = LinearAlgebraFactory::createVectorInt(Mlocal);
+  hiopVectorInt* v2_map = LinearAlgebraFactory::createVectorInt(Mlocal);
   
   int fail = 0;
 
@@ -244,6 +248,8 @@ int runTests(const char* mem_space, MPI_Comm comm)
     fail += test.vectorStartingAtCopyFromStartingAt(*v_smaller, *v);
     fail += test.vectorCopyToStarting(*v, *v_smaller);
     fail += test.vectorStartingAtCopyToStartingAt(*v, *v_smaller);
+    fail += test.vector_copy_from_two_vec(*v, *v_smaller, *v_map, *v2_smaller, *v2_map);
+    fail += test.vector_copy_to_two_vec(*v, *v_smaller, *v_map, *v2_smaller, *v2_map);
   }
 
   fail += test.vectorSelectPattern(*x, *y, rank);


### PR DESCRIPTION
This PR replaces PR #235, since @pelesh adds a temporary fix, and now the code works on all the platform.

Now I define `hiopInt` as type of `long long` and it works fine.
However, if I define it as `int` then we fail to compile the code, since we still use `long long` in the interface. 
For example
```
virtual bool eval_cons(const long long& n, const long long& m, 
		       const long long& num_cons, const long long* idx_cons,  
		       const double* x, bool new_x, 
		       double* cons)=0;
```

Things we need to discuss here are:
1. how to define/use temporary integer type in hiop
2. should we address this issue in this PR

@pelesh @cnpetra 