### PR TITLE
fix #227

### DIFF
--- a/src/LinAlg/hiopMatrixRajaSparseTriplet.cpp
+++ b/src/LinAlg/hiopMatrixRajaSparseTriplet.cpp
@@ -509,7 +509,7 @@ void hiopMatrixRajaSparseTriplet::row_max_abs_value(hiopVector& ret_vec)
   double* values = values_;
 
   RAJA::forall<hiop_raja_exec>(
-    RAJA::RangeSegment(0, num_rows+1),
+    RAJA::RangeSegment(0, num_rows),
     RAJA_LAMBDA(RAJA::Index_type row_id)
     {
       for(int itnz=idx_start[row_id]; itnz<idx_start[row_id+1]; itnz++) {


### PR DESCRIPTION
Fix a bug in RAJA implementation of `row_max_abs_value`.

CLOSE: #227 