### PR TITLE
RAJA implementation for sparse matrix

### DIFF
--- a/src/LinAlg/hiopLinAlgFactory.hpp
+++ b/src/LinAlg/hiopLinAlgFactory.hpp
@@ -108,6 +108,16 @@ public:
    */
   static void deleteRawArray(double* a);
 
+  /**
+   * @brief Static method to create a raw C Index array
+   */
+  static index_type* createRawIndexArray(size_type n);
+
+  /**
+   * @brief Static method to delete a raw C array
+   */
+  static void deleteRawIndexArray(index_type* a);
+
   /// Method to set memory space ID
   static void set_mem_space(const std::string& mem_space);
 

--- a/src/LinAlg/hiopMatrixRajaSparseTriplet.cpp
+++ b/src/LinAlg/hiopMatrixRajaSparseTriplet.cpp
@@ -984,7 +984,7 @@ void hiopMatrixRajaSparseTriplet::copyRowsFrom(const hiopMatrix& src_gen,
   int itnz_dst = 0;
 
   int m_src = src.m();
-  if(src.row_starts_host == nullptr){
+  if(src.row_starts_host == nullptr) {
     src.row_starts_host = src.allocAndBuildRowStarts();
   }
   assert(src.row_starts_host);
@@ -997,7 +997,7 @@ void hiopMatrixRajaSparseTriplet::copyRowsFrom(const hiopMatrix& src_gen,
   int nnz_dst = numberOfNonzeros();
 
   // this function only set up sparsity in the first run. Sparsity won't change after the first run.
-  if(row_starts_host == nullptr){
+  if(row_starts_host == nullptr) {
     row_starts_host = new RowStartsInfo(nrows_, mem_space_);
     assert(row_starts_host);
     int* dst_row_st_init = row_starts_host->idx_start_;
@@ -1077,14 +1077,14 @@ void hiopMatrixRajaSparseTriplet::copyRowsBlockFrom(const hiopMatrix& src_gen,
   int n_rows_src = src.m();
   int n_rows_dst = this->m();
 
-  if(src.row_starts_host == nullptr){
+  if(src.row_starts_host == nullptr) {
     src.row_starts_host = src.allocAndBuildRowStarts();
   }
   assert(src.row_starts_host);
   int* src_row_st = src.row_starts_host->idx_start_;
 
   // this function only set up sparsity in the first run. Sparsity won't change after the first run.
-  if(row_starts_host == nullptr){
+  if(row_starts_host == nullptr) {
     row_starts_host = new RowStartsInfo(n_rows_dst, mem_space_);
     assert(row_starts_host);
     int* dst_row_st_init = row_starts_host->idx_start_;

--- a/src/LinAlg/hiopMatrixRajaSparseTriplet.cpp
+++ b/src/LinAlg/hiopMatrixRajaSparseTriplet.cpp
@@ -664,9 +664,9 @@ void hiopMatrixRajaSparseTriplet::copy_to(hiopMatrixDense& W)
   
   RAJA::View<double, RAJA::Layout<2>> WM(W.local_data(), W.m(), W.n());
   
-  int nnz = nnz_;
-  int nrows = nrows_;
-  int ncols = ncols_;
+  int nnz = this->nnz_;
+  int nrows = this->nrows_;
+  int ncols = this->ncols_;
   int* jCol = jCol_;
   int* iRow = iRow_;
   double* values = values_;

--- a/src/LinAlg/hiopMatrixRajaSparseTriplet.cpp
+++ b/src/LinAlg/hiopMatrixRajaSparseTriplet.cpp
@@ -980,8 +980,6 @@ void hiopMatrixRajaSparseTriplet::copyRowsFrom(const hiopMatrix& src_gen,
   const int* jCol_src = src.j_col();
   const double* values_src = src.M();
   int nnz_src = src.numberOfNonzeros();
-  int itnz_src = 0;
-  int itnz_dst = 0;
 
   int m_src = src.m();
   if(src.row_starts_host == nullptr) {
@@ -1066,8 +1064,6 @@ void hiopMatrixRajaSparseTriplet::copyRowsBlockFrom(const hiopMatrix& src_gen,
   const int* jCol_src = src.j_col();
   const double* values_src = src.M();
   int nnz_src = src.numberOfNonzeros();
-  int itnz_src = 0;
-  int itnz_dst = 0;
 
   // local copy of member variable/function, for RAJA access
   int* iRow = iRow_;

--- a/src/LinAlg/hiopMatrixRajaSparseTriplet.hpp
+++ b/src/LinAlg/hiopMatrixRajaSparseTriplet.hpp
@@ -202,13 +202,13 @@ public:
                                  const index_type& dest_row_st,
                                  const index_type& dest_col_st,
                                  const size_type& dest_nnz_st,
-                                 const bool offdiag_only = false) {assert(0 && "FIXME_NY");}
+                                 const bool offdiag_only = false) {assert(0 && "not implemented");}
     
   virtual void copySubmatrixFromTrans(const hiopMatrix& src_gen,
                                       const index_type& dest_row_st,
                                       const index_type& dest_col_st,
                                       const size_type& dest_nnz_st,
-                                      const bool offdiag_only = false) {assert(0 && "FIXME_NY");}
+                                      const bool offdiag_only = false) {assert(0 && "not implemented");}
 
   /**
   * @brief Copy the selected cols/rows of a diagonal matrix (a constant 'scalar' times identity),
@@ -220,14 +220,14 @@ public:
                                                        const index_type& dest_col_st,
                                                        const size_type& dest_nnz_st,
                                                        const int &nnz_to_copy,
-                                                       const hiopVector& ix) {assert(0 && "FIXME_NY");}
+                                                       const hiopVector& ix) {assert(0 && "not implemented");}
 
   virtual void setSubmatrixToConstantDiag_w_rowpattern(const double& scalar,
                                                        const index_type& dest_row_st,
                                                        const index_type& dest_col_st,
                                                        const size_type& dest_nnz_st,
                                                        const int &nnz_to_copy,
-                                                       const hiopVector& ix) {assert(0 && "FIXME_NY");}
+                                                       const hiopVector& ix) {assert(0 && "not implemented");}
 
   /**
   * @brief Copy a diagonal matrix to destination.
@@ -238,7 +238,7 @@ public:
                                         const index_type& dest_row_st,
                                         const index_type& dest_col_st,
                                         const size_type& dest_nnz_st,
-                                        const int &nnz_to_copy){assert(0 && "FIXME_NY");}
+                                        const int &nnz_to_copy){assert(0 && "not implemented");}
 
   /** 
    * @brief same as @copyDiagMatrixToSubblock, but copies only diagonal entries specified by 'pattern' 
@@ -248,7 +248,7 @@ public:
                                                   const index_type& dest_col_st,
                                                   const size_type& dest_nnz_st,
                                                   const int &nnz_to_copy,
-                                                  const hiopVector& pattern) {assert(0 && "FIXME_NY");}
+                                                  const hiopVector& pattern) {assert(0 && "not implemented");}
   
   virtual double max_abs_value();
 
@@ -275,7 +275,7 @@ public:
                             int **csr_jCol,
                             double **csr_kVal,
                             int **index_covert_CSR2Triplet,
-                            int **index_covert_extra_Diag2CSR) {assert(0 && "FIXME_NY");}
+                            int **index_covert_extra_Diag2CSR) {assert(0 && "not implemented");}
 
   virtual size_type numberOfOffDiagNonzeros() const {assert("not implemented"&&0);return 0;};
 

--- a/src/LinAlg/hiopMatrixRajaSparseTriplet.hpp
+++ b/src/LinAlg/hiopMatrixRajaSparseTriplet.hpp
@@ -184,7 +184,7 @@ public:
                                  const index_type& rows_src_idx_st,
                                  const size_type& n_rows,
                                  const index_type& rows_dest_idx_st,
-                                 const size_type& dest_nnz_st) {assert(0 && "FIXME_NY");}
+                                 const size_type& dest_nnz_st);
   
   /**
   * @brief Copy matrix 'src_gen', into 'this' as a submatrix from corner 'dest_row_st' and 'dest_col_st'

--- a/src/LinAlg/hiopMatrixRajaSparseTriplet.hpp
+++ b/src/LinAlg/hiopMatrixRajaSparseTriplet.hpp
@@ -120,19 +120,19 @@ public:
   /* add to the diagonal of 'this' (destination) starting at 'start_on_dest_diag' elements of
   * 'd_' (source) starting at index 'start_on_src_vec'. The number of elements added is 'num_elems', scaled by 'scal'
   */
-  virtual void copySubDiagonalFrom(const long long& start_on_dest_diag,
-                                   const long long& num_elems,
+  virtual void copySubDiagonalFrom(const index_type& start_on_dest_diag,
+                                   const size_type& num_elems,
                                    const hiopVector& d_,
-                                   const long long& start_on_nnz_idx,
-                                   double scal=1.0) {assert(0 && "FIXME_NY");}
+                                   const index_type& start_on_nnz_idx,
+                                   double scal);
 
   /* add constant 'c' to the diagonal of 'this' (destination) starting at 'start_on_dest_diag' elements.
   * The number of elements added is 'num_elems'
   */
-  virtual void setSubDiagonalTo(const long long& start_on_dest_diag,
-                                const long long& num_elems,
+  virtual void setSubDiagonalTo(const index_type& start_on_dest_diag,
+                                const size_type& num_elems,
                                 const double& c,
-                                const long long& start_on_nnz_idx) {assert(0 && "FIXME_NY");}
+                                const index_type& start_on_nnz_idx);
 
   virtual void addMatrix(double alpha, const hiopMatrix& X);
 

--- a/src/LinAlg/hiopMatrixRajaSparseTriplet.hpp
+++ b/src/LinAlg/hiopMatrixRajaSparseTriplet.hpp
@@ -85,15 +85,11 @@ public:
 
   virtual void copyRowsFrom(const hiopMatrix& src, const index_type* rows_idxs, size_type n_rows);
   
-  virtual void timesVec(double beta,  hiopVector& y,
-			double alpha, const hiopVector& x) const;
-  virtual void timesVec(double beta,  double* y,
-			double alpha, const double* x) const;
+  virtual void timesVec(double beta,  hiopVector& y, double alpha, const hiopVector& x) const;
+  virtual void timesVec(double beta,  double* y, double alpha, const double* x) const;
 
-  virtual void transTimesVec(double beta,   hiopVector& y,
-			     double alpha, const hiopVector& x) const;
-  virtual void transTimesVec(double beta,   double* y,
-			     double alpha, const double* x) const;
+  virtual void transTimesVec(double beta, hiopVector& y, double alpha, const hiopVector& x) const;
+  virtual void transTimesVec(double beta, double* y, double alpha, const double* x) const;
 
   virtual void timesMat(double beta, hiopMatrix& W, double alpha, const hiopMatrix& X) const;
 
@@ -104,11 +100,15 @@ public:
   virtual void addDiagonal(const double& alpha, const hiopVector& d_);
   virtual void addDiagonal(const double& value);
   virtual void addSubDiagonal(const double& alpha, index_type start, const hiopVector& d_);
+
   /* add to the diagonal of 'this' (destination) starting at 'start_on_dest_diag' elements of
    * 'd_' (source) starting at index 'start_on_src_vec'. The number of elements added is 'num_elems' 
    * when num_elems>=0, or the remaining elems on 'd_' starting at 'start_on_src_vec'. */
-  virtual void addSubDiagonal(int start_on_dest_diag, const double& alpha, 
-			      const hiopVector& d_, int start_on_src_vec, int num_elems=-1)
+  virtual void addSubDiagonal(int start_on_dest_diag,
+                              const double& alpha,
+                              const hiopVector& d_,
+                              int start_on_src_vec,
+                              int num_elems=-1)
   {
     assert(false && "not needed / implemented");
   }
@@ -117,22 +117,52 @@ public:
     assert(false && "not needed / implemented");
   }
 
+  /* add to the diagonal of 'this' (destination) starting at 'start_on_dest_diag' elements of
+  * 'd_' (source) starting at index 'start_on_src_vec'. The number of elements added is 'num_elems', scaled by 'scal'
+  */
+  virtual void copySubDiagonalFrom(const long long& start_on_dest_diag,
+                                   const long long& num_elems,
+                                   const hiopVector& d_,
+                                   const long long& start_on_nnz_idx,
+                                   double scal=1.0) {assert(0 && "FIXME_NY");}
+
+  /* add constant 'c' to the diagonal of 'this' (destination) starting at 'start_on_dest_diag' elements.
+  * The number of elements added is 'num_elems'
+  */
+  virtual void setSubDiagonalTo(const long long& start_on_dest_diag,
+                                const long long& num_elems,
+                                const double& c,
+                                const long long& start_on_nnz_idx) {assert(0 && "FIXME_NY");}
+
   virtual void addMatrix(double alpha, const hiopMatrix& X);
 
   /* block of W += alpha*transpose(this) */
-  virtual void transAddToSymDenseMatrixUpperTriangle(int row_dest_start, int col_dest_start, 
-						     double alpha, hiopMatrixDense& W) const;
-  virtual void addUpperTriangleToSymDenseMatrixUpperTriangle(int diag_start, 
-							     double alpha, hiopMatrixDense& W) const
+  virtual void transAddToSymDenseMatrixUpperTriangle(int row_dest_start,
+                                                     int col_dest_start,
+                                                     double alpha,
+                                                     hiopMatrixDense& W) const;
+  virtual void addUpperTriangleToSymDenseMatrixUpperTriangle(int diag_start,
+                                                             double alpha,
+                                                             hiopMatrixDense& W) const
   {
     assert(false && "counterpart method of hiopMatrixRajaSymSparseTriplet should be used");
   }
+
+  virtual void addUpperTriangleToSymSparseMatrixUpperTriangle(int diag_start,
+                                                              double alpha,
+                                                              hiopMatrixSparse& W) const
+  {
+    assert(false && "counterpart method of hiopMatrixRajaSymSparseTriplet should be used");
+  }
+
   /* diag block of W += alpha * M * D^{-1} * transpose(M), where M=this 
    *
    * Only the upper triangular entries of W are updated.
    */
-  virtual void addMDinvMtransToDiagBlockOfSymDeMatUTri(int rowCol_dest_start, const double& alpha, 
-						       const hiopVector& D, hiopMatrixDense& W) const;
+  virtual void addMDinvMtransToDiagBlockOfSymDeMatUTri(int rowCol_dest_start,
+                                                       const double& alpha,
+                                                       const hiopVector& D,
+                                                       hiopMatrixDense& W) const;
 
   /* block of W += alpha * M * D^{-1} * transpose(N), where M=this 
    *
@@ -143,75 +173,82 @@ public:
    * the (strictly) lower triangular  elements (these are ignored later on since only the upper 
    * triangular part of W will be accessed)
    */
-  virtual void addMDinvNtransToSymDeMatUTri(int row_dest_start, int col_dest_start, const double& alpha,
-					    const hiopVector& D, const hiopMatrixSparse& N,
-					    hiopMatrixDense& W) const;
+  virtual void addMDinvNtransToSymDeMatUTri(int row_dest_start,
+                                            int col_dest_start,
+                                            const double& alpha,
+                                            const hiopVector& D,
+                                            const hiopMatrixSparse& N,
+                                            hiopMatrixDense& W) const;
 
   virtual void copyRowsBlockFrom(const hiopMatrix& src_gen,
                                  const index_type& rows_src_idx_st,
                                  const size_type& n_rows,
                                  const index_type& rows_dest_idx_st,
-                                 const size_type& dest_nnz_st)
-  {
-    assert(false && "not needed / implemented");
-  }
-
+                                 const size_type& dest_nnz_st) {assert(0 && "FIXME_NY");}
+  
+  /**
+  * @brief Copy matrix 'src_gen', into 'this' as a submatrix from corner 'dest_row_st' and 'dest_col_st'
+  * The non-zero elements start from 'dest_nnz_st' will be replaced by the new elements. 
+  * When `offdiag_only` is set to true, only the off-diagonal part of `src_gen` is copied.
+  *
+  * @pre 'this' must have enough rows and cols after row 'dest_row_st' and col 'dest_col_st'
+  * @pre 'dest_nnz_st' + the number of non-zeros in the copied matrix must be less or equal to 
+  * this->numOfNumbers()
+  * @pre User must know the nonzero pattern of src and dest matrices. The method assumes 
+  * that non-zero patterns does not change between calls and that 'src_gen' is a valid
+  *  submatrix of 'this'
+  */
   virtual void copySubmatrixFrom(const hiopMatrix& src_gen,
                                  const index_type& dest_row_st,
                                  const index_type& dest_col_st,
                                  const size_type& dest_nnz_st,
-                                 const bool offdiag_only = false)
-  {
-    assert(false && "not needed / implemented");
-  }
+                                 const bool offdiag_only = false) {assert(0 && "FIXME_NY");}
     
   virtual void copySubmatrixFromTrans(const hiopMatrix& src_gen,
                                       const index_type& dest_row_st,
                                       const index_type& dest_col_st,
                                       const size_type& dest_nnz_st,
-                                      const bool offdiag_only = false)
-  {
-    assert(false && "not needed / implemented");
-  }  
-  
+                                      const bool offdiag_only = false) {assert(0 && "FIXME_NY");}
+
+  /**
+  * @brief Copy the selected cols/rows of a diagonal matrix (a constant 'scalar' times identity),
+  * into 'this' as a submatrix from corner 'dest_row_st' and 'dest_col_st'
+  * The non-zero elements start from 'dest_nnz_st' will be replaced by the new elements.
+  */
   virtual void setSubmatrixToConstantDiag_w_colpattern(const double& scalar,
                                                        const index_type& dest_row_st,
                                                        const index_type& dest_col_st,
                                                        const size_type& dest_nnz_st,
                                                        const int &nnz_to_copy,
-                                                       const hiopVector& ix)
-  {
-    assert(false && "not needed / implemented");
-  }
+                                                       const hiopVector& ix) {assert(0 && "FIXME_NY");}
 
   virtual void setSubmatrixToConstantDiag_w_rowpattern(const double& scalar,
                                                        const index_type& dest_row_st,
                                                        const index_type& dest_col_st,
                                                        const size_type& dest_nnz_st,
                                                        const int &nnz_to_copy,
-                                                       const hiopVector& ix)
-  {
-    assert(false && "not needed / implemented");
-  }
+                                                       const hiopVector& ix) {assert(0 && "FIXME_NY");}
 
+  /**
+  * @brief Copy a diagonal matrix to destination.
+  * This diagonal matrix is 'src_val'*identity matrix with size 'n_rows'x'n_rows'.
+  * The destination is updated from the start row 'row_dest_st' and start column 'col_dest_st'.
+  */
   virtual void copyDiagMatrixToSubblock(const double& src_val,
                                         const index_type& dest_row_st,
                                         const index_type& dest_col_st,
                                         const size_type& dest_nnz_st,
-                                        const int &nnz_to_copy)
-  {
-    assert(false && "not needed / implemented");
-  }
+                                        const int &nnz_to_copy){assert(0 && "FIXME_NY");}
 
+  /** 
+   * @brief same as @copyDiagMatrixToSubblock, but copies only diagonal entries specified by 'pattern' 
+   */
   virtual void copyDiagMatrixToSubblock_w_pattern(const hiopVector& x,
                                                   const index_type& dest_row_st,
                                                   const index_type& dest_col_st,
                                                   const size_type& dest_nnz_st,
                                                   const int &nnz_to_copy,
-                                                  const hiopVector& pattern)
-  {
-    assert(false && "not needed / implemented");
-  }
+                                                  const hiopVector& pattern) {assert(0 && "FIXME_NY");}
   
   virtual double max_abs_value();
 
@@ -238,10 +275,7 @@ public:
                             int **csr_jCol,
                             double **csr_kVal,
                             int **index_covert_CSR2Triplet,
-                            int **index_covert_extra_Diag2CSR)
-  {
-    assert(false && "not needed / implemented");
-  }
+                            int **index_covert_extra_Diag2CSR) {assert(0 && "FIXME_NY");}
 
   virtual size_type numberOfOffDiagNonzeros() const {assert("not implemented"&&0);return 0;};
 

--- a/src/LinAlg/hiopMatrixSparse.hpp
+++ b/src/LinAlg/hiopMatrixSparse.hpp
@@ -91,7 +91,6 @@ public:
    */
   virtual void copy_to(hiopMatrixDense& W) = 0;
 
-  // Unit test is missing. FIXME_NY
   virtual void copyRowsFrom(const hiopMatrix& src, const index_type* rows_idxs, size_type n_rows) = 0;
 
   virtual void timesVec(double beta, hiopVector& y, double alpha, const hiopVector& x) const = 0;

--- a/src/LinAlg/hiopMatrixSparse.hpp
+++ b/src/LinAlg/hiopMatrixSparse.hpp
@@ -81,11 +81,17 @@ public:
   virtual void setToConstant(double c) = 0;
   virtual void copyFrom(const hiopMatrixSparse& dm) = 0;
   
-  /// @brief copy the nonzeros into 3 arrays, in their triplet form.
+  /* @brief copy the nonzeros into 3 arrays, in their triplet form. 
+   * This function is not used right now. Unit test is missing.
+   */
   virtual void copy_to(int* irow, int* jcol, double* val) = 0;
-  /// @brief copy the matrix into a dense matrix
+
+  /* @brief copy the matrix into a dense matrix
+   * This function is not used right now. Unit test is missing.
+   */
   virtual void copy_to(hiopMatrixDense& W) = 0;
 
+  // Unit test is missing. FIXME_NY
   virtual void copyRowsFrom(const hiopMatrix& src, const index_type* rows_idxs, size_type n_rows) = 0;
 
   virtual void timesVec(double beta, hiopVector& y, double alpha, const hiopVector& x) const = 0;
@@ -115,6 +121,23 @@ public:
   {
     assert(false && "not needed / implemented");
   }
+
+  /* add to the diagonal of 'this' (destination) starting at 'start_on_dest_diag' elements of
+  * 'd_' (source) starting at index 'start_on_src_vec'. The number of elements added is 'num_elems', scaled by 'scal'
+  */
+  virtual void copySubDiagonalFrom(const index_type& start_on_dest_diag,
+                                   const size_type& num_elems,
+                                   const hiopVector& d_,
+                                   const index_type& start_on_nnz_idx,
+                                   double scal=1.0) = 0;
+
+  /* add constant 'c' to the diagonal of 'this' (destination) starting at 'start_on_dest_diag' elements.
+  * The number of elements added is 'num_elems'
+  */
+  virtual void setSubDiagonalTo(const index_type& start_on_dest_diag,
+                                const size_type& num_elems,
+                                const double& c,
+                                const index_type& start_on_nnz_idx) = 0;
 
   virtual void addMatrix(double alpha, const hiopMatrix& X) = 0;
 

--- a/src/LinAlg/hiopMatrixSparseTriplet.hpp
+++ b/src/LinAlg/hiopMatrixSparseTriplet.hpp
@@ -56,7 +56,7 @@ public:
    * when num_elems>=0, or the remaining elems on 'd_' starting at 'start_on_src_vec'. */
   virtual void addSubDiagonal(int start_on_dest_diag,
                               const double& alpha,
-			      const hiopVector& d_,
+                              const hiopVector& d_,
                               int start_on_src_vec,
                               int num_elems=-1)
   {
@@ -89,10 +89,10 @@ public:
   /* block of W += alpha*transpose(this), where W is dense */
   virtual void transAddToSymDenseMatrixUpperTriangle(int row_dest_start,
                                                      int col_dest_start,
-						     double alpha,
+                                                     double alpha,
                                                      hiopMatrixDense& W) const;
   virtual void addUpperTriangleToSymDenseMatrixUpperTriangle(int diag_start,
-							     double alpha,
+                                                             double alpha,
                                                              hiopMatrixDense& W) const
   {
     assert(false && "counterpart method of hiopMatrixSymSparseTriplet should be used");
@@ -102,7 +102,7 @@ public:
                                                               double alpha,
                                                               hiopMatrixSparse& W) const
   {
-    assert(false && "implemented only for symmetric matrices");
+    assert(false && "counterpart method of hiopMatrixSymSparseTriplet should be used");
   }
 
   /* diag block of W += alpha * M * D^{-1} * transpose(M), where M=this

--- a/src/LinAlg/hiopVectorInt.hpp
+++ b/src/LinAlg/hiopVectorInt.hpp
@@ -80,6 +80,8 @@ public:
 
   virtual void copy_to_dev() = 0;
   virtual void copy_from_dev() = 0;
+  
+  virtual void copy_from(const index_type* v_local) = 0;
 };
 
 } // namespace hiop

--- a/src/LinAlg/hiopVectorIntRaja.cpp
+++ b/src/LinAlg/hiopVectorIntRaja.cpp
@@ -106,4 +106,13 @@ void hiopVectorIntRaja::copy_to_dev()
   }
 }
 
+void hiopVectorIntRaja::copy_from(const index_type* v_local)
+{
+  if(v_local) {
+    auto& resmgr = umpire::ResourceManager::getInstance();
+    index_type* data = const_cast<index_type*>(v_local);
+    resmgr.copy(buf_, data, sz_*sizeof(index_type));
+  }
+}
+
 } // namespace hiop

--- a/src/LinAlg/hiopVectorIntRaja.hpp
+++ b/src/LinAlg/hiopVectorIntRaja.hpp
@@ -97,6 +97,9 @@ public:
   virtual inline index_type* local_data() { return buf_; }
 
   virtual inline const index_type* local_data_const() const { return buf_; }
+  
+  virtual void copy_from(const index_type* v_local);
+
 };
 
 } // namespace hiop

--- a/src/LinAlg/hiopVectorIntSeq.cpp
+++ b/src/LinAlg/hiopVectorIntSeq.cpp
@@ -54,6 +54,7 @@
  */
 
 #include "hiopVectorIntSeq.hpp"
+#include <cstring> //for memcpy
 
 namespace hiop
 {
@@ -67,5 +68,12 @@ hiopVectorIntSeq::~hiopVectorIntSeq()
 {
   delete[] buf_;
 }
+
+void hiopVectorIntSeq::copy_from(const index_type* v_local)
+{
+  if(v_local)
+    memcpy(buf_, v_local, sz_*sizeof(index_type));
+}
+
 
 } // namespace hiop

--- a/src/LinAlg/hiopVectorIntSeq.hpp
+++ b/src/LinAlg/hiopVectorIntSeq.hpp
@@ -80,6 +80,9 @@ public:
   virtual inline index_type* local_data_host() { return local_data(); }
 
   virtual inline const index_type* local_data_host_const() const { return local_data_const(); }
+  
+  virtual void copy_from(const index_type* v_local);
+
 };
 
 } // namespace hiop

--- a/tests/LinAlg/matrixTestsRajaSparseTriplet.cpp
+++ b/tests/LinAlg/matrixTestsRajaSparseTriplet.cpp
@@ -61,6 +61,7 @@
 #include <hiopVectorRajaPar.hpp>
 #include <hiopMatrixRajaSparseTriplet.hpp>
 #include "matrixTestsRajaSparseTriplet.hpp"
+#include "hiopVectorIntRaja.hpp"
 
 namespace hiop{ namespace tests {
 
@@ -350,5 +351,26 @@ void MatrixTestsRajaSparseTriplet::maybeCopyFromDev(hiop::hiopMatrixSparse* mat)
   { }
 }
 
+int MatrixTestsRajaSparseTriplet::getLocalElement(hiop::hiopVectorInt* xvec, int idx) const
+{
+  if(auto* x = dynamic_cast<hiop::hiopVectorIntRaja*>(xvec)) {
+    x->copy_from_dev();
+    return x->local_data_host_const()[idx];
+  } else {
+    assert(false && "Wrong type of vector passed into `MatrixTestsRajaSparseTriplet::getLocalElement`!");
+  }
+  return 0;
+}
+
+void MatrixTestsRajaSparseTriplet::setLocalElement(hiop::hiopVectorInt* xvec, int idx, int value) const
+{
+  if(auto* x = dynamic_cast<hiop::hiopVectorIntRaja*>(xvec)) {
+    x->copy_from_dev();
+    x->local_data_host()[idx] = value;
+    x->copy_to_dev();
+  } else {
+    assert(false && "Wrong type of vector passed into `MatrixTestsRajaSparseTriplet::setLocalElement`!");
+  }
+}
 
 }} // namespace hiop::tests

--- a/tests/LinAlg/matrixTestsRajaSparseTriplet.cpp
+++ b/tests/LinAlg/matrixTestsRajaSparseTriplet.cpp
@@ -175,6 +175,32 @@ int MatrixTestsRajaSparseTriplet::verifyAnswer(hiop::hiopMatrixSparse* A, const 
   return fail;
 }
 
+/**
+ *  * @brief Verifies values of the sparse matrix *only at indices already defined by the sparsity pattern*
+ *   * This may seem misleading, but verify answer does not check *every* value of the matrix,
+ *    * but only `nnz` elements with index from nnz_st to nnz_ed
+ *     *
+ *      */
+[[nodiscard]]
+int MatrixTestsRajaSparseTriplet::verifyAnswer(hiop::hiopMatrix* A, local_ordinal_type nnz_st, local_ordinal_type nnz_ed, const double answer)
+{
+  if(A == nullptr)
+    return 1;
+  auto mat = dynamic_cast<hiop::hiopMatrixRajaSparseTriplet*>(A);
+  mat->copyFromDev();
+  const local_ordinal_type nnz = mat->numberOfNonzeros();
+  const real_type* values = mat->M_host();
+  int fail = 0;
+  for (local_ordinal_type i=nnz_st; i<nnz_ed; i++)
+  {
+    if (!isEqual(values[i], answer))
+    {
+      fail++;
+    }
+  }
+  return fail;
+}
+
 /*
  * Pass a function-like object to calculate the expected
  * answer dynamically, based on the row and column

--- a/tests/LinAlg/matrixTestsRajaSparseTriplet.cpp
+++ b/tests/LinAlg/matrixTestsRajaSparseTriplet.cpp
@@ -176,11 +176,10 @@ int MatrixTestsRajaSparseTriplet::verifyAnswer(hiop::hiopMatrixSparse* A, const 
 }
 
 /**
- *  * @brief Verifies values of the sparse matrix *only at indices already defined by the sparsity pattern*
- *   * This may seem misleading, but verify answer does not check *every* value of the matrix,
- *    * but only `nnz` elements with index from nnz_st to nnz_ed
- *     *
- *      */
+ * @brief Verifies values of the sparse matrix *only at indices already defined by the sparsity pattern*
+ * This may seem misleading, but verify answer does not check *every* value of the matrix,
+ * but only `nnz` elements with index from nnz_st to nnz_ed
+ */
 [[nodiscard]]
 int MatrixTestsRajaSparseTriplet::verifyAnswer(hiop::hiopMatrix* A, local_ordinal_type nnz_st, local_ordinal_type nnz_ed, const double answer)
 {

--- a/tests/LinAlg/matrixTestsRajaSparseTriplet.hpp
+++ b/tests/LinAlg/matrixTestsRajaSparseTriplet.hpp
@@ -90,7 +90,7 @@ private:
   virtual const local_ordinal_type* getColumnIndices(const hiop::hiopMatrixSparse* a);
   virtual local_ordinal_type getLocalSize(const hiop::hiopVector *x) override;
   virtual int verifyAnswer(hiop::hiopMatrixSparse* A, real_type answer) override;
-  virtual int verifyAnswer(hiop::hiopMatrix* A, local_ordinal_type nnz_st, local_ordinal_type nnz_ed, const double answer) {assert(false);return 0;};
+  virtual int verifyAnswer(hiop::hiopMatrix* A, local_ordinal_type nnz_st, local_ordinal_type nnz_ed, const double answer);
   virtual int verifyAnswer(
       hiop::hiopMatrixDense* A,
       std::function<real_type(local_ordinal_type, local_ordinal_type)> expect) override;

--- a/tests/LinAlg/matrixTestsRajaSparseTriplet.hpp
+++ b/tests/LinAlg/matrixTestsRajaSparseTriplet.hpp
@@ -102,6 +102,9 @@ private:
   virtual local_ordinal_type* numNonzerosPerCol(hiop::hiopMatrixSparse* mat);
   virtual void maybeCopyToDev(hiop::hiopMatrixSparse*);
   virtual void maybeCopyFromDev(hiop::hiopMatrixSparse*);
+
+  virtual int getLocalElement(hiop::hiopVectorInt*, int) const;
+  virtual void setLocalElement(hiop::hiopVectorInt*, int, int) const;
 public:
   virtual void initializeMatrix(hiop::hiopMatrixSparse* mat, local_ordinal_type entries_per_row);
 };

--- a/tests/LinAlg/matrixTestsSparse.hpp
+++ b/tests/LinAlg/matrixTestsSparse.hpp
@@ -1027,13 +1027,12 @@ public:
   * @pre User must know the nonzero pattern of A and B. Assume non-zero patterns of A and B wont change, and A is a submatrix of B
   * @pre Otherwise, this function may replace the non-zero values and nonzero patterns for the undesired elements.
   */
-  int
-  copyRowsBlockFrom(
-    hiop::hiopMatrixSparse& A,
-    hiop::hiopMatrixSparse& B,
-    local_ordinal_type A_rows_st, local_ordinal_type n_rows,
-    local_ordinal_type B_rows_st, local_ordinal_type B_nnz_st
-    )
+  int copy_rows_block_from(hiop::hiopMatrixSparse& A,
+                           hiop::hiopMatrixSparse& B,
+                           local_ordinal_type A_rows_st,
+                           local_ordinal_type n_rows,
+                           local_ordinal_type B_rows_st,
+                           local_ordinal_type B_nnz_st)
   {
     const local_ordinal_type* A_iRow = getRowIndices(&A);
     const local_ordinal_type* A_jCol = getColumnIndices(&A);

--- a/tests/LinAlg/matrixTestsSparse.hpp
+++ b/tests/LinAlg/matrixTestsSparse.hpp
@@ -942,7 +942,39 @@ public:
     return fail;
   }
 
+  /// @brief Copies rows from another sparse matrix into this one, according to the patten `select`. ith row of A = select[i]_th row of B 
+  int matrix_copy_rows_from( hiop::hiopMatrixSparse& A, hiop::hiopMatrixSparse& B, local_ordinal_type& select)
+  {
+    const local_ordinal_type* A_iRow = getRowIndices(&A);
+    const local_ordinal_type* A_jCol = getColumnIndices(&A);
+    const local_ordinal_type A_nnz = A.numberOfNonzeros();
 
+    const local_ordinal_type* B_iRow = getRowIndices(&B);
+    const local_ordinal_type* B_jCol = getColumnIndices(&B);
+    const local_ordinal_type B_nnz = B.numberOfNonzeros();
+
+    int n_A_rows = A.m();
+    int n_B_rows = B.m();    
+    assert(A.n() == B.n());
+    assert(n_A_rows <= n_B_rows);
+
+    const real_type A_val = one;
+    const real_type B_val = two;
+
+    A.setToConstant(A_val);
+    B.setToConstant(B_val);
+
+    int fail{0};
+
+    A.copyRowsFrom(B, &select, n_A_rows);
+
+    //FIXME_NY
+    fail += verifyAnswer(&A, two),    
+    
+    printMessage(fail, __func__);
+    return fail;
+
+  }
 
   /// @todo add implementation of `startingAtAddSubDiagonalToStartingAt`
   /// for abstract sparse matrix interface and all sparse matrix classes, 

--- a/tests/LinAlg/matrixTestsSparse.hpp
+++ b/tests/LinAlg/matrixTestsSparse.hpp
@@ -973,7 +973,6 @@ public:
 
     A.copyRowsFrom(B, select.local_data_const(), n_A_rows);
 
-    //FIXME_NY
     fail += verifyAnswer(&A, two),    
     
     printMessage(fail, __func__);

--- a/tests/LinAlg/matrixTestsSparse.hpp
+++ b/tests/LinAlg/matrixTestsSparse.hpp
@@ -64,6 +64,7 @@
 #include <hiopMatrixSparseTriplet.hpp>
 #include <hiopMatrixRajaSparseTriplet.hpp>
 #include <hiopVectorPar.hpp>
+#include <hiopVectorInt.hpp>
 #include "testBase.hpp"
 
 namespace hiop { namespace tests {
@@ -943,7 +944,7 @@ public:
   }
 
   /// @brief Copies rows from another sparse matrix into this one, according to the patten `select`. ith row of A = select[i]_th row of B 
-  int matrix_copy_rows_from( hiop::hiopMatrixSparse& A, hiop::hiopMatrixSparse& B, local_ordinal_type& select)
+  int matrix_copy_rows_from( hiop::hiopMatrixSparse& A, hiop::hiopMatrixSparse& B, hiop::hiopVectorInt& select)
   {
     const local_ordinal_type* A_iRow = getRowIndices(&A);
     const local_ordinal_type* A_jCol = getColumnIndices(&A);
@@ -964,9 +965,13 @@ public:
     A.setToConstant(A_val);
     B.setToConstant(B_val);
 
+    for(int i=0; i<select.size(); i++) {
+      setLocalElement(&select, i, 2*i);
+    }
+
     int fail{0};
 
-    A.copyRowsFrom(B, &select, n_A_rows);
+    A.copyRowsFrom(B, select.local_data_const(), n_A_rows);
 
     //FIXME_NY
     fail += verifyAnswer(&A, two),    
@@ -1216,6 +1221,9 @@ private:
   virtual local_ordinal_type* numNonzerosPerCol(hiop::hiopMatrixSparse* mat) = 0;
   virtual void maybeCopyToDev(hiop::hiopMatrixSparse*) = 0;
   virtual void maybeCopyFromDev(hiop::hiopMatrixSparse*) = 0;
+
+  virtual int getLocalElement(hiop::hiopVectorInt*, int) const = 0;
+  virtual void setLocalElement(hiop::hiopVectorInt*, int, int) const = 0;
 
 public:
   /**

--- a/tests/LinAlg/matrixTestsSparseTriplet.cpp
+++ b/tests/LinAlg/matrixTestsSparseTriplet.cpp
@@ -59,6 +59,7 @@
 #include <cstring>
 #include <hiopMatrix.hpp>
 #include "matrixTestsSparseTriplet.hpp"
+#include <hiopVectorIntSeq.hpp>
 
 namespace hiop{ namespace tests {
 
@@ -389,6 +390,24 @@ int MatrixTestsSparseTriplet::copyRowsBlockFrom(hiop::hiopMatrixSparse& src_gen,
 
   printMessage(fail, __func__);
   return fail;
+}
+
+int MatrixTestsSparseTriplet::getLocalElement(hiop::hiopVectorInt* xvec, int idx) const
+{
+  if(auto* x = dynamic_cast<hiop::hiopVectorIntSeq*>(xvec)) {
+    return x->local_data_host_const()[idx];
+  } else {
+    assert(false && "Wrong type of vector passed into `MatrixTestsSparseTriplet::getLocalElement`!");
+  }
+}
+
+void MatrixTestsSparseTriplet::setLocalElement(hiop::hiopVectorInt* xvec, int idx, int value) const
+{
+  if(auto* x = dynamic_cast<hiop::hiopVectorIntSeq*>(xvec)) {
+    x->local_data_host()[idx] = value;
+  } else {
+    assert(false && "Wrong type of vector passed into `MatrixTestsSparseTriplet::setLocalElement`!");
+  }
 }
 
 }} // namespace hiop::tests

--- a/tests/LinAlg/matrixTestsSparseTriplet.cpp
+++ b/tests/LinAlg/matrixTestsSparseTriplet.cpp
@@ -344,54 +344,6 @@ void MatrixTestsSparseTriplet::maybeCopyToDev(hiop::hiopMatrixSparse*) { }
  */
 void MatrixTestsSparseTriplet::maybeCopyFromDev(hiop::hiopMatrixSparse*) { }
 
-int MatrixTestsSparseTriplet::copyRowsBlockFrom(hiop::hiopMatrixSparse& src_gen,hiop::hiopMatrixSparse& dist_gen,
-                                         local_ordinal_type rows_src_idx_st, local_ordinal_type n_rows,
-                                         local_ordinal_type rows_dest_idx_st, local_ordinal_type dest_nnz_st
-                                         )
-{
-  auto &src_Mat = dynamic_cast<hiop::hiopMatrixSparseTriplet&>(src_gen);
-  auto &dist_Mat = dynamic_cast<hiop::hiopMatrixSparseTriplet&>(dist_gen);
-  assert(dist_Mat.n() >= src_Mat.n());
-  assert(n_rows + rows_src_idx_st <= src_Mat.m());
-  assert(n_rows + rows_dest_idx_st <= dist_Mat.m());
-
-  auto iRow_src = src_Mat.i_row();
-  auto jCol_src = src_Mat.j_col();
-  auto values_src = src_Mat.M();
-  auto nnz_src = src_Mat.numberOfNonzeros();
-  auto itnz_src{0};
-  auto itnz_dest=dest_nnz_st;
-  int fail{0};
-  
-  auto iRow_ = dist_Mat.i_row();
-  auto jCol_ = dist_Mat.j_col();
-  auto values_ = dist_Mat.M();
-  auto nnz_ = dist_Mat.numberOfNonzeros();
-
-  //int iterators should suffice
-  for(auto row_add=0; row_add<n_rows; ++row_add) {
-    auto row_src  = rows_src_idx_st  + row_add;
-    auto row_dest = rows_dest_idx_st + row_add;
-    
-   // assuming the source matrix is row-major orderd, otherwise we need to check all the nonzeros
-    while(itnz_src<nnz_src && iRow_src[itnz_src]<row_src) {
-      ++itnz_src;
-    }
-
-    while(itnz_src<nnz_src && iRow_src[itnz_src]==row_src) {
-      assert(itnz_dest<nnz_);
-      iRow_[itnz_dest] = row_dest;//iRow_src[itnz_src];
-      jCol_[itnz_dest] = jCol_src[itnz_src];
-      values_[itnz_dest++] = values_src[itnz_src++];
-
-      assert(itnz_dest<=nnz_);
-    }
-  }
-
-  printMessage(fail, __func__);
-  return fail;
-}
-
 int MatrixTestsSparseTriplet::getLocalElement(hiop::hiopVectorInt* xvec, int idx) const
 {
   if(auto* x = dynamic_cast<hiop::hiopVectorIntSeq*>(xvec)) {

--- a/tests/LinAlg/matrixTestsSparseTriplet.hpp
+++ b/tests/LinAlg/matrixTestsSparseTriplet.hpp
@@ -82,13 +82,13 @@ private:
   virtual void setLocalElement(
       hiop::hiopVector *_x,
       const local_ordinal_type i,
-      const real_type val);
+      const real_type val) override;
   virtual real_type getLocalElement(const hiop::hiopMatrix *a, local_ordinal_type i, local_ordinal_type j) override;
   virtual real_type getLocalElement(const hiop::hiopVector *x, local_ordinal_type i) override;
   virtual real_type* getMatrixData(hiop::hiopMatrixSparse* a) override;
   virtual real_type getMatrixData(hiop::hiopMatrixSparse* a, local_ordinal_type i, local_ordinal_type j) override;
-  virtual const local_ordinal_type* getRowIndices(const hiop::hiopMatrixSparse* a);
-  virtual const local_ordinal_type* getColumnIndices(const hiop::hiopMatrixSparse* a);
+  virtual const local_ordinal_type* getRowIndices(const hiop::hiopMatrixSparse* a) override;
+  virtual const local_ordinal_type* getColumnIndices(const hiop::hiopMatrixSparse* a) override;
   virtual local_ordinal_type getLocalSize(const hiop::hiopVector *x) override;
   virtual int verifyAnswer(hiop::hiopMatrixSparse* A, real_type answer) override;
   virtual int verifyAnswer(hiop::hiopMatrix* A, local_ordinal_type nnz_st, local_ordinal_type nnz_ed, const double answer) override;
@@ -99,12 +99,15 @@ private:
   virtual int verifyAnswer(
       hiop::hiopVector *x,
       std::function<real_type(local_ordinal_type)> expect) override;
-  virtual local_ordinal_type* numNonzerosPerRow(hiop::hiopMatrixSparse* mat);
-  virtual local_ordinal_type* numNonzerosPerCol(hiop::hiopMatrixSparse* mat);
-  virtual void maybeCopyToDev(hiop::hiopMatrixSparse*);
-  virtual void maybeCopyFromDev(hiop::hiopMatrixSparse*);
+  virtual local_ordinal_type* numNonzerosPerRow(hiop::hiopMatrixSparse* mat) override;
+  virtual local_ordinal_type* numNonzerosPerCol(hiop::hiopMatrixSparse* mat) override;
+  virtual void maybeCopyToDev(hiop::hiopMatrixSparse*) override;
+  virtual void maybeCopyFromDev(hiop::hiopMatrixSparse*) override;
+
+  virtual int getLocalElement(hiop::hiopVectorInt*, int) const override;
+  virtual void setLocalElement(hiop::hiopVectorInt*, int, int) const override;
 public:
-  virtual void initializeMatrix(hiop::hiopMatrixSparse* mat, local_ordinal_type entries_per_row);
+  virtual void initializeMatrix(hiop::hiopMatrixSparse* mat, local_ordinal_type entries_per_row) override;
   virtual int copyRowsBlockFrom(hiop::hiopMatrixSparse& src_gen, hiop::hiopMatrixSparse& dist_gen,
                                          local_ordinal_type rows_src_idx_st, local_ordinal_type n_rows,
                                          local_ordinal_type rows_dest_idx_st, local_ordinal_type dest_nnz_st

--- a/tests/LinAlg/matrixTestsSparseTriplet.hpp
+++ b/tests/LinAlg/matrixTestsSparseTriplet.hpp
@@ -108,10 +108,6 @@ private:
   virtual void setLocalElement(hiop::hiopVectorInt*, int, int) const override;
 public:
   virtual void initializeMatrix(hiop::hiopMatrixSparse* mat, local_ordinal_type entries_per_row) override;
-  virtual int copyRowsBlockFrom(hiop::hiopMatrixSparse& src_gen, hiop::hiopMatrixSparse& dist_gen,
-                                         local_ordinal_type rows_src_idx_st, local_ordinal_type n_rows,
-                                         local_ordinal_type rows_dest_idx_st, local_ordinal_type dest_nnz_st
-                                         );
 };
 
 }} // namespace hiop::tests

--- a/tests/LinAlg/matrixTestsSymSparseTriplet.hpp
+++ b/tests/LinAlg/matrixTestsSymSparseTriplet.hpp
@@ -82,8 +82,8 @@ private:
   virtual real_type getLocalElement(const hiop::hiopMatrix *a, local_ordinal_type i, local_ordinal_type j) override;
   virtual real_type getLocalElement(const hiop::hiopVector *x, local_ordinal_type i) override;
   virtual real_type* getMatrixData(hiop::hiopMatrixSparse* a) override;
-  virtual const local_ordinal_type* getRowIndices(const hiop::hiopMatrixSparse* a);
-  virtual const local_ordinal_type* getColumnIndices(const hiop::hiopMatrixSparse* a);
+  virtual const local_ordinal_type* getRowIndices(const hiop::hiopMatrixSparse* a) override;
+  virtual const local_ordinal_type* getColumnIndices(const hiop::hiopMatrixSparse* a) override;
   virtual local_ordinal_type getLocalSize(const hiop::hiopVector *x) override;
   virtual int verifyAnswer(
       hiop::hiopMatrixDense* A,
@@ -91,8 +91,8 @@ private:
   virtual int verifyAnswer(
       hiop::hiopVector *x,
       std::function<real_type(local_ordinal_type)> expect) override;
-  virtual local_ordinal_type* numNonzerosPerRow(hiop::hiopMatrixSparse* mat);
-  virtual local_ordinal_type* numNonzerosPerCol(hiop::hiopMatrixSparse* mat);
+  virtual local_ordinal_type* numNonzerosPerRow(hiop::hiopMatrixSparse* mat) override;
+  virtual local_ordinal_type* numNonzerosPerCol(hiop::hiopMatrixSparse* mat) override;
 };
 
 }} // namespace hiop::tests

--- a/tests/LinAlg/vectorTestsInt.hpp
+++ b/tests/LinAlg/vectorTestsInt.hpp
@@ -122,6 +122,33 @@ public:
     return fail;
   }
 
+  virtual bool vector_copy_from(hiop::hiopVectorInt& x, hiop::hiopVectorInt& y) const
+  {
+    int fail = 0;
+    const int idx = x.size()/2;
+    const int x_val = 1;
+    const int y_val = 1;
+
+    for(int i=0; i<x.size(); i++) {
+      setLocalElement(&x, i, x_val);
+    }
+    
+    for(int i=0; i<y.size(); i++) {
+      setLocalElement(&y, i, y_val);
+    }
+    
+    x.copy_from(y.local_data_const());
+
+    for(int i=0; i<x.size(); i++) {
+      if (x.local_data_host_const()[i] != y_val) {
+        fail++;
+      }
+    }
+
+    printMessage(fail, __func__);
+    return fail;
+  }
+
 private:
   virtual int getLocalElement(hiop::hiopVectorInt*, int) const = 0;
   virtual void setLocalElement(hiop::hiopVectorInt*, int, int) const = 0;

--- a/tests/testMatrixSparse.cpp
+++ b/tests/testMatrixSparse.cpp
@@ -148,11 +148,7 @@ int main(int argc, char** argv)
 
     fail += test.matrixTimesMatTrans(*mxn_sparse, *m2xn_sparse, mxm2_dense);
     fail += test.matrixAddMDinvNtransToSymDeMatUTri(*mxn_sparse, *m2xn_sparse, vec_n, W_dense, i_offset, j_offset);
-    
-    // copy the 1st row of mxn_sparse to the last row.
-    // replace the nonzero index from "nnz-entries_per_row"
-    fail += test.copyRowsBlockFrom(*mxn_sparse, *m2xn_sparse,0, 1, M_global-1, mxn_sparse->numberOfNonzeros()-entries_per_row);
-
+  
     // copy sparse matrix to a dense matrix
     hiop::hiopMatrixDenseRowMajor mxn_dense(M_global, N_global);
     fail += test.matrix_copy_to(mxn_dense, *mxn_sparse);
@@ -170,6 +166,10 @@ int main(int argc, char** argv)
     
     hiop::hiopVectorIntSeq select(M_local);
     fail += test.matrix_copy_rows_from(*mxn_sparse, *m2xn_sparse, select);
+
+    // copy the 1st row of mxn_sparse to the last row in m2xn_sparse
+    // replace the nonzero index from "nnz-entries_per_row"
+    fail += test.copy_rows_block_from(*mxn_sparse, *m2xn_sparse,0, 1, M_global-1, mxn_sparse->numberOfNonzeros()-entries_per_row);
 
     // Remove testing objects
     delete mxn_sparse;
@@ -262,6 +262,10 @@ int main(int argc, char** argv)
   
     hiop::hiopVectorIntRaja select(M_local, mem_space);
     fail += test.matrix_copy_rows_from(*mxn_sparse, *m2xn_sparse, select);
+
+    // copy the 1st row of mxn_sparse to the last row in m2xn_sparse
+    // replace the nonzero index from "nnz-entries_per_row"
+    fail += test.copy_rows_block_from(*mxn_sparse, *m2xn_sparse,0, 1, M_global-1, mxn_sparse->numberOfNonzeros()-entries_per_row);
 
     // Remove testing objects
     delete mxn_sparse;

--- a/tests/testMatrixSparse.cpp
+++ b/tests/testMatrixSparse.cpp
@@ -165,8 +165,15 @@ int main(int argc, char** argv)
     // functions used to build large sparse matrix from small pieces
     fail += test.matrix_copy_subdiagonal_from(m3xn3_dense, *m3xn3_sparse, vec_m);
     fail += test.matrix_set_subdiagonal_to(m3xn3_dense, *m3xn3_sparse);
+    
+    local_ordinal_type *select = new local_ordinal_type[M_local];
+    for(auto i=0; i<M_local; i++){
+      select[i] = 2*i;
+    }
+    fail += test.matrix_copy_rows_from(*mxn_sparse, *m2xn_sparse, *select);
 
     // Remove testing objects
+    delete [] select;
     delete mxn_sparse;
     delete m2xn_sparse;
     delete m3xn3_sparse;
@@ -251,7 +258,28 @@ int main(int argc, char** argv)
       hiop::LinearAlgebraFactory::createMatrixSparse(M_global+M2, N_global+2*(M_global+M2), nnz3);
     fail += test.matrix_set_Jac_FR(m3xn3_dense, *m3xn3_sparse, *mxn_sparse, *m2xn_sparse);
 
+    // functions used to build large sparse matrix from small pieces
+    fail += test.matrix_copy_subdiagonal_from(m3xn3_dense, *m3xn3_sparse, vec_m);
+    fail += test.matrix_set_subdiagonal_to(m3xn3_dense, *m3xn3_sparse);
+    
+    local_ordinal_type *select = new local_ordinal_type[M_local];
+    for(auto i=0; i<M_local; i++){
+      select[i] = 2*i;
+    }
+    
+
+
+    local_ordinal_type *select_host = new local_ordinal_type[M_local];
+    for(auto i=0; i<M_local; i++){
+      select_host[i] = 2*i;
+    }
+    hiop::hiopVectorIntRaja select(N_global, mem_space);
+    select.copy_from(select_host);
+  
+    fail += test.matrix_copy_rows_from(*mxn_sparse, *m2xn_sparse, *select);
+
     // Remove testing objects
+    delete [] select_host;
     delete mxn_sparse;
     delete m2xn_sparse;
     delete m3xn3_sparse;

--- a/tests/testMatrixSparse.cpp
+++ b/tests/testMatrixSparse.cpp
@@ -116,7 +116,7 @@ int main(int argc, char** argv)
     fail += test.matrix_row_max_abs_value(*mxn_sparse, vec_m);
     fail += test.matrix_scale_row(*mxn_sparse, vec_m);
     fail += test.matrixIsFinite(*mxn_sparse);
-
+  
     // Need a dense matrix to store the output of the following tests
     global_ordinal_type W_delta = M_global * 10;
     hiop::hiopMatrixDenseRowMajor W_dense(N_global + W_delta, N_global + W_delta);
@@ -151,7 +151,7 @@ int main(int argc, char** argv)
     // replace the nonzero index from "nnz-entries_per_row"
     fail += test.copyRowsBlockFrom(*mxn_sparse, *m2xn_sparse,0, 1, M_global-1, mxn_sparse->numberOfNonzeros()-entries_per_row);
 
-    // copy sparse matrix to dense matrix
+    // copy sparse matrix to a dense matrix
     hiop::hiopMatrixDenseRowMajor mxn_dense(M_global, N_global);
     fail += test.matrix_copy_to(mxn_dense, *mxn_sparse);
   
@@ -161,6 +161,10 @@ int main(int argc, char** argv)
     hiop::hiopMatrixSparse* m3xn3_sparse = 
       hiop::LinearAlgebraFactory::createMatrixSparse(M_global+M2, N_global+2*(M_global+M2), nnz3);
     fail += test.matrix_set_Jac_FR(m3xn3_dense, *m3xn3_sparse, *mxn_sparse, *m2xn_sparse);
+
+    // functions used to build large sparse matrix from small pieces
+    fail += test.matrix_copy_subdiagonal_from(m3xn3_dense, *m3xn3_sparse, vec_m);
+    fail += test.matrix_set_subdiagonal_to(m3xn3_dense, *m3xn3_sparse);
 
     // Remove testing objects
     delete mxn_sparse;

--- a/tests/testMatrixSparse.cpp
+++ b/tests/testMatrixSparse.cpp
@@ -62,10 +62,12 @@
 #include <hiopOptions.hpp>
 #include <hiopLinAlgFactory.hpp>
 #include <hiopVector.hpp>
+#include <hiopVectorIntSeq.hpp>
 #include <hiopMatrixDenseRowMajor.hpp>
 #include "LinAlg/matrixTestsSparseTriplet.hpp"
 
 #ifdef HIOP_USE_RAJA
+#include <hiopVectorIntRaja.hpp>
 #include <hiopVectorRajaPar.hpp>
 #include <hiopMatrixRajaDense.hpp>
 #include "LinAlg/matrixTestsRajaSparseTriplet.hpp"
@@ -166,14 +168,10 @@ int main(int argc, char** argv)
     fail += test.matrix_copy_subdiagonal_from(m3xn3_dense, *m3xn3_sparse, vec_m);
     fail += test.matrix_set_subdiagonal_to(m3xn3_dense, *m3xn3_sparse);
     
-    local_ordinal_type *select = new local_ordinal_type[M_local];
-    for(auto i=0; i<M_local; i++){
-      select[i] = 2*i;
-    }
-    fail += test.matrix_copy_rows_from(*mxn_sparse, *m2xn_sparse, *select);
+    hiop::hiopVectorIntSeq select(M_local);
+    fail += test.matrix_copy_rows_from(*mxn_sparse, *m2xn_sparse, select);
 
     // Remove testing objects
-    delete [] select;
     delete mxn_sparse;
     delete m2xn_sparse;
     delete m3xn3_sparse;
@@ -261,25 +259,11 @@ int main(int argc, char** argv)
     // functions used to build large sparse matrix from small pieces
     fail += test.matrix_copy_subdiagonal_from(m3xn3_dense, *m3xn3_sparse, vec_m);
     fail += test.matrix_set_subdiagonal_to(m3xn3_dense, *m3xn3_sparse);
-    
-    local_ordinal_type *select = new local_ordinal_type[M_local];
-    for(auto i=0; i<M_local; i++){
-      select[i] = 2*i;
-    }
-    
-
-
-    local_ordinal_type *select_host = new local_ordinal_type[M_local];
-    for(auto i=0; i<M_local; i++){
-      select_host[i] = 2*i;
-    }
-    hiop::hiopVectorIntRaja select(N_global, mem_space);
-    select.copy_from(select_host);
   
-    fail += test.matrix_copy_rows_from(*mxn_sparse, *m2xn_sparse, *select);
+    hiop::hiopVectorIntRaja select(M_local, mem_space);
+    fail += test.matrix_copy_rows_from(*mxn_sparse, *m2xn_sparse, select);
 
     // Remove testing objects
-    delete [] select_host;
     delete mxn_sparse;
     delete m2xn_sparse;
     delete m3xn3_sparse;

--- a/tests/testMatrixSparse.cpp
+++ b/tests/testMatrixSparse.cpp
@@ -261,7 +261,8 @@ int main(int argc, char** argv)
     fail += test.matrix_set_subdiagonal_to(m3xn3_dense, *m3xn3_sparse);
   
     hiop::hiopVectorIntRaja select(M_local, mem_space);
-    fail += test.matrix_copy_rows_from(*mxn_sparse, *m2xn_sparse, select);
+    hiop::hiopMatrixSparse* mxn_sparse_2 = hiop::LinearAlgebraFactory::createMatrixSparse(M_local, N_local, nnz);
+    fail += test.matrix_copy_rows_from(*mxn_sparse_2, *m2xn_sparse, select);
 
     // copy the 1st row of mxn_sparse to the last row in m2xn_sparse
     // replace the nonzero index from "nnz-entries_per_row"
@@ -269,6 +270,7 @@ int main(int argc, char** argv)
 
     // Remove testing objects
     delete mxn_sparse;
+    delete mxn_sparse_2;
     delete m2xn_sparse;
     delete m3xn3_sparse;
 

--- a/tests/testVector.cpp
+++ b/tests/testVector.cpp
@@ -342,7 +342,11 @@ int runIntTests(const char* mem_space)
   fail += test.vectorGetElement(*x);
   fail += test.vectorSetElement(*x);
 
+  auto* y = LinearAlgebraFactory::createVectorInt(sz);
+  fail += test.vector_copy_from(*x, *y);
+  
   delete x;
+  delete y;
 
   return fail;
 }


### PR DESCRIPTION
This PR is ready for review.
Note that I will change the base from `fr-mds-dev` to develop once we merge #239 

In this PR, I addressed the following functions and their corresponding unit tests:
1. `hiopMatrixRajaSparseTriplet::copyRowsFrom` 
2. `hiopMatrixRajaSparseTriplet::copy_rows_block_from` 
3. `hiopMatrixRajaSparseTriplet::copySubDiagonalFrom`
4. `hiopMatrixRajaSparseTriplet::setSubDiagonalTo`
5. `hiopVectorIntRaja::copy_from`

According to the discussion with Cosmin, I will address other RAJA functions in different PRs.
Try to make each PR as short as possible, so others can review the code easily.

CLOSE #103 