### PR TITLE
Header install hotfix

### DIFF
--- a/src/Interface/CMakeLists.txt
+++ b/src/Interface/CMakeLists.txt
@@ -14,6 +14,7 @@ set(hiopInterface_INTERFACE_HEADERS
   hiopInterface.h
   hiopInterface.hpp
   hiopVersion.hpp
+  hiop_types.h
   )
 
 install(

--- a/src/Interface/CMakeLists.txt
+++ b/src/Interface/CMakeLists.txt
@@ -13,6 +13,7 @@ set(hiopInterface_INTERFACE_HEADERS
   chiopInterface.hpp
   hiopInterface.h
   hiopInterface.hpp
+  hiopInterfacePrimalDecomp.hpp
   hiopVersion.hpp
   hiop_types.h
   )


### PR DESCRIPTION
`hiop_defs.hpp` now includes `hiop_types.h` as of commit `37ea1152`. Some installed headers include `hiop_defs.hpp`, but `hiop_types.h` is not installed, so dependents of hiop fail to build. Is this intended behavior? If so, this patch should fix it.