### PR TITLE
Add missing pridecomp header in src/Opt

### DIFF
--- a/src/Optimization/CMakeLists.txt
+++ b/src/Optimization/CMakeLists.txt
@@ -20,6 +20,7 @@ set(hiopOptimization_SPARSE_SRC
 
 set(hiopOptimization_INTERFACE_HEADERS
   hiopAlgFilterIPM.hpp
+  hiopAlgPrimalDecomp.hpp
   hiopDualsUpdater.hpp
   hiopFactAcceptor.hpp
   hiopFilter.hpp


### PR DESCRIPTION
Found another missing header. I think this should be the last.