### PR TITLE
modify rowStartInfo for hiopMatrixRajaSparseTriplet

### DIFF
--- a/src/LinAlg/hiopMatrixRajaSparseTriplet.cpp
+++ b/src/LinAlg/hiopMatrixRajaSparseTriplet.cpp
@@ -1486,7 +1486,7 @@ void hiopMatrixRajaSymSparseTriplet::set_Hess_FR(const hiopMatrixSparse& Hess,
             
             { // nonzeros from the base Hessian
               index_type k_base = M2_row_start_host[i-1];
-              inindex_type nnz_in_row_base = M2_row_start_host[i] - k_base;
+              index_type nnz_in_row_base = M2_row_start_host[i] - k_base;
               
               if(nnz_in_row_base > 0 && M2iRow_host[k_base] == M2jCol_host[k_base]) {
                 // first nonzero in this row is a diagonal term (Hess is in upper triangular form)

--- a/src/LinAlg/hiopMatrixRajaSparseTriplet.cpp
+++ b/src/LinAlg/hiopMatrixRajaSparseTriplet.cpp
@@ -70,9 +70,7 @@
 #include <cstring>
 
 #include <cassert>
-#include <iterator>
-#include <numeric>
-#include <vector>
+// #include <numeric> //std::inclusive_scan is only available after C++17
 
 namespace hiop
 {

--- a/src/LinAlg/hiopMatrixRajaSparseTriplet.hpp
+++ b/src/LinAlg/hiopMatrixRajaSparseTriplet.hpp
@@ -301,6 +301,7 @@ protected:
   struct RowStartsInfo
   {
     int *idx_start_; //size num_rows+1
+    int *idx_start_host_; //size num_rows+1
     int num_rows_;
     std::string mem_space_;
     RowStartsInfo()
@@ -309,10 +310,12 @@ protected:
     RowStartsInfo(int n_rows, std::string memspace);
       //: idx_start(new int[n_rows+1]), num_rows(n_rows)
     virtual ~RowStartsInfo();
+    
+    void copy_from_dev();
+    void copy_to_dev();
   };
 
-  mutable RowStartsInfo* row_starts_host;
-  //mutable RowStartsInfo* row_starts;
+  mutable RowStartsInfo* row_starts_;
 
 protected:
   RowStartsInfo* allocAndBuildRowStarts() const; 

--- a/src/LinAlg/hiopMatrixRajaSparseTriplet.hpp
+++ b/src/LinAlg/hiopMatrixRajaSparseTriplet.hpp
@@ -300,15 +300,14 @@ protected:
 protected:
   struct RowStartsInfo
   {
-    int *idx_start_; //size num_rows+1
-    int *idx_start_host_; //size num_rows+1
-    int num_rows_;
+    index_type *idx_start_; //size num_rows+1
+    index_type *idx_start_host_; //size num_rows+1
+    size_type num_rows_;
     std::string mem_space_;
     RowStartsInfo()
       : idx_start_(NULL), num_rows_(0)
     {}
-    RowStartsInfo(int n_rows, std::string memspace);
-      //: idx_start(new int[n_rows+1]), num_rows(n_rows)
+    RowStartsInfo(size_type n_rows, std::string memspace);
     virtual ~RowStartsInfo();
     
     void copy_from_dev();

--- a/src/LinAlg/hiopMatrixSparseTriplet.cpp
+++ b/src/LinAlg/hiopMatrixSparseTriplet.cpp
@@ -172,8 +172,8 @@ void hiopMatrixSparseTriplet::timesMatTrans(double beta,
     // j>=i
     for(int j=0; j<m2; j++) {
       acc = 0.;
-      int ki=M1.row_starts_->idx_start_[i];
-      int kj=M2.row_starts_->idx_start_[j];
+      index_type ki=M1.row_starts_->idx_start_[i];
+      index_type kj=M2.row_starts_->idx_start_[j];
 
       while(ki<M1.row_starts_->idx_start_[i+1] && kj<M2.row_starts_->idx_start_[j+1]) {
         assert(ki<M1.nnz_);
@@ -408,7 +408,7 @@ addMDinvMtransToDiagBlockOfSymDeMatUTri(int rowAndCol_dest_start,
   for(int i=0; i<this->nrows_; i++) {
     //j==i
     acc = 0.;
-    for(int k=row_starts_->idx_start_[i]; k<row_starts_->idx_start_[i+1]; k++)
+    for(index_type k=row_starts_->idx_start_[i]; k<row_starts_->idx_start_[i+1]; k++)
       acc += this->values_[k] / DM[this->jCol_[k]] * this->values_[k];
     //WM[i+row_dest_start][i+col_dest_start] += alpha*acc;
     WM[(i+row_dest_start)*m_W+i+col_dest_start] += alpha*acc;
@@ -418,7 +418,7 @@ addMDinvMtransToDiagBlockOfSymDeMatUTri(int rowAndCol_dest_start,
       //dest[i,j] = weigthed_dotprod(this_row_i,this_row_j)
       acc = 0.;
 
-      int ki=row_starts_->idx_start_[i], kj=row_starts_->idx_start_[j];
+      index_type ki=row_starts_->idx_start_[i], kj=row_starts_->idx_start_[j];
       while(ki<row_starts_->idx_start_[i+1] && kj<row_starts_->idx_start_[j+1]) {
         assert(ki<this->nnz_);
         assert(kj<this->nnz_);
@@ -492,8 +492,8 @@ addMDinvNtransToSymDeMatUTri(int row_dest_start, int col_dest_start,
 
       // dest[i,j] = weigthed_dotprod(M1_row_i,M2_row_j)
       acc = 0.;
-      int ki=M1.row_starts_->idx_start_[i];
-      int kj=M2.row_starts_->idx_start_[j];
+      index_type ki=M1.row_starts_->idx_start_[i];
+      index_type kj=M2.row_starts_->idx_start_[j];
 
       while(ki<M1.row_starts_->idx_start_[i+1] && kj<M2.row_starts_->idx_start_[j+1]) {
         assert(ki<M1.nnz_);
@@ -534,9 +534,9 @@ hiopMatrixSparseTriplet::allocAndBuildRowStarts() const
 
   if(nrows_<=0) return rsi;
 
-  int it_triplet=0;
+  size_type it_triplet=0;
   rsi->idx_start_[0]=0;
-  for(int i=1; i<=this->nrows_; i++) {
+  for(index_type i=1; i<=this->nrows_; i++) {
 
     rsi->idx_start_[i]=rsi->idx_start_[i-1];
 
@@ -831,7 +831,7 @@ void hiopMatrixSparseTriplet::set_Jac_FR(const hiopMatrixSparse& Jac_c,
     // Jac for c(x) - p + n
     const int* J_c_col = J_c.j_col();
     for(int i = 0; i < m_c; ++i) {
-      int k_base = J_c.row_starts_->idx_start_[i];
+      index_type k_base = J_c.row_starts_->idx_start_[i];
     
       // copy from base Jac_c
       while(k_base < J_c.row_starts_->idx_start_[i+1]) {
@@ -854,7 +854,7 @@ void hiopMatrixSparseTriplet::set_Jac_FR(const hiopMatrixSparse& Jac_c,
     // Jac for d(x) - p + n
     const int* J_d_col = J_d.j_col();
     for(int i = 0; i < m_d; ++i) {
-      int k_base = J_d.row_starts_->idx_start_[i];
+      index_type k_base = J_d.row_starts_->idx_start_[i];
     
       // copy from base Jac_d
       while(k_base < J_d.row_starts_->idx_start_[i+1]) {
@@ -883,7 +883,7 @@ void hiopMatrixSparseTriplet::set_Jac_FR(const hiopMatrixSparse& Jac_c,
     // Jac for c(x) - p + n
     const double* J_c_val = J_c.M();
     for(int i = 0; i < m_c; ++i) {
-      int k_base = J_c.row_starts_->idx_start_[i];
+      index_type k_base = J_c.row_starts_->idx_start_[i];
     
       // copy from base Jac_c
       while(k_base < J_c.row_starts_->idx_start_[i+1]) {
@@ -902,8 +902,8 @@ void hiopMatrixSparseTriplet::set_Jac_FR(const hiopMatrixSparse& Jac_c,
     // Jac for d(x) - p + n
     const double* J_d_val = J_d.M();
     for(int i = 0; i < m_d; ++i) {
-      int k_base = J_d.row_starts_->idx_start_[i];
-      int nnz_in_row = J_d.row_starts_->idx_start_[i+1] - k_base;
+      index_type k_base = J_d.row_starts_->idx_start_[i];
+      size_type nnz_in_row = J_d.row_starts_->idx_start_[i+1] - k_base;
     
       // copy from base Jac_d
       while(k_base < J_d.row_starts_->idx_start_[i+1]) {
@@ -1367,8 +1367,8 @@ void hiopMatrixSymSparseTriplet::set_Hess_FR(const hiopMatrixSparse& Hess,
     const int* Hess_col = Hess_base.j_col();
     if(m_h > 0) {
       for(int i = 0; i < m_h; ++i) {
-        int k_base = Hess_base.row_starts_->idx_start_[i];
-        int nnz_in_row = Hess_base.row_starts_->idx_start_[i+1] - k_base;
+        index_type k_base = Hess_base.row_starts_->idx_start_[i];
+        size_type nnz_in_row = Hess_base.row_starts_->idx_start_[i+1] - k_base;
       
         // insert diagonal entry due to the new obj term
         iRow_[k] = iHSS[k] = i;
@@ -1414,8 +1414,8 @@ void hiopMatrixSymSparseTriplet::set_Hess_FR(const hiopMatrixSparse& Hess,
 
     if(m_h > 0) {
       for(int i = 0; i < m_h; ++i) {
-        int k_base = Hess_base.row_starts_->idx_start_[i];
-        int nnz_in_row = Hess_base.row_starts_->idx_start_[i+1] - k_base;
+        index_type k_base = Hess_base.row_starts_->idx_start_[i];
+        size_type nnz_in_row = Hess_base.row_starts_->idx_start_[i+1] - k_base;
       
         // add diagonal entry due to the new obj term
         values_[k] = MHSS[k] = diag_data[i];

--- a/src/LinAlg/hiopMatrixSparseTriplet.cpp
+++ b/src/LinAlg/hiopMatrixSparseTriplet.cpp
@@ -449,7 +449,7 @@ addMDinvNtransToSymDeMatUTri(int row_dest_start, int col_dest_start,
                              const hiopVector& D, const hiopMatrixSparse& M2mat,
                              hiopMatrixDense& W) const
 {
-  const auto& M2 = dynamic_cast<const hiopMatrixSparseTriplet&>(M2mat);
+  const hiopMatrixSparseTriplet& M2 = dynamic_cast<const hiopMatrixSparseTriplet&>(M2mat);
   const hiopMatrixSparseTriplet& M1 = *this;
   const int m1 = M1.nrows_, nx = M1.ncols_, m2 = M2.nrows_;
   assert(nx==M1.ncols_);
@@ -462,7 +462,7 @@ addMDinvNtransToSymDeMatUTri(int row_dest_start, int col_dest_start,
   assert(col_dest_start>=0 && col_dest_start+m2<=W.n());
 
   double* WM = W.local_data();
-  auto m_W = W.m();
+  int m_W = W.m();
   
   const double* DM = D.local_data_const();
 

--- a/src/LinAlg/hiopMatrixSparseTriplet.hpp
+++ b/src/LinAlg/hiopMatrixSparseTriplet.hpp
@@ -272,13 +272,13 @@ protected:
 protected:
   struct RowStartsInfo
   {
-    int *idx_start_; //size num_rows+1
-    int num_rows_;
+    index_type *idx_start_; //size num_rows+1
+    size_type num_rows_;
     RowStartsInfo()
       : idx_start_(NULL), num_rows_(0)
     {}
-    RowStartsInfo(int n_rows)
-      : idx_start_(new int[n_rows+1]), num_rows_(n_rows)
+    RowStartsInfo(size_type n_rows)
+      : idx_start_(new index_type[n_rows+1]), num_rows_(n_rows)
     {}
     virtual ~RowStartsInfo()
     {


### PR DESCRIPTION
This PR addresses the following issues:
1. Compute `row_start` on CPU and save it for later use.
2. Add functions to synchronize the host and device data in RowStartsInfo.
3. Remove RAJA:inclusive_scan, and build row_start on CPU when FR is activated

