### PR TITLE
add user options to control the max/min constraint violation used in the filter line-search algorithm

### DIFF
--- a/src/Optimization/hiopAlgFilterIPM.cpp
+++ b/src/Optimization/hiopAlgFilterIPM.cpp
@@ -304,6 +304,10 @@ void hiopAlgFilterIPMBase::reloadOptions()
   //logbar Hessian
   kappa_Sigma = 1e10; 
   _tau=fmax(tau_min,1.0-_mu);
+
+  theta_max_fact_ = nlp->options->GetNumeric("theta_max_fact");
+  theta_min_fact_ = nlp->options->GetNumeric("theta_min_fact");
+
   theta_max = 1e7; //temporary - will be updated after ini pt is computed
   theta_min = 1e7; //temporary - will be updated after ini pt is computed
 
@@ -925,8 +929,8 @@ hiopSolveStatus hiopAlgFilterIPMQuasiNewton::run()
 
   iter_num=0; nlp->runStats.nIter=iter_num;
 
-  theta_max=1e+4*fmax(1.0,resid->get_theta());
-  theta_min=1e-4*fmax(1.0,resid->get_theta());
+  theta_max = theta_max_fact_*fmax(1.0,resid->get_theta());
+  theta_min = theta_min_fact_*fmax(1.0,resid->get_theta());
 
   hiopKKTLinSysLowRank* kkt=new hiopKKTLinSysLowRank(nlp);
 
@@ -1373,8 +1377,8 @@ hiopSolveStatus hiopAlgFilterIPMNewton::run()
   iter_num=0; nlp->runStats.nIter=iter_num;
   bool disableLS = nlp->options->GetString("accept_every_trial_step")=="yes";
 
-  theta_max=1e+4*fmax(1.0,resid->get_theta());
-  theta_min=1e-4*fmax(1.0,resid->get_theta());
+  theta_max = theta_max_fact_*fmax(1.0,resid->get_theta());
+  theta_min = theta_min_fact_*fmax(1.0,resid->get_theta());
 
   hiopKKTLinSys* kkt = decideAndCreateLinearSystem(nlp);
   assert(kkt != NULL);

--- a/src/Optimization/hiopAlgFilterIPM.hpp
+++ b/src/Optimization/hiopAlgFilterIPM.hpp
@@ -223,6 +223,8 @@ protected:
   double theta_max;
   //1e-4*max{1,\theta(x_0)} used in the switching condition during the line search
   double theta_min;
+  double theta_max_fact_;
+  double theta_min_fact_;
 
   /*** Algorithm's parameters ***/
   double mu0;           //intial mu

--- a/src/Utils/hiopOptions.cpp
+++ b/src/Utils/hiopOptions.cpp
@@ -648,6 +648,20 @@ void hiopOptionsNLP::register_options()
                         1e6,
                         "Minimum step size allowed in line-search (default 1e-16). If step size is less than this number, " 
                         "feasibility restoration problem is activated.");
+
+    register_num_option("theta_max_fact",
+                        1e+4,
+                        0.0,
+                        1e+7,
+                        "Maximum constraint violation (theta_max) is scaled by this fact before using in the fileter line-search "
+                        "algorithm (default 1e+4). (eqn (21) in Filt-IPM paper)");
+
+    register_num_option("theta_min_fact",
+                        1e-4,
+                        0.0,
+                        1e+7,
+                        "Minimum constraint violation (theta_min) is scaled by this fact before using in the fileter line-search "
+                        "algorithm (default 1e-4). (eqn (21) in Filt-IPM paper)");
   }
   {
     vector<string> range(5);


### PR DESCRIPTION
Add the following user options to control the max/min constraint violation used in the filter line-search algorithm:
1. theta_max_fact
2. theta_min_fact

CLOSE #277 