### PR TITLE
FindHiopCudaLibraries.cmake Fix

### DIFF
--- a/cmake/FindHiopCudaLibraries.cmake
+++ b/cmake/FindHiopCudaLibraries.cmake
@@ -9,7 +9,6 @@ add_library(hiop_cuda INTERFACE)
 
 find_package(CUDAToolkit REQUIRED)
 
-# Note : unsure if building both static + shared at same time breaks this.
 if(HIOP_BUILD_SHARED)
   target_link_libraries(hiop_cuda INTERFACE 
     CUDA::cusparse

--- a/cmake/FindHiopCudaLibraries.cmake
+++ b/cmake/FindHiopCudaLibraries.cmake
@@ -9,13 +9,21 @@ add_library(hiop_cuda INTERFACE)
 
 find_package(CUDAToolkit REQUIRED)
 
-target_link_libraries(hiop_cuda INTERFACE 
-  culibos
-  nvblas
-  cusparse
-  cudart
-  cublasLt
-  )
+# Note : unsure if building both static + shared at same time breaks this.
+if(HIOP_BUILD_SHARED)
+  target_link_libraries(hiop_cuda INTERFACE 
+    CUDA::cusparse
+    CUDA::cudart
+    CUDA::cublasLt
+    )
+endif()
+if(HIOP_BUILD_STATIC)
+  target_link_libraries(hiop_cuda INTERFACE 
+    CUDA::cusparse_static
+    CUDA::cudart_static
+    CUDA::cublasLt_static
+    )
+endif()
 
 install(TARGETS hiop_cuda EXPORT hiop-targets)
 


### PR DESCRIPTION
Closes #293. I ended up removing culibos and nvblas from being explicitly linked against, as well as using the `CUDA::` namespace as recommended in the documentation. This is passing CI on all platforms so I think it is good to go, although I am now suspicious as to how this was working before.