### PR TITLE
fixing a bug and update alpha in pridecomp solver

### DIFF
--- a/src/Drivers/nlpPriDec_ex8.cpp
+++ b/src/Drivers/nlpPriDec_ex8.cpp
@@ -268,7 +268,7 @@ bool PriDecMasterProblemEx8::eval_f_rterm(size_t idx, const int& n,const  double
     }
   }
   rval *= 0.5;
-  rval /= S_;
+  //rval /= S_;
   return true;
 };
 
@@ -279,9 +279,9 @@ bool PriDecMasterProblemEx8::eval_grad_rterm(size_t idx, const int& n, double* x
   double* grad_vec = grad.local_data();
   for(int i=0; i<n; i++) {
     if(i==idx) {   
-      grad_vec[i] = (x[i]+S_)/S_;
+      grad_vec[i] = (x[i]+S_);
     } else {
-      grad_vec[i] = x[i]/S_;
+      grad_vec[i] = x[i];
     }
   }
   return true;

--- a/src/Drivers/nlpPriDec_ex9.cpp
+++ b/src/Drivers/nlpPriDec_ex9.cpp
@@ -178,7 +178,7 @@ bool PriDecMasterProblemEx9::eval_grad_rterm(size_t idx, const int& n, double* x
   assert(nx_==n);
   double* grad_vec = grad.local_data();
   for(int i=0;i<n;i++) { 
-    grad_vec[i] = (x[i]-y_[i])/S_;
+    grad_vec[i] = (x[i]-y_[i]);
   }
   return true;
 };

--- a/src/Drivers/nlpPriDec_ex9_driver.cpp
+++ b/src/Drivers/nlpPriDec_ex9_driver.cpp
@@ -142,6 +142,7 @@ int main(int argc, char **argv)
   PriDecMasterProblemEx9 pridec_problem(nx, nx, nS, S);
   hiop::hiopAlgPrimalDecomposition pridec_solver(&pridec_problem, MPI_COMM_WORLD);
   pridec_solver.set_initial_alpha_ratio(0.5);
+  pridec_solver.set_alpha_min(0.3);
   //pridec_solver.set_tolerance(1e-6);
   //pridec_solver.set_max_iteration(5);
   auto status = pridec_solver.run();

--- a/src/Drivers/nlpPriDec_ex9_user_recourse.hpp
+++ b/src/Drivers/nlpPriDec_ex9_user_recourse.hpp
@@ -168,7 +168,7 @@ public:
   {
     assert(ny_==n);
     obj_value = 0.;
-    for(int i=0;i<n;i++) {
+    for(int i=0;i<n; i++) {
       obj_value += (x[i]-x_[i])*(x[i]-x_[i]);
     }
     obj_value *= 0.5;
@@ -213,8 +213,9 @@ public:
   bool eval_grad_f(const size_type& n, const double* x, bool new_x, double* gradf)
   {
     assert(ny_==n);    
-    for(int i=0;i<nx_;i++) gradf[i] = (x[i]-x_[i]);
-
+    for(int i=0;i<nx_; i++) {
+      gradf[i] = (x[i]-x_[i]);
+    }
     return true;
   }
  

--- a/src/Drivers/nlpPriDec_ex9_user_recourse.hpp
+++ b/src/Drivers/nlpPriDec_ex9_user_recourse.hpp
@@ -171,7 +171,7 @@ public:
     for(int i=0;i<n;i++) {
       obj_value += (x[i]-x_[i])*(x[i]-x_[i]);
     }
-    obj_value *= 0.5/double(S_);
+    obj_value *= 0.5;
     return true;
   }
  
@@ -213,7 +213,7 @@ public:
   bool eval_grad_f(const size_type& n, const double* x, bool new_x, double* gradf)
   {
     assert(ny_==n);    
-    for(int i=0;i<nx_;i++) gradf[i] = (x[i]-x_[i])/double(S_);
+    for(int i=0;i<nx_;i++) gradf[i] = (x[i]-x_[i]);
 
     return true;
   }
@@ -390,7 +390,7 @@ public:
     }
     // need lambda
     if(MHSS!=NULL) {
-      for(int i=0;i<nsparse_;i++) MHSS[i] =  obj_factor/double(S_); //what is this?     
+      for(int i=0;i<nsparse_;i++) MHSS[i] =  obj_factor; //what is this?     
       MHSS[0] += 2*lambda[m-1];
       for(int i=1;i<nsparse_;i++) {
         MHSS[i] += lambda[m-1]* 2.; //what is this?     
@@ -399,7 +399,7 @@ public:
     if(HDD!=NULL){
       //HDD size: ndense_*ndense_
       for(int i=0; i<ndense;i++) {
-        HDD[ndense*i+i] = obj_factor/double(S_);
+        HDD[ndense*i+i] = obj_factor;
         HDD[ndense*i+i] += 2*lambda[m-1];
       }
     }
@@ -435,7 +435,7 @@ public:
   bool compute_gradx(const int n, const double* y, double*  gradx)
   {
     assert(nx_==n);
-    for(int i=0;i<nx_;i++) gradx[i] = (x_[i]-y[i])/double(S_);
+    for(int i=0;i<nx_;i++) gradx[i] = (x_[i]-y[i]);
     return true;
   };
 

--- a/src/Optimization/hiopAlgPrimalDecomp.cpp
+++ b/src/Optimization/hiopAlgPrimalDecomp.cpp
@@ -164,6 +164,7 @@ HessianApprox(hiopInterfacePriDecProblem* priDecProb, hiopOptions* options_pride
   n_=n;
   fkm1 = 1e20;
   fk = 1e20;
+  fkm1_lin = 1e20;
   // x at k-1 step, the current step is k
   xkm1 = LinearAlgebraFactory::create_vector(options_->GetString("mem_space"), n_);
   // s_{k-1} = x_k - x_{k-1}
@@ -241,12 +242,12 @@ initialize(const double f_val, const hiopVector& xk, const hiopVector& grad)
     gkm1->copyFromStarting(0, grad.local_data_const(), n_);
   }
   if(skm1==NULL) {
-    //TODO: Frank, dont we need to allocate here?
+    skm1 = LinearAlgebraFactory::create_vector(options_->GetString("mem_space"), n_);
     assert(n_!=-1);
     skm1->copyFromStarting(0, xk.local_data_const(), n_);
   }
   if(ykm1==NULL) {
-    //TODO: Frank, dont we need to allocate here?
+    ykm1 = LinearAlgebraFactory::create_vector(options_->GetString("mem_space"), n_);
     assert(n_!=-1);
     ykm1->copyFromStarting(0, xk.local_data_const(), n_);
   }
@@ -269,11 +270,12 @@ update_hess_coeff(const hiopVector& xk,
   ykm1->copyFrom(gk);
   ykm1->axpy(-1.0, *gkm1);
   
-  //alpha_min = std::max(temp3/2/f_val,2.5); 
-  update_ratio();
   assert(xkm1->get_local_size()==xk.get_local_size());
   xkm1->copyFrom(xk);
+  fkm1_lin = gkm1->dotProductWith(*skm1); 
   gkm1->copyFrom(gk);
+
+  //update_ratio(); //update ratio relies on gk not gkm1
 }
  
 /** 
@@ -291,24 +293,26 @@ update_hess_coeff(const hiopVector& xk,
  
 void hiopAlgPrimalDecomposition::HessianApprox::update_ratio()
 {
-  double rk = fkm1;
+  double rk = fkm1+fkm1_lin;
 
   //TODO: use a member class hiopVector to avoid repeatead allocs/deallocs
-  hiopVector* temp = LinearAlgebraFactory::create_vector(options_->GetString("mem_space"), gkm1->get_local_size()); 
-  temp->copyFrom(*gkm1);   
-  rk += temp->dotProductWith(*skm1);
+  //hiopVector* temp = LinearAlgebraFactory::create_vector(options_->GetString("mem_space"), gkm1->get_local_size()); 
+  //temp->copyFrom(*gkm1);   
+  //rk += temp->dotProductWith(*skm1);
   rk += 0.5*alpha_*(skm1->twonorm())*(skm1->twonorm()); 
-  delete temp;
+  //delete temp;
   //printf("recourse estimate inside HessianApprox %18.12e\n",rk);
   double rho_k = (fkm1-fk)/(fkm1-rk);
+  
+  
   if(ver_ >=outlevel2) {
     printf("previuos val  %18.12e, real val %18.12e, predicted val %18.12e, rho_k %18.12e\n",fkm1,fk,rk,rho_k);
   }
   //a measure for when alpha should be decreasing (in addition to being good approximation)
   double quanorm = 0.; double gradnorm=0.;
   quanorm += skm1->dotProductWith(*skm1);
-  gradnorm += gkm1->dotProductWith(*skm1);
-
+  //gradnorm += gkm1->dotProductWith(*skm1);
+  gradnorm += fkm1_lin;
   quanorm = alpha_*quanorm;
 
   double alpha_g_ratio = quanorm/fabs(gradnorm);
@@ -366,6 +370,65 @@ update_ratio_tr(const double rhok,
   alpha_ratio = std::min(ratio_max,alpha_ratio); 
 }
 
+// update ratio rho_k with both base case and recourse function
+void hiopAlgPrimalDecomposition::HessianApprox::
+update_ratio(const double base_v, const double base_vm1)
+{
+  double rk = fkm1+fkm1_lin;
+
+  //TODO: use a member class hiopVector to avoid repeatead allocs/deallocs
+  //hiopVector* temp = LinearAlgebraFactory::create_vector(options_->GetString("mem_space"), gkm1->get_local_size()); 
+  //temp->copyFrom(*gkm1);   
+  //rk += temp->dotProductWith(*skm1);
+  rk += 0.5*alpha_*(skm1->twonorm())*(skm1->twonorm()); 
+  //delete temp;
+  //printf("recourse estimate inside HessianApprox %18.12e\n",rk);
+  double rho_k = (base_vm1+fkm1-fk-base_v)/(fkm1+base_vm1-rk-base_v);
+   
+  if(ver_ >=outlevel2) {
+    printf("previuos base  %18.12e, current base %18.12e, previuos val  %18.12e, real val %18.12e, predicted val %18.12e, rho_k %18.12e\n",base_vm1,base_v,fkm1,fk,rk,rho_k);
+  }
+  
+  //using a trust region criteria for adjusting ratio
+  update_ratio_tr(rho_k, ratio_);
+
+  tr_ratio_ = 1.0;
+  update_ratio_tr(rho_k, tr_ratio_);
+}
+
+
+void hiopAlgPrimalDecomposition::HessianApprox::
+update_ratio_tr(const double rhok,
+                double& alpha_ratio)
+{
+  if(rhok < 1/4. ) {
+    alpha_ratio = alpha_ratio/0.75;
+    if(ver_ >=outlevel1) {
+      printf("increasing alpha ratio or increasing minimum for quadratic coefficient\n");
+    }
+  } else {
+    if(rhok > 0.75) { 
+      alpha_ratio *= 0.75;
+      if(ver_ >=outlevel2) {
+        printf("decreasing alpha ratio or decreasing minimum for quadratic coefficient\n");
+      }
+    }
+  }
+  if(rhok<1/8.) {
+    if(ver_ >=outlevel3) {
+      printf("This step needs to be rejected.\n");
+    }
+    //sol_base = solm1;
+    //f = fm1;
+    //gradf = gkm1;
+  }
+  alpha_ratio = std::max(ratio_min,alpha_ratio); 
+  alpha_ratio = std::min(ratio_max,alpha_ratio); 
+}
+
+
+
+
 /* currently provides multiple ways to compute alpha, one is to the BB alpha
  * or the alpha computed through the BarzilaiBorwein gradient method, a quasi-Newton method.
  */
@@ -409,6 +472,19 @@ double hiopAlgPrimalDecomposition::HessianApprox::get_alpha_f(const hiopVector& 
   return alpha_;
 }
 
+double hiopAlgPrimalDecomposition::HessianApprox::get_alpha_tr()
+{
+
+  //printf("alpha check %18.12e\n",temp3/2.0);
+  alpha_ *= tr_ratio_;
+  alpha_ = std::max(alpha_min,alpha_);
+  alpha_ = std::min(alpha_max,alpha_);
+  if(ver_ >=outlevel3) {
+    printf("alpha ratio %18.12e\n",ratio_);
+  }
+  return alpha_;
+}
+
 // stopping criteria based on gradient
 double hiopAlgPrimalDecomposition::HessianApprox::check_convergence_grad(const hiopVector& gk)
 {
@@ -424,37 +500,42 @@ double hiopAlgPrimalDecomposition::HessianApprox::check_convergence_grad(const h
   temp->scale(-alpha_);
   temp4 = temp->twonorm()*temp->twonorm();
   
-  temp3 = ykm1->twonorm()*ykm1->twonorm();
+  temp3 = ykm1->twonorm();
   temp->axpy(1.0,*ykm1);
-  temp1 = temp->twonorm()*temp->twonorm();
+  temp1 = temp->twonorm();
 
-  temp2 = gk.twonorm()*gk.twonorm();
+  temp2 = gk.twonorm();
 
-  double convg = std::sqrt(temp1)/std::sqrt(temp2);
+  double convg = temp1/temp2;
   if(ver_ >=outlevel2) {
+    //ykm1->print();
+    printf("alpha  %18.12e \n",alpha_);
     printf("temp1  %18.12e, temp2 %18.12e, temp3 %18.12e, temp4 %18.12e\n",temp1,temp2,temp3,temp4);
   }
   delete temp;
   return convg;
 }
-// stopping criteria based on function value change
-double hiopAlgPrimalDecomposition::HessianApprox::check_convergence_fcn()
+
+// stopping criteria based on function value change of both base case and recourse
+double hiopAlgPrimalDecomposition::HessianApprox::
+check_convergence_fcn(const double base_v, const double base_vm1)
 {
-  double predicted_decrease = 0.;
+  double predicted_decrease = fkm1_lin;
 
   assert(n_==gkm1->get_local_size());
   //TODO: use a class member for 'temp' to avoid allocs/deallocs
-  hiopVector* temp;
-  temp = LinearAlgebraFactory::create_vector(options_->GetString("mem_space"), gkm1->get_local_size()); 
-  temp->copyFrom(*gkm1);   
-  predicted_decrease += temp->dotProductWith(*skm1);
+  //hiopVector* temp;
+  //temp = LinearAlgebraFactory::create_vector(options_->GetString("mem_space"), gkm1->get_local_size()); 
+  //temp->copyFrom(*gkm1);   
+  //predicted_decrease += temp->dotProductWith(*skm1);
   predicted_decrease += 0.5*alpha_*(skm1->twonorm())*(skm1->twonorm()); 
 
   if(ver_ >=outlevel2) {
     printf("predicted decrease  %18.12e", predicted_decrease);
   }
+  predicted_decrease += base_v - base_vm1;
   predicted_decrease = fabs(predicted_decrease);
-  delete temp;
+  //delete temp;
   return predicted_decrease;
 }
 
@@ -464,16 +545,16 @@ double hiopAlgPrimalDecomposition::HessianApprox::check_convergence_fcn()
 // objective which is the sum of the base case value and the recourse function value.
 // This requires the previous steps to compute, hence in the HessianApprox class.
 double hiopAlgPrimalDecomposition::HessianApprox::
-compute_base(const double val, const double rval)
+compute_base(const double val)
 {
-  double rec_appx = rval;
+  double rec_appx = fkm1+fkm1_lin;
   //TODO: use a class member for 'temp' to avoid allocs/deallocs
-  hiopVector* temp;
-  temp = LinearAlgebraFactory::create_vector(options_->GetString("mem_space"), gkm1->get_local_size()); 
-  temp->copyFrom(*gkm1);   
-  rec_appx += temp->dotProductWith(*skm1);
+  //hiopVector* temp;
+  //temp = LinearAlgebraFactory::create_vector(options_->GetString("mem_space"), gkm1->get_local_size()); 
+  //temp->copyFrom(*gkm1);   
+  //rec_appx += temp->dotProductWith(*skm1);
   rec_appx += 0.5*alpha_*(skm1->twonorm())*(skm1->twonorm()); 
-  delete temp;
+  //delete temp;
   return val-rec_appx;
 }
 
@@ -506,6 +587,7 @@ set_alpha_max(const double alp_max)
 {
   alpha_max = alp_max;
 }
+
 hiopAlgPrimalDecomposition::
 hiopAlgPrimalDecomposition(hiopInterfacePriDecProblem* prob_in,
                            MPI_Comm comm_world/*=MPI_COMM_WORLD*/) 
@@ -526,9 +608,8 @@ hiopAlgPrimalDecomposition(hiopInterfacePriDecProblem* prob_in,
   //only two rank types for now, master and evaluator/worker
 
   #ifdef HIOP_USE_MPI
-    int ierr = MPI_Comm_rank(comm_world, &my_rank_); assert(ierr == MPI_SUCCESS);
-    // TODO: Frank: shouldn't we use comm_world on the next call
-    int ret = MPI_Comm_size(MPI_COMM_WORLD, &comm_size_); assert(ret==MPI_SUCCESS);
+    int ierr = MPI_Comm_rank(comm_world_, &my_rank_); assert(ierr == MPI_SUCCESS);
+    int ret = MPI_Comm_size(comm_world, &comm_size_); assert(ret==MPI_SUCCESS);
     if(my_rank_==0) { 
       my_rank_type_ = 0;
     } else {
@@ -566,9 +647,8 @@ hiopAlgPrimalDecomposition(hiopInterfacePriDecProblem* prob_in,
   //only two rank types for now, master and evaluator/worker
 
 #ifdef HIOP_USE_MPI
-  int ierr = MPI_Comm_rank(comm_world, &my_rank_); assert(ierr == MPI_SUCCESS);
-  // TODO: Frank: shouldn't we use comm_world on the next call
-  int ret = MPI_Comm_size(MPI_COMM_WORLD, &comm_size_); assert(ret==MPI_SUCCESS);
+  int ierr = MPI_Comm_rank(comm_world_, &my_rank_); assert(ierr == MPI_SUCCESS);
+  int ret = MPI_Comm_size(comm_world_, &comm_size_); assert(ret==MPI_SUCCESS);
   if(my_rank_==0) { 
     my_rank_type_ = 0;
   } else {
@@ -647,7 +727,8 @@ step_size_inf(const int nc, const int* idx, const hiopVector& x, const hiopVecto
   temp = LinearAlgebraFactory::create_vector(options_->GetString("mem_space"), x0.get_local_size()); 
   temp->copyFrom(idx, x);   
   temp->axpy(-1.0, x0); 
-  step = temp->infnorm();
+  //step = temp->infnorm();
+  step = temp->twonorm();
   delete temp;
   return step;
 }
@@ -678,6 +759,16 @@ void hiopAlgPrimalDecomposition::set_initial_alpha_ratio(const double alpha)
 {
   assert(alpha>=0&&alpha<10.);
   alpha_ratio_ = alpha;
+}
+
+void hiopAlgPrimalDecomposition::set_alpha_min(const double alp_min)
+{
+  alpha_min_ = alp_min;
+}
+
+void hiopAlgPrimalDecomposition::set_alpha_max(const double alp_max)
+{
+  alpha_max_ = alp_max;
 }
 
 /* MPI engine for parallel solver
@@ -731,11 +822,15 @@ void hiopAlgPrimalDecomposition::set_initial_alpha_ratio(const double alpha)
 
     //hess_appx_2 is declared by all ranks while only rank 0 uses it
     HessianApprox* hess_appx_2 = new HessianApprox(nc_, alpha_ratio_, master_prob_, options_);
+    hess_appx_2->set_alpha_min(alpha_min_);
+    hess_appx_2->set_alpha_max(alpha_max_);
+
     if(ver_ >= outlevel3) {
       hess_appx_2->set_verbosity(ver_);
     }
 
-    double base_val = 0.; // base case objective value 
+    double base_val = 0.; // base case objective value
+    double base_valm1 = 0.; // base case objective value from the previuos step 
     double recourse_val = 0.;  // recourse objective value
     double dinf = 0.; // step size 
 
@@ -771,12 +866,13 @@ void hiopAlgPrimalDecomposition::set_initial_alpha_ratio(const double alpha)
         if(solver_status_){     
 
         }
-        if(ver_ >=outlevel2) {
+        if(ver_ >=outlevel3) {
 	  x_->print();
           //for(int i=0;i<n_;i++) printf("x %d %18.12e ",i,x_[i]);
           //printf("\n ");
         }
 	base_val = master_prob_->get_objective();
+	base_valm1 = master_prob_->get_objective();
       }
 
       // send base case solutions to all ranks
@@ -880,6 +976,7 @@ void hiopAlgPrimalDecomposition::set_initial_alpha_ratio(const double alpha)
               idx += 1; 
             } 
           }
+
           // Current way of ending the loop while accounting for all the last round of results
           if(last_loop) {
             last_loop=0;
@@ -889,6 +986,8 @@ void hiopAlgPrimalDecomposition::set_initial_alpha_ratio(const double alpha)
           }
 
         }
+        rval /= S_;
+	grad_r->scale(1.0/S_);
         // send end signal to all evaluators
         int cur_idx = -1;
         for(int r=1; r< comm_size_;r++) {
@@ -1070,8 +1169,10 @@ void hiopAlgPrimalDecomposition::set_initial_alpha_ratio(const double alpha)
         }
 
         if(it==0) {
+          //grad_r->print();
           hess_appx_2->initialize(rval, *x0, *grad_r);
           double alp_temp = hess_appx_2->get_alpha_f(*grad_r);
+          //double alp_temp = hess_appx_2->get_alpha_tr();
           if(ver_ >=outlevel2) {
             printf("alpd %18.12e\n",alp_temp);
           }
@@ -1079,10 +1180,18 @@ void hiopAlgPrimalDecomposition::set_initial_alpha_ratio(const double alpha)
             hess_appx_vec[i] = alp_temp;
 	  }
         } else {
-          hess_appx_2->update_hess_coeff(*x0, *grad_r, rval);
+          //grad_r->print();
+
+	  hess_appx_2->update_hess_coeff(*x0, *grad_r, rval);
+          //update base case objective, this requires updated skm1 and ykm1
+	  base_valm1 = base_val;
+	  base_val = hess_appx_2->compute_base(master_prob_->get_objective());
 
           //hess_appx_2->update_ratio();
-          double alp_temp = hess_appx_2->get_alpha_f(*grad_r);
+          hess_appx_2->update_ratio(base_val, base_valm1);
+          
+	  //double alp_temp = hess_appx_2->get_alpha_f(*grad_r);
+          double alp_temp = hess_appx_2->get_alpha_tr();
           //double alp_temp2 = hess_appx_2->get_alpha_BB();
           if(ver_ >=outlevel2) {
             printf("alpd %18.12e\n",alp_temp);
@@ -1092,7 +1201,7 @@ void hiopAlgPrimalDecomposition::set_initial_alpha_ratio(const double alpha)
           if(ver_ >=outlevel2) {
             printf("gradient convergence measure %18.12e\n",convg_g);
           }
-          convg_f = hess_appx_2->check_convergence_fcn();
+          convg_f = hess_appx_2->check_convergence_fcn(base_val, base_valm1);
           if(ver_ >=outlevel2) {
             printf("function val convergence measure %18.12e\n",convg_f);
           }
@@ -1100,7 +1209,7 @@ void hiopAlgPrimalDecomposition::set_initial_alpha_ratio(const double alpha)
           for(int i=0; i<nc_; i++) {
             hess_appx_vec[i] = alp_temp;
 	  }
-	  base_val = hess_appx_2->compute_base(master_prob_->get_objective(),rval);
+
         }
 
         // wait for the sending/receiving to finish
@@ -1143,7 +1252,7 @@ void hiopAlgPrimalDecomposition::set_initial_alpha_ratio(const double alpha)
           fflush(stdout);
         }
 
-        if(ver_ >=outlevel2) {
+        if(ver_ >=outlevel3) {
 	  x_->print();
           //for(int i=0;i<n_;i++) {
           //  printf("x%d %18.12e ",i,x_[i]);
@@ -1220,18 +1329,18 @@ hiopSolveStatus hiopAlgPrimalDecomposition::run_single()
   hiopVector* x0 = grad_r->alloc_clone();
   double* x0_vec = x0->local_data();
 
-  //TODO: Frank, this is CPU loop, needs to be done via a hiopVector method
-  for(int i=0; i<nc_; i++) {
-    grad_r_vec[i] = 0.;
-  }
+  grad_r->setToZero();
 
   //hess_appx_2 has to be declared by all ranks while only rank 0 uses it
   HessianApprox* hess_appx_2 = new HessianApprox(nc_, alpha_ratio_, master_prob_, options_);
+  hess_appx_2->set_alpha_min(alpha_min_);
+  hess_appx_2->set_alpha_max(alpha_max_);
   
   hiopInterfacePriDecProblem::RecourseApproxEvaluator* evaluator =
     new hiopInterfacePriDecProblem::RecourseApproxEvaluator(nc_, S_, xc_idx_, options_->GetString("mem_space"));
 
   double base_val = 0.; // base case objective value 
+  double base_valm1 = 0.; // base case objective value from previous iteration
   double recourse_val = 0.;  // recourse objective value
   double dinf = 0.; // step size 
   double convg = 1e20;
@@ -1254,11 +1363,12 @@ hiopSolveStatus hiopAlgPrimalDecomposition::run_single()
       if(solver_status_) {     
       }
       base_val = master_prob_->get_objective();
+      base_valm1 = base_val;
     }
 
     // array for number of indices, this is subjected to change	
     rval = 0.;
-    grad_r->setToZero( );
+    grad_r->setToZero();
 
     int* cont_idx = new int[S_];
     for(int i=0;i<S_;i++) {
@@ -1298,7 +1408,10 @@ hiopSolveStatus hiopAlgPrimalDecomposition::run_single()
       //  grad_r_vec[i] += grad_aux[i];
       //}
       delete grad_aux;
-    }        
+    }     
+
+    rval /= S_;
+    grad_r->scale(1.0/S_);
     if(ver_ >=outlevel2) {
       printf("real rval %18.12e\n",rval);
     }
@@ -1312,6 +1425,7 @@ hiopSolveStatus hiopAlgPrimalDecomposition::run_single()
     if(it==0) {
       hess_appx_2->initialize(rval, *x0, *grad_r);
       double alp_temp = hess_appx_2->get_alpha_f(*grad_r);
+      //double alp_temp = hess_appx_2->get_alpha_tr();
       if(ver_ >=outlevel2) {
         printf("alpd %18.12e\n",alp_temp);
       }
@@ -1320,8 +1434,15 @@ hiopSolveStatus hiopAlgPrimalDecomposition::run_single()
       }
     } else {
       hess_appx_2->update_hess_coeff(*x0, *grad_r, rval);
+      
+      base_valm1 = base_val;
+      base_val = hess_appx_2->compute_base(master_prob_->get_objective());
+      
       //hess_appx_2->update_ratio();
-      double alp_temp = hess_appx_2->get_alpha_f(*grad_r);
+      hess_appx_2->update_ratio(base_val, base_valm1);
+      
+      //double alp_temp = hess_appx_2->get_alpha_f(*grad_r);
+      double alp_temp = hess_appx_2->get_alpha_tr();
       if(ver_ >=outlevel2) {
         printf("alpd %18.12e\n",alp_temp);
       }
@@ -1330,7 +1451,7 @@ hiopSolveStatus hiopAlgPrimalDecomposition::run_single()
       if(ver_ >=outlevel2) {
         printf("convergence measure %18.12e\n",convg_g);
       }
-      convg_f = hess_appx_2->check_convergence_fcn();
+      convg_f = hess_appx_2->check_convergence_fcn(base_val, base_valm1);
       if(ver_ >=outlevel2) {
         printf("function val convergence measure %18.12e\n",convg_f);
       }
@@ -1338,12 +1459,10 @@ hiopSolveStatus hiopAlgPrimalDecomposition::run_single()
       for(int i=0; i<nc_; i++) {
         hess_appx_vec[i] = alp_temp;
       }
-
-      base_val = hess_appx_2->compute_base(master_prob_->get_objective(),rval);
     }
 
     // for debugging purpose print out the recourse gradient
-    if(ver_ >=outlevel2) {
+    if(ver_ >=outlevel3) {
       grad_r->print();
       //for(int i=0;i<nc_;i++) {
       //  printf("grad %d  %18.12e ",i,grad_r_vec[i]);
@@ -1379,7 +1498,7 @@ hiopSolveStatus hiopAlgPrimalDecomposition::run_single()
     dinf = step_size_inf(nc_, xc_idx_, *x_, *x0); 
 
     // print solution x at the end of a full solve
-    if(ver_ >=outlevel2) {
+    if(ver_ >=outlevel3) {
       x_->print();
     }
     //assert("for debugging" && false); //for debugging purpose

--- a/src/Optimization/hiopAlgPrimalDecomp.cpp
+++ b/src/Optimization/hiopAlgPrimalDecomp.cpp
@@ -295,12 +295,7 @@ void hiopAlgPrimalDecomposition::HessianApprox::update_ratio()
 {
   double rk = fkm1+fkm1_lin;
 
-  //TODO: use a member class hiopVector to avoid repeatead allocs/deallocs
-  //hiopVector* temp = LinearAlgebraFactory::create_vector(options_->GetString("mem_space"), gkm1->get_local_size()); 
-  //temp->copyFrom(*gkm1);   
-  //rk += temp->dotProductWith(*skm1);
   rk += 0.5*alpha_*(skm1->twonorm())*(skm1->twonorm()); 
-  //delete temp;
   //printf("recourse estimate inside HessianApprox %18.12e\n",rk);
   double rho_k = (fkm1-fk)/(fkm1-rk);
   
@@ -376,12 +371,7 @@ update_ratio(const double base_v, const double base_vm1)
 {
   double rk = fkm1+fkm1_lin;
 
-  //TODO: use a member class hiopVector to avoid repeatead allocs/deallocs
-  //hiopVector* temp = LinearAlgebraFactory::create_vector(options_->GetString("mem_space"), gkm1->get_local_size()); 
-  //temp->copyFrom(*gkm1);   
-  //rk += temp->dotProductWith(*skm1);
   rk += 0.5*alpha_*(skm1->twonorm())*(skm1->twonorm()); 
-  //delete temp;
   //printf("recourse estimate inside HessianApprox %18.12e\n",rk);
   double rho_k = (base_vm1+fkm1-fk-base_v)/(fkm1+base_vm1-rk-base_v);
    
@@ -493,7 +483,6 @@ double hiopAlgPrimalDecomposition::HessianApprox::check_convergence_grad(const h
   double temp3 = 0.;
   double temp4 = 0.;
   
-  //TODO: use a class member for 'temp' to avoid allocs/deallocs
   hiopVector* temp;
   temp = LinearAlgebraFactory::create_vector(options_->GetString("mem_space"), skm1->get_local_size()); 
   temp->copyFrom(*skm1);  
@@ -523,11 +512,6 @@ check_convergence_fcn(const double base_v, const double base_vm1)
   double predicted_decrease = fkm1_lin;
 
   assert(n_==gkm1->get_local_size());
-  //TODO: use a class member for 'temp' to avoid allocs/deallocs
-  //hiopVector* temp;
-  //temp = LinearAlgebraFactory::create_vector(options_->GetString("mem_space"), gkm1->get_local_size()); 
-  //temp->copyFrom(*gkm1);   
-  //predicted_decrease += temp->dotProductWith(*skm1);
   predicted_decrease += 0.5*alpha_*(skm1->twonorm())*(skm1->twonorm()); 
 
   if(ver_ >=outlevel2) {
@@ -535,7 +519,6 @@ check_convergence_fcn(const double base_v, const double base_vm1)
   }
   predicted_decrease += base_v - base_vm1;
   predicted_decrease = fabs(predicted_decrease);
-  //delete temp;
   return predicted_decrease;
 }
 
@@ -548,11 +531,6 @@ double hiopAlgPrimalDecomposition::HessianApprox::
 compute_base(const double val)
 {
   double rec_appx = fkm1+fkm1_lin;
-  //TODO: use a class member for 'temp' to avoid allocs/deallocs
-  //hiopVector* temp;
-  //temp = LinearAlgebraFactory::create_vector(options_->GetString("mem_space"), gkm1->get_local_size()); 
-  //temp->copyFrom(*gkm1);   
-  //rec_appx += temp->dotProductWith(*skm1);
   rec_appx += 0.5*alpha_*(skm1->twonorm())*(skm1->twonorm()); 
   //delete temp;
   return val-rec_appx;
@@ -867,7 +845,7 @@ void hiopAlgPrimalDecomposition::set_alpha_max(const double alp_max)
 
         }
         if(ver_ >=outlevel3) {
-	  x_->print();
+          x_->print();
           //for(int i=0;i<n_;i++) printf("x %d %18.12e ",i,x_[i]);
           //printf("\n ");
         }
@@ -987,7 +965,7 @@ void hiopAlgPrimalDecomposition::set_alpha_max(const double alp_max)
 
         }
         rval /= S_;
-	grad_r->scale(1.0/S_);
+        grad_r->scale(1.0/S_);
         // send end signal to all evaluators
         int cur_idx = -1;
         for(int r=1; r< comm_size_;r++) {
@@ -1253,11 +1231,7 @@ void hiopAlgPrimalDecomposition::set_alpha_max(const double alp_max)
         }
 
         if(ver_ >=outlevel3) {
-	  x_->print();
-          //for(int i=0;i<n_;i++) {
-          //  printf("x%d %18.12e ",i,x_[i]);
-          //}
-          //printf(" \n");
+          x_->print();
         }
         t2 = MPI_Wtime(); 
         if(ver_ >=outlevel2) {

--- a/src/Optimization/hiopAlgPrimalDecomp.hpp
+++ b/src/Optimization/hiopAlgPrimalDecomp.hpp
@@ -127,6 +127,10 @@ public:
 
   void set_initial_alpha_ratio(const double ratio);
     
+  void set_alpha_min(const double alp_min); 
+   
+  void set_alpha_max(const double alp_max);
+  
   void set_max_iteration(const int max_it); 
   
   void set_tolerance(const double tol);
@@ -219,6 +223,12 @@ public:
     void update_ratio_tr(const double rhok, const double rkm1, const double rk, 
                          const double alpha_g_ratio, double& alpha_ratio);
 
+    // updating ratio_ using both base case and recourse objective function
+    void update_ratio(const double base_v, const double base_vm1);
+
+    void update_ratio_tr(const double rhok, double& alpha_ratio);
+
+
     /* currently provides multiple ways to compute alpha, one is to the BB alpha
      * or the alpha computed through the BarzilaiBorwein gradient method, a quasi-Newton method.
      */
@@ -232,11 +242,16 @@ public:
      */ 
     double get_alpha_f(const hiopVector& gk);
 
+    /* Computing alpha through alpha = alpha_*ratio_
+     * Not based on function information
+     */ 
+    double get_alpha_tr();
+    
     /* Function to check convergence based gradient 
      */
     double check_convergence_grad(const hiopVector& gk);
-    double check_convergence_fcn();
-    double compute_base(const double val, const double rval);
+    double check_convergence_fcn(const double base_v, const double base_vm1);
+    double compute_base(const double val);
 
     // setting the output level for the Hessian approximation 
     void set_verbosity(const int i); 
@@ -246,23 +261,27 @@ public:
     void set_alpha_ratio_max(const double alp_ratio_max);
 
     void set_alpha_min(const double alp_min); 
-    
+   
     void set_alpha_max(const double alp_max);
+
   private:
     int n_;
-    double alpha_=1.0;  
+    double alpha_=1e6;  
     double ratio_ = 1.0;
+    double tr_ratio_ = 1.0;
     double ratio_min = 0.5;  
     double ratio_max = 5.0;  
     double alpha_min = 1e-5;  
-    double alpha_max = 1e10;  
+    double alpha_max = 1e6;  
+
     double fk; 
     double fkm1;
+    double fkm1_lin;
     hiopVector* xkm1;
     hiopVector* gkm1;
     hiopVector* skm1;
     hiopVector* ykm1;
-    size_t ver_=1;
+    size_t ver_= 2;
     hiopInterfacePriDecProblem* priDecProb_;
     hiopOptions* options_;
   };
@@ -311,6 +330,10 @@ private:
   int accp_count = 0;
   //initial alpha_ratio if used
   double alpha_ratio_=1.0;
+  
+  double alpha_min_ = 1e-5;  
+  double alpha_max_ = 1e6;  
+  
   //real decrease over expected decrease ratio
   double rhok_ = 0.;
 protected:

--- a/src/Optimization/hiopAlgPrimalDecomp.hpp
+++ b/src/Optimization/hiopAlgPrimalDecomp.hpp
@@ -266,7 +266,7 @@ public:
 
   private:
     int n_;
-    double alpha_=1e6;  
+    double alpha_ = 1e6;  
     double ratio_ = 1.0;
     double tr_ratio_ = 1.0;
     double ratio_min = 0.5;  
@@ -281,7 +281,7 @@ public:
     hiopVector* gkm1;
     hiopVector* skm1;
     hiopVector* ykm1;
-    size_t ver_= 2;
+    size_t ver_ = 2; //output level for HessianApprox class
     hiopInterfacePriDecProblem* priDecProb_;
     hiopOptions* options_;
   };
@@ -329,7 +329,7 @@ private:
   //consecutive iteration count where NLP residual is lower than acceptable tolerance
   int accp_count = 0;
   //initial alpha_ratio if used
-  double alpha_ratio_=1.0;
+  double alpha_ratio_ = 1.0;
   
   double alpha_min_ = 1e-5;  
   double alpha_max_ = 1e6;  


### PR DESCRIPTION
Performing the average of recourse functions in pridecomp solver instead of user defined functions. Adding some update rules for alpha. In particular, both base case and recourse objectives are now used in the algorithm.