### PR TITLE
Add job step to watch pnnl ci results

### DIFF
--- a/.github/workflows/push_mirror.yml
+++ b/.github/workflows/push_mirror.yml
@@ -14,4 +14,27 @@ jobs:
           GIT_PASSWORD: ${{ secrets.GIT_PASSWORD }}
           GIT_PUSH_ARGS: --push-option=ci.skip --tags --force --prune
       - uses: nelonoel/branch-name@v1.0.1
-      - run: curl -X POST -F token=${{ secrets.PNNL_PIPELINE_TRIGGER_TOKEN }} -F ref=${BRANCH_NAME} https://gitlab.pnnl.gov/api/v4/projects/769/trigger/pipeline
+      - name: Trigger Pipeline
+        run: |
+          response=$(curl -X POST -F token=${{ secrets.PNNL_PIPELINE_TRIGGER_TOKEN }} -F ref=${BRANCH_NAME} https://gitlab.pnnl.gov/api/v4/projects/769/trigger/pipeline)
+          exit_code=$?
+          sudo apt install jq
+          pipeline_id=$(echo $response | jq '.id' | sed 's/"//g')
+          echo "PIPELINE_ID=${pipeline_id}" >> $GITHUB_ENV
+          exit $exit_code
+      - name: Watch Pipeline Results
+        run: |
+          sudo apt install jq
+          while :; do
+            response=$(curl --header "PRIVATE-TOKEN: ${{ secrets.PNNL_GITLAB_CI_PAT }}" "https://gitlab.pnnl.gov/api/v4/projects/769/pipelines/${PIPELINE_ID}")
+            status=$(echo $response | jq '.status' | sed -e 's/"//g')
+            echo
+            echo "Full response: ${response}"
+            echo
+            echo "-- Got pipeline status: $status"
+            echo
+            bash_code=$(echo $status | perl -ne 'if (/failed/){print"exit 1";exit;} elsif (/success/){print"exit 0";exit;}')
+            eval "$bash_code"
+            sleep 60 
+          done
+


### PR DESCRIPTION
This should reflect the pipeline status in the final step of the github actions job, at least for the pnnl pipeline. We'll have to get more clever to watch the ornl pipeline also since that repo is just periodically mirrored, but this is at least a move in the right direction.