### PR TITLE
Cuda configuration fix

### DIFF
--- a/cmake/FindHiopCudaLibraries.cmake
+++ b/cmake/FindHiopCudaLibraries.cmake
@@ -9,16 +9,6 @@ add_library(hiop_cuda INTERFACE)
 
 find_package(CUDAToolkit REQUIRED)
 
-# # Uncomment for old workaround
-# target_link_libraries(hiop_cuda INTERFACE 
-#   culibos
-#   nvblas
-#   cusparse
-#   cusolver
-#   cudart
-#   cublasLt
-#   )
-
 if(HIOP_BUILD_SHARED)
   target_link_libraries(hiop_cuda INTERFACE 
     nvblas # shared only

--- a/cmake/FindHiopCudaLibraries.cmake
+++ b/cmake/FindHiopCudaLibraries.cmake
@@ -21,7 +21,7 @@ find_package(CUDAToolkit REQUIRED)
 
 if(HIOP_BUILD_SHARED)
   target_link_libraries(hiop_cuda INTERFACE 
-    CUDA::nvblas # shared only
+    nvblas # shared only
     CUDA::cusparse
     CUDA::cudart
     cublas

--- a/cmake/FindHiopCudaLibraries.cmake
+++ b/cmake/FindHiopCudaLibraries.cmake
@@ -9,32 +9,35 @@ add_library(hiop_cuda INTERFACE)
 
 find_package(CUDAToolkit REQUIRED)
 
-target_link_libraries(hiop_cuda INTERFACE 
-  culibos
-  nvblas
-  cusparse
-  cusolver
-  cudart
-  cublasLt
-  )
+# # Uncomment for old workaround
+# target_link_libraries(hiop_cuda INTERFACE 
+#   culibos
+#   nvblas
+#   cusparse
+#   cusolver
+#   cudart
+#   cublasLt
+#   )
 
-# if(HIOP_BUILD_SHARED)
-#   target_link_libraries(hiop_cuda INTERFACE 
-#     CUDA::cusparse
-#     CUDA::cudart
-#     CUDA::cublasLt
-#     CUDA::cusolver
-#     )
-# endif()
-# if(HIOP_BUILD_STATIC)
-#   target_link_libraries(hiop_cuda INTERFACE
-#     CUDA::culibos
-#     CUDA::cusparse_static
-#     CUDA::cudart_static
-#     CUDA::cublasLt_static
-#     CUDA::cusolver_static
-#     )
-# endif()
+if(HIOP_BUILD_SHARED)
+  target_link_libraries(hiop_cuda INTERFACE 
+    CUDA::nvblas # shared only
+    CUDA::cusparse
+    CUDA::cudart
+    cublas
+    cublasLt
+    CUDA::cusolver
+  )
+endif()
+if(HIOP_BUILD_STATIC)
+  target_link_libraries(hiop_cuda INTERFACE
+    CUDA::cusparse_static
+    CUDA::cudart_static
+    cublas
+    cublasLt
+    CUDA::cusolver_static
+  )
+endif()
 
 install(TARGETS hiop_cuda EXPORT hiop-targets)
 


### PR DESCRIPTION
Resolves #311

Some notes:
- When building with static +strumpack, I noticed that the strumpack library would report lots or complaints about incompatibility with toc optimization. I notice that this also reports searching for header files in `/scratch` for @ashermancinelli... `toc optimization is not supported for 0xe7e90002 instruction`
- When building with shared + stumpack, I get information about requiring PIC to be enabled:
```
call to `strumpack::TaskTimer::~TaskTimer()' lacks nop, can't restore toc; recompile with -fPIC
/usr/bin/ld: final link failed: Bad value
collect2: error: ld returned 1 exit status
```

That being said, if we enforce compiling with only static libs for strumpack, this seems to be a functioning commit. Further discussion may well be necessary @pelesh @kswirydo 