### PR TITLE
Add functions to hiopVectorInt

### DIFF
--- a/src/LinAlg/hiopVectorInt.hpp
+++ b/src/LinAlg/hiopVectorInt.hpp
@@ -82,6 +82,12 @@ public:
   virtual void copy_from_dev() = 0;
   
   virtual void copy_from(const index_type* v_local) = 0;
+  
+  /// @brief Set all elements to zero.
+  virtual void set_to_zero() = 0;
+
+  /// @brief Set all elements  to  c
+  virtual void set_to_constant( const index_type c ) = 0;
 };
 
 } // namespace hiop

--- a/src/LinAlg/hiopVectorIntRaja.cpp
+++ b/src/LinAlg/hiopVectorIntRaja.cpp
@@ -54,6 +54,11 @@
  */
 
 #include "hiopVectorIntRaja.hpp"
+#include <umpire/Allocator.hpp>
+#include <umpire/ResourceManager.hpp>
+
+#include <RAJA/RAJA.hpp>
+#include "hiop_raja_defs.hpp"
 
 namespace hiop
 {
@@ -125,7 +130,7 @@ void hiopVectorIntRaja::set_to_zero()
 void hiopVectorIntRaja::set_to_constant(const index_type c)
 {
   index_type* data = buf_;
-  RAJA::forall< hiop_raja_exec >(RAJA::RangeSegment(0, sz_),
+  RAJA::forall<hiop_raja_exec>(RAJA::RangeSegment(0, sz_),
     RAJA_LAMBDA(RAJA::Index_type i)
     {
       data[i] = c;

--- a/src/LinAlg/hiopVectorIntRaja.cpp
+++ b/src/LinAlg/hiopVectorIntRaja.cpp
@@ -115,4 +115,21 @@ void hiopVectorIntRaja::copy_from(const index_type* v_local)
   }
 }
 
+void hiopVectorIntRaja::set_to_zero()
+{
+  auto& rm = umpire::ResourceManager::getInstance();
+  rm.memset(buf_, 0);
+}
+
+/// Set all vector elements to constant c
+void hiopVectorIntRaja::set_to_constant(const index_type c)
+{
+  index_type* data = buf_;
+  RAJA::forall< hiop_raja_exec >(RAJA::RangeSegment(0, sz_),
+    RAJA_LAMBDA(RAJA::Index_type i)
+    {
+      data[i] = c;
+    });
+}
+
 } // namespace hiop

--- a/src/LinAlg/hiopVectorIntRaja.hpp
+++ b/src/LinAlg/hiopVectorIntRaja.hpp
@@ -100,6 +100,11 @@ public:
   
   virtual void copy_from(const index_type* v_local);
 
+  /// @brief Set all elements to zero.
+  virtual void set_to_zero();
+
+  /// @brief Set all elements  to  c
+  virtual void set_to_constant(const index_type c);
 };
 
 } // namespace hiop

--- a/src/LinAlg/hiopVectorIntRaja.hpp
+++ b/src/LinAlg/hiopVectorIntRaja.hpp
@@ -56,9 +56,6 @@
  */
 
 #include "hiopVectorInt.hpp"
-#include <umpire/Allocator.hpp>
-#include <umpire/ResourceManager.hpp>
-#include <RAJA/RAJA.hpp>
 #include <string>
 
 namespace hiop

--- a/src/LinAlg/hiopVectorIntSeq.cpp
+++ b/src/LinAlg/hiopVectorIntSeq.cpp
@@ -75,5 +75,18 @@ void hiopVectorIntSeq::copy_from(const index_type* v_local)
     memcpy(buf_, v_local, sz_*sizeof(index_type));
 }
 
+void hiopVectorIntSeq::set_to_zero()
+{
+  for(index_type i=0; i<sz_; ++i) {
+    buf_[i] = 0;
+  }
+}
+
+void hiopVectorIntSeq::set_to_constant(const index_type c)
+{
+  for(index_type i=0; i<sz_; ++i) {
+    buf_[i] = c;
+  }
+}
 
 } // namespace hiop

--- a/src/LinAlg/hiopVectorIntSeq.hpp
+++ b/src/LinAlg/hiopVectorIntSeq.hpp
@@ -83,6 +83,11 @@ public:
   
   virtual void copy_from(const index_type* v_local);
 
+  /// @brief Set all elements to zero.
+  virtual void set_to_zero();
+
+  /// @brief Set all elements  to  c
+  virtual void set_to_constant(const index_type c);
 };
 
 } // namespace hiop

--- a/tests/LinAlg/matrixTestsRajaSparseTriplet.cpp
+++ b/tests/LinAlg/matrixTestsRajaSparseTriplet.cpp
@@ -176,21 +176,23 @@ int MatrixTestsRajaSparseTriplet::verifyAnswer(hiop::hiopMatrixSparse* A, const 
 }
 
 /**
- * @brief Verifies values of the sparse matrix *only at indices already defined by the sparsity pattern*
- * This may seem misleading, but verify answer does not check *every* value of the matrix,
- * but only `nnz` elements with index from nnz_st to nnz_ed
+ * @brief Verifies a range of nonzeros in a sparse matrix, starting from index "nnz_from" to index "nnz_to"-1.
  */
 [[nodiscard]]
-int MatrixTestsRajaSparseTriplet::verifyAnswer(hiop::hiopMatrix* A, local_ordinal_type nnz_st, local_ordinal_type nnz_ed, const double answer)
+int MatrixTestsRajaSparseTriplet::verifyAnswer(hiop::hiopMatrix* A, local_ordinal_type nnz_from, local_ordinal_type nnz_to, const double answer)
 {
-  if(A == nullptr)
+  if(A == nullptr) {
     return 1;
+  }
   auto mat = dynamic_cast<hiop::hiopMatrixRajaSparseTriplet*>(A);
   mat->copyFromDev();
   const local_ordinal_type nnz = mat->numberOfNonzeros();
+  if(nnz_to-nnz_from > nnz) {
+    return 1;
+  }
   const real_type* values = mat->M_host();
   int fail = 0;
-  for (local_ordinal_type i=nnz_st; i<nnz_ed; i++)
+  for (local_ordinal_type i=nnz_from; i<nnz_to; i++)
   {
     if (!isEqual(values[i], answer))
     {

--- a/tests/LinAlg/vectorTestsInt.hpp
+++ b/tests/LinAlg/vectorTestsInt.hpp
@@ -129,13 +129,8 @@ public:
     const int x_val = 1;
     const int y_val = 1;
 
-    for(int i=0; i<x.size(); i++) {
-      setLocalElement(&x, i, x_val);
-    }
-    
-    for(int i=0; i<y.size(); i++) {
-      setLocalElement(&y, i, y_val);
-    }
+    setLocalElement(&x, x_val);
+    setLocalElement(&y, y_val);
     
     x.copy_from(y.local_data_const());
 
@@ -152,6 +147,7 @@ public:
 private:
   virtual int getLocalElement(hiop::hiopVectorInt*, int) const = 0;
   virtual void setLocalElement(hiop::hiopVectorInt*, int, int) const = 0;
+  virtual void setLocalElement(hiop::hiopVectorInt*, int) const = 0;
 };
 
 }} // namespace hiop::tests

--- a/tests/LinAlg/vectorTestsIntRaja.cpp
+++ b/tests/LinAlg/vectorTestsIntRaja.cpp
@@ -81,4 +81,14 @@ void VectorTestsIntRaja::setLocalElement(hiop::hiopVectorInt* xvec, int idx, int
   }
 }
 
+void VectorTestsIntRaja::setLocalElement(hiop::hiopVectorInt* xvec, int value) const
+{
+  if(auto* x = dynamic_cast<hiop::hiopVectorIntRaja*>(xvec)) {
+    x->set_to_constant(value);
+    x->copy_from_dev();
+  } else {
+    assert(false && "Wrong type of vector passed into `VectorTestsIntRaja::setLocalElement`!");
+  }
+}
+
 }} // namespace hiop::tests

--- a/tests/LinAlg/vectorTestsIntRaja.hpp
+++ b/tests/LinAlg/vectorTestsIntRaja.hpp
@@ -47,7 +47,7 @@
 // product endorsement purposes.
 
 /**
- * @file vectorTestsIntSeq.hpp
+ * @file vectorTestsIntRaja.hpp
  *
  * @author Asher Mancinelli <asher.mancinelli@pnnl.gov>, PNNL
  *
@@ -73,6 +73,7 @@ public:
 private:
   virtual int getLocalElement(hiop::hiopVectorInt*, int) const;
   virtual void setLocalElement(hiop::hiopVectorInt*, int, int) const;
+  virtual void setLocalElement(hiop::hiopVectorInt*, int) const;
 };
 
 }} // namespace hiop::tests

--- a/tests/LinAlg/vectorTestsIntSeq.cpp
+++ b/tests/LinAlg/vectorTestsIntSeq.cpp
@@ -77,4 +77,13 @@ void VectorTestsIntSeq::setLocalElement(hiop::hiopVectorInt* xvec, int idx, int 
   }
 }
 
+void VectorTestsIntSeq::setLocalElement(hiop::hiopVectorInt* xvec, int value) const
+{
+  if(auto* x = dynamic_cast<hiop::hiopVectorIntSeq*>(xvec)) {
+    x->set_to_constant(value);
+  } else {
+    assert(false && "Wrong type of vector passed into `VectorTestsIntSeq::setLocalElement`!");
+  }
+}
+
 }} // namespace hiop::tests

--- a/tests/LinAlg/vectorTestsIntSeq.hpp
+++ b/tests/LinAlg/vectorTestsIntSeq.hpp
@@ -74,6 +74,7 @@ public:
 private:
   virtual int getLocalElement(hiop::hiopVectorInt*, int) const;
   virtual void setLocalElement(hiop::hiopVectorInt*, int, int) const;
+  virtual void setLocalElement(hiop::hiopVectorInt*, int) const;
 };
 
 }} // namespace hiop::tests


### PR DESCRIPTION
This PR adds the following functions into hiopVectorInt:
1. set_to zero
2. set_to_constant

It also adds a new function to the suite of unit tests, to allow user set a local int vector to a constant.

CLOSE #314 