### PR TITLE
Add inertia-free approach

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -463,6 +463,7 @@ if (HIOP_WITH_MAKETEST)
   if(HIOP_SPARSE)
     add_test(NAME NlpSparse6_1 COMMAND ${RUNCMD} "$<TARGET_FILE:nlpSparse_ex6.exe>" "500" "-selfcheck")
     add_test(NAME NlpSparse7_1 COMMAND ${RUNCMD} "$<TARGET_FILE:nlpSparse_ex7.exe>" "500" "-selfcheck")
+    add_test(NAME NlpSparse7_2 COMMAND ${RUNCMD} "$<TARGET_FILE:nlpSparse_ex7.exe>" "500" "-inertiafree" "-selfcheck")
   endif(HIOP_SPARSE)
 
   if(HIOP_USE_MPI)

--- a/src/Drivers/nlpSparse_ex7.cpp
+++ b/src/Drivers/nlpSparse_ex7.cpp
@@ -22,6 +22,9 @@
  *  s.t.  [-inf] <= 4*x_1 + 2*x_3 <= [ 19 ]                  (rnkdef-con1)
  *        4*x_1 + 2*x_2 == 10                                (rnkdef-con2)
  *
+ *  other parameters are:
+ *  convex_obj: set to 1 to have a convex problem, otherwise set it to 0.
+ *  scale_quartic_obj_term: scaling factor for the quartic term in the objective (1.0 by default).
  *
  */
 Ex7::Ex7(int n, bool convex_obj, bool rankdefic_Jac_eq, bool rankdefic_Jac_ineq, double scal_neg_obj)

--- a/src/Drivers/nlpSparse_ex7.hpp
+++ b/src/Drivers/nlpSparse_ex7.hpp
@@ -26,14 +26,14 @@ using index_type = hiop::index_type;
 /** Nonlinear *highly nonconvex* and *rank deficient* problem test for the Filter IPM
  * Newton of HiOp. It uses a Sparse NLP formulation. The problem is based on Ex6.
  *
- *  min   -(2*convex_obj-1)*sum 1/4* { (x_{i}-1)^4 : i=1,...,n} + 0.5x^Tx
+ *  min   (2*convex_obj-1)*scal*sum 1/4* { (x_{i}-1)^4 : i=1,...,n} + 0.5x^Tx
  *  s.t.
  *            4*x_1 + 2*x_2                     == 10
  *        5<= 2*x_1         + x_3
  *        1<= 2*x_1                 + 0.5*x_i   <= 2*n, for i=4,...,n
  *        x_1 free
  *        0.0 <= x_2
- *        1.5 <= x_3 <= 10
+ *        1.0 <= x_3 <= 10
  *        x_i >=0.5, i=4,...,n
  *
  * Optionally, one can add the following constraints to obtain a rank-deficient Jacobian
@@ -46,7 +46,7 @@ using index_type = hiop::index_type;
 class Ex7 : public hiop::hiopInterfaceSparse
 {
 public:
-  Ex7(int n, bool convex_obj, bool rankdefic_Jac_eq, bool rankdefic_Jac_ineq);
+  Ex7(int n, bool convex_obj, bool rankdefic_Jac_eq, bool rankdefic_Jac_ineq,  double scal_neg_obj = 1.0);
   virtual ~Ex7();
 
   virtual bool get_prob_sizes(size_type& n, size_type& m);
@@ -81,6 +81,7 @@ public:
 private:
   int n_vars, n_cons;
   bool convex_obj_, rankdefic_eq_, rankdefic_ineq_;
+  double scal_neg_obj_;
 };
 
 #endif

--- a/src/Drivers/nlpSparse_ex7.hpp
+++ b/src/Drivers/nlpSparse_ex7.hpp
@@ -41,6 +41,9 @@ using index_type = hiop::index_type;
  *  s.t.  [-inf] <= 4*x_1 + 2*x_3 <= [ 19 ]                  (rnkdef-con1)
  *        4*x_1 + 2*x_2 == 10                                (rnkdef-con2)
  *
+ *  other parameters are:
+ *  convex_obj: set to 1 to have a convex problem, otherwise set it to 0
+ *  scale_quartic_obj_term: scaling factor for the quartic term in the objective (1.0 by default).
  *
  */
 class Ex7 : public hiop::hiopInterfaceSparse

--- a/src/Drivers/nlpSparse_ex7_driver.cpp
+++ b/src/Drivers/nlpSparse_ex7_driver.cpp
@@ -103,15 +103,16 @@ int main(int argc, char **argv)
   }
 
   bool convex_obj = false;
-  bool rankdefic_Jac_eq = false;
-  bool rankdefic_Jac_ineq = false;
+  bool rankdefic_Jac_eq = true;
+  bool rankdefic_Jac_ineq = true;
+  double scal_neg_obj = 0.1;
 
-  Ex7 nlp_interface(n,convex_obj,rankdefic_Jac_eq,rankdefic_Jac_ineq);
+  Ex7 nlp_interface(n,convex_obj,rankdefic_Jac_eq,rankdefic_Jac_ineq, scal_neg_obj);
   hiopNlpSparse nlp(nlp_interface);
   nlp.options->SetStringValue("compute_mode", "cpu");
   nlp.options->SetStringValue("KKTLinsys", "xdycyd");
   if(inertia_free) {
-    nlp.options->SetStringValue("fact_acceptor", "inertia_free");    
+    nlp.options->SetStringValue("fact_acceptor", "inertia_free");
   }
 //  nlp.options->SetIntegerValue("max_iter", 100);
 //  nlp.options->SetNumericValue("kappa1", 1e-8);
@@ -141,7 +142,6 @@ int main(int argc, char **argv)
   MPI_Finalize();
 #endif
 
-
   return 0;
 }
 
@@ -149,13 +149,8 @@ int main(int argc, char **argv)
 static bool self_check(size_type n, double objval, const bool inertia_free)
 {
 #define num_n_saved 3 //keep this is sync with n_saved and objval_saved
-  const size_type n_saved[] = {50, 500, 5000};
-  double objval_saved[] = { -1.58349999995100e+03, -1.53428124950100e+03, -1.04209374500105e+03};
-  if(inertia_free) {
-    objval_saved[0] = 8.6822576e+00;
-    objval_saved[1] = 5.7901005e+01;
-    objval_saved[2] = 5.5008848e+02;
-  }
+  const size_type n_saved[] = {50, 500, 10000};
+  const double objval_saved[] = { 8.7754974e+00,  6.4322371e+01,  1.2369786e+03};
 
 #define relerr 1e-6
   bool found=false;

--- a/src/Optimization/hiopAlgFilterIPM.cpp
+++ b/src/Optimization/hiopAlgFilterIPM.cpp
@@ -1310,13 +1310,20 @@ hiopFactAcceptor* hiopAlgFilterIPMNewton::
 decideAndCreateFactAcceptor(hiopPDPerturbation* p, hiopNlpFormulation* nlp)
 {
   std::string strKKT = nlp->options->GetString("fact_acceptor");
-  
   if(strKKT == "inertia_free")
   {
     return new hiopFactAcceptorInertiaFreeDWD(p, nlp->m_eq()+nlp->m_ineq());
   } else {
+
+
     return new hiopFactAcceptorIC(p, nlp->m_eq()+nlp->m_ineq());
   } 
+}
+
+hiopFactAcceptor* hiopAlgFilterIPMNewtonInertiaFree::
+decideAndCreateFactAcceptor(hiopPDPerturbation* p, hiopNlpFormulation* nlp)
+{
+  return new hiopFactAcceptorInertiaFreeDWD(p, nlp->m_eq()+nlp->m_ineq());
 }
 
 hiopSolveStatus hiopAlgFilterIPMNewton::run()
@@ -1558,66 +1565,28 @@ hiopSolveStatus hiopAlgFilterIPMNewton::run()
           linsol_safe_mode_lastiter = iter_num;
 
           nlp->log->printf(hovWarning,
-                           "Requesting additional accuracy and stability from the KKT linear system "
-                           "at iteration %d (safe mode ON)\n", iter_num);
+                          "Requesting additional accuracy and stability from the KKT linear system "
+                          "at iteration %d (safe mode ON)\n", iter_num);
 
           // repeat linear solve (computeDirections) in safe mode (meaning additional accuracy
           // and stability is requested)
           continue;
         }
       } // end of if(!kkt->update(it_curr, _grad_f, _Jac_c, _Jac_d, _Hess_Lagr))
-
-      //
-      // solve for search directions
-      //
-      size_type num_refact = 0;
-      while(1) {
-        if(!kkt->computeDirections(resid, dir)) {
-
-          nlp->runStats.kkt.start_optimiz_iteration();
-
-          if(linsol_safe_mode_on) {
-            nlp->log->write("Unrecoverable error in step computation (solve)[1]. Will exit here.", hovError);
-            return solver_status_ = Err_Step_Computation;
-          } else {
-            if(linsol_forcequick) {
-              nlp->log->write("Unrecoverable error in step computation (solve)[2]. Will exit here.", hovError);
-              return solver_status_ = Err_Step_Computation;
-            }
-            linsol_safe_mode_on = true;
-            linsol_safe_mode_lastiter = iter_num;
-
-            nlp->log->printf(hovWarning,
-                            "Requesting additional accuracy and stability from the KKT linear system "
-                            "at iteration %d (safe mode ON)\n", iter_num);
-
-            // repeat linear solve (computeDirections) in safe mode (meaning additional accuracy
-            // and stability is requested)
-            continue;
-
-          }
-        } // end of if(!kkt->computeDirections(resid, dir))
-
-        //at this point all is good in terms of searchDirections computations as far as the linear solve
-        //is concerned; the search direction can be of ascent because some fast factorizations do not
-        //support inertia calculation; this case will be handled later on in this loop
-        //( //! todo nopiv inertia calculation ))
-        
-        if(nlp->options->GetString("fact_acceptor") == "inertia_free") {
-          bret = kkt->inertia_free_update(num_refact, dir, _grad_f, _Jac_c, _Jac_d, _Hess_Lagr);
-          if(bret) {
-            // inertia-free test fails. Refactorization with new regularization has been applied
-            num_refact++;
-          } else {
-            // pass inertia-free test. Accept this trial iter.
-            break;
-          }
-        } else {
-          break;
-        }
-      }
       
       nlp->runStats.kkt.end_optimiz_iteration();
+      
+      if(nlp->options->GetString("fact_acceptor") == "inertia_correction"){
+        if(!compute_search_direction(kkt, linsol_safe_mode_on, linsol_safe_mode_lastiter, linsol_forcequick, iter_num)) {
+          continue;
+        } 
+      } else {
+        if(!compute_search_direction_inertia_free(kkt, linsol_safe_mode_on, linsol_safe_mode_lastiter, linsol_forcequick, iter_num)) {
+          continue;
+        }         
+      }
+
+      nlp->runStats.kkt.start_optimiz_iteration();
 
       if(perf_report_kkt_) {
         nlp->log->printf(hovSummary, "%s", nlp->runStats.kkt.get_summary_last_iter().c_str());
@@ -2228,6 +2197,180 @@ bool hiopAlgFilterIPMBase::solve_feasibility_restoration(hiopKKTLinSys* kkt, hio
       return false;
     }
   } 
+  return true;
+}
+
+
+bool hiopAlgFilterIPMNewton::compute_search_direction(hiopKKTLinSys* kkt,
+                                                      bool& linsol_safe_mode_on,
+                                                      int& linsol_safe_mode_lastiter,
+                                                      const bool linsol_forcequick,
+                                                      const int iter_num)
+{
+  nlp->runStats.kkt.start_optimiz_iteration();
+
+  //
+  // solve for search directions
+  //
+  if(!kkt->computeDirections(resid, dir)) {
+
+    nlp->runStats.kkt.start_optimiz_iteration();
+
+    if(linsol_safe_mode_on) {
+      nlp->log->write("Unrecoverable error in step computation (solve)[1]. Will exit here.", hovError);
+      return solver_status_ = Err_Step_Computation;
+    } else {
+      if(linsol_forcequick) {
+        nlp->log->write("Unrecoverable error in step computation (solve)[2]. Will exit here.", hovError);
+        return solver_status_ = Err_Step_Computation;
+      }
+      linsol_safe_mode_on = true;
+      linsol_safe_mode_lastiter = iter_num;
+
+      nlp->log->printf(hovWarning,
+                      "Requesting additional accuracy and stability from the KKT linear system "
+                      "at iteration %d (safe mode ON)\n", iter_num);
+
+      // repeat linear solve (computeDirections) in safe mode (meaning additional accuracy
+      // and stability is requested)
+      return false;
+    }
+  } // end of if(!kkt->computeDirections(resid, dir))
+
+  //at this point all is good in terms of searchDirections computations as far as the linear solve
+  //is concerned; the search direction can be of ascent because some fast factorizations do not
+  //support inertia calculation; this case will be handled later on in this loop
+  //( //! todo nopiv inertia calculation ))
+
+  nlp->runStats.kkt.end_optimiz_iteration();
+  return true;
+}
+
+bool hiopAlgFilterIPMNewton::compute_search_direction_inertia_free(hiopKKTLinSys* kkt,
+                                                                   bool& linsol_safe_mode_on,
+                                                                   int& linsol_safe_mode_lastiter,
+                                                                   const bool linsol_forcequick,
+                                                                   const int iter_num)
+{
+  nlp->runStats.kkt.start_optimiz_iteration();
+  size_type num_refact = 0;
+  const size_t max_refactorizaion = 10;
+
+  while(true)
+  {
+    //
+    // solve for search directions
+    //
+    if(!kkt->computeDirections(resid, dir)) {
+
+      nlp->runStats.kkt.start_optimiz_iteration();
+
+      if(linsol_safe_mode_on) {
+        nlp->log->write("Unrecoverable error in step computation (solve)[1]. Will exit here.", hovError);
+        return solver_status_ = Err_Step_Computation;
+      } else {
+        if(linsol_forcequick) {
+          nlp->log->write("Unrecoverable error in step computation (solve)[2]. Will exit here.", hovError);
+          return solver_status_ = Err_Step_Computation;
+        }
+        linsol_safe_mode_on = true;
+        linsol_safe_mode_lastiter = iter_num;
+
+        nlp->log->printf(hovWarning,
+                        "Requesting additional accuracy and stability from the KKT linear system "
+                        "at iteration %d (safe mode ON)\n", iter_num);
+
+        // repeat linear solve (computeDirections) in safe mode (meaning additional accuracy
+        // and stability is requested)
+        return false;
+      }
+    } // end of if(!kkt->computeDirections(resid, dir))
+
+    //at this point all is good in terms of searchDirections computations as far as the linear solve
+    //is concerned; the search direction can be of ascent because some fast factorizations do not
+    //support inertia calculation; this case will be handled later on in this loop
+    //( //! todo nopiv inertia calculation ))
+
+    if(kkt->test_direction(dir, _Hess_Lagr)) {
+      break;
+    } else {
+      if(num_refact >= max_refactorizaion) {
+        nlp->log->printf(hovError,
+                         "Reached max number (%d) of refactorization within an outer iteration.\n",
+                         max_refactorizaion);
+        return false;
+      }
+      kkt->factorize_inertia_free();
+      num_refact++;
+      nlp->runStats.kkt.nUpdateICCorr++;
+    }
+  }
+
+  return true;
+}
+
+
+
+bool hiopAlgFilterIPMNewtonInertiaFree::compute_search_direction(hiopKKTLinSys* kkt,
+                                                                 bool& linsol_safe_mode_on,
+                                                                 int& linsol_safe_mode_lastiter,
+                                                                 const bool linsol_forcequick,
+                                                                 const int iter_num)
+{
+  nlp->runStats.kkt.start_optimiz_iteration();
+  size_type num_refact = 0;
+  const size_t max_refactorizaion = 10;
+
+  while(true)
+  {
+    //
+    // solve for search directions
+    //
+    if(!kkt->computeDirections(resid, dir)) {
+
+      nlp->runStats.kkt.start_optimiz_iteration();
+
+      if(linsol_safe_mode_on) {
+        nlp->log->write("Unrecoverable error in step computation (solve)[1]. Will exit here.", hovError);
+        return solver_status_ = Err_Step_Computation;
+      } else {
+        if(linsol_forcequick) {
+          nlp->log->write("Unrecoverable error in step computation (solve)[2]. Will exit here.", hovError);
+          return solver_status_ = Err_Step_Computation;
+        }
+        linsol_safe_mode_on = true;
+        linsol_safe_mode_lastiter = iter_num;
+
+        nlp->log->printf(hovWarning,
+                        "Requesting additional accuracy and stability from the KKT linear system "
+                        "at iteration %d (safe mode ON)\n", iter_num);
+
+        // repeat linear solve (computeDirections) in safe mode (meaning additional accuracy
+        // and stability is requested)
+        return false;
+      }
+    } // end of if(!kkt->computeDirections(resid, dir))
+
+    //at this point all is good in terms of searchDirections computations as far as the linear solve
+    //is concerned; the search direction can be of ascent because some fast factorizations do not
+    //support inertia calculation; this case will be handled later on in this loop
+    //( //! todo nopiv inertia calculation ))
+
+    if(kkt->test_direction(dir, _Hess_Lagr)) {
+      break;
+    } else {
+      if(num_refact >= max_refactorizaion) {
+        nlp->log->printf(hovError,
+                         "Reached max number (%d) of refactorization within an outer iteration.\n",
+                         max_refactorizaion);
+        return false;
+      }
+      kkt->factorize_inertia_free();
+      num_refact++;
+      nlp->runStats.kkt.nUpdateICCorr++;
+    }
+  }
+
   return true;
 }
 

--- a/src/Optimization/hiopAlgFilterIPM.hpp
+++ b/src/Optimization/hiopAlgFilterIPM.hpp
@@ -317,24 +317,5 @@ private:
   hiopAlgFilterIPMNewton& operator=(const hiopAlgFilterIPMNewton&) {return *this;};
 };
 
-class hiopAlgFilterIPMNewtonInertiaFree : public hiopAlgFilterIPMNewton
-{
-public:
-  hiopAlgFilterIPMNewtonInertiaFree(hiopNlpFormulation* nlp, const bool within_FR = false)
-    :hiopAlgFilterIPMNewton(nlp, within_FR)
-  {}
-  virtual ~hiopAlgFilterIPMNewtonInertiaFree();
-
-protected:
-  virtual hiopFactAcceptor* decideAndCreateFactAcceptor(hiopPDPerturbation* p, hiopNlpFormulation* nlp);
-
-  virtual bool compute_search_direction(hiopKKTLinSys* kkt,
-                                        bool& linsol_safe_mode_on,
-                                        int& linsol_safe_mode_lastiter,
-                                        const bool linsol_forcequick,
-                                        const int iter_num);
-
-};
-
 } //end of namespace
 #endif

--- a/src/Optimization/hiopAlgFilterIPM.hpp
+++ b/src/Optimization/hiopAlgFilterIPM.hpp
@@ -291,11 +291,23 @@ public:
 
   virtual hiopSolveStatus run();
 
-private:
+protected:
   virtual void outputIteration(int lsStatus, int lsNum, int use_soc = 0, int use_fr = 0);
   virtual hiopKKTLinSys* decideAndCreateLinearSystem(hiopNlpFormulation* nlp);
   /// @brief get the method to decide if a factorization is acceptable or not
   virtual hiopFactAcceptor* decideAndCreateFactAcceptor(hiopPDPerturbation* p, hiopNlpFormulation* nlp);
+
+  virtual bool compute_search_direction(hiopKKTLinSys* kkt,
+                                        bool& linsol_safe_mode_on,
+                                        int& linsol_safe_mode_lastiter,
+                                        const bool linsol_forcequick,
+                                        const int iter_num);
+
+  virtual bool compute_search_direction_inertia_free(hiopKKTLinSys* kkt,
+                                                     bool& linsol_safe_mode_on,
+                                                     int& linsol_safe_mode_lastiter,
+                                                     const bool linsol_forcequick,
+                                                     const int iter_num);
 
   hiopPDPerturbation pd_perturb_;
   hiopFactAcceptor* fact_acceptor_;
@@ -303,6 +315,25 @@ private:
   hiopAlgFilterIPMNewton() : hiopAlgFilterIPMBase(NULL) {};
   hiopAlgFilterIPMNewton(const hiopAlgFilterIPMNewton& ) : hiopAlgFilterIPMBase(NULL){};
   hiopAlgFilterIPMNewton& operator=(const hiopAlgFilterIPMNewton&) {return *this;};
+};
+
+class hiopAlgFilterIPMNewtonInertiaFree : public hiopAlgFilterIPMNewton
+{
+public:
+  hiopAlgFilterIPMNewtonInertiaFree(hiopNlpFormulation* nlp, const bool within_FR = false)
+    :hiopAlgFilterIPMNewton(nlp, within_FR)
+  {}
+  virtual ~hiopAlgFilterIPMNewtonInertiaFree();
+
+protected:
+  virtual hiopFactAcceptor* decideAndCreateFactAcceptor(hiopPDPerturbation* p, hiopNlpFormulation* nlp);
+
+  virtual bool compute_search_direction(hiopKKTLinSys* kkt,
+                                        bool& linsol_safe_mode_on,
+                                        int& linsol_safe_mode_lastiter,
+                                        const bool linsol_forcequick,
+                                        const int iter_num);
+
 };
 
 } //end of namespace

--- a/src/Optimization/hiopFactAcceptor.cpp
+++ b/src/Optimization/hiopFactAcceptor.cpp
@@ -4,7 +4,7 @@
 //
 // This file is part of HiOp. For details, see https://github.com/LLNL/hiop. HiOp 
 // is released under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause). 
-// Please also read “Additional BSD Notice” below.
+// Please also read ï¿½Additional BSD Noticeï¿½ below.
 //
 // Redistribution and use in source and binary forms, with or without modification, 
 // are permitted provided that the following conditions are met:
@@ -61,36 +61,41 @@
 namespace hiop
 {
 
-int hiopFactAcceptorIC::requireReFactorization(const hiopNlpFormulation& nlp, const int& n_neg_eig,
-                                               double& delta_wx, double& delta_wd, double& delta_cc, double& delta_cd)
+int hiopFactAcceptorIC::requireReFactorization(const hiopNlpFormulation& nlp,
+                                               const int& n_neg_eig,
+                                               double& delta_wx,
+                                               double& delta_wd,
+                                               double& delta_cc,
+                                               double& delta_cd,
+                                               const bool force_reg)
 {
   int continue_re_fact{1};
 
   if(n_required_neg_eig_>0) {
-   if(n_neg_eig < 0) {
-        //matrix singular
-        nlp.log->printf(hovScalars, "linsys is singular.\n");
+    if(n_neg_eig < 0) {
+      //matrix singular
+      nlp.log->printf(hovScalars, "linsys is singular.\n");
 
-        if(!perturb_calc_->compute_perturb_singularity(delta_wx, delta_wd, delta_cc, delta_cd)) {\
-          continue_re_fact = -1;
-        }
-      } else if(n_neg_eig != n_required_neg_eig_) {
-        //wrong inertia
-        nlp.log->printf(hovScalars, "linsys negative eigs mismatch: has %d expected %d.\n",
-         n_neg_eig,  n_required_neg_eig_);
+      if(!perturb_calc_->compute_perturb_singularity(delta_wx, delta_wd, delta_cc, delta_cd)) {\
+        continue_re_fact = -1;
+      }
+    } else if(n_neg_eig != n_required_neg_eig_) {
+      //wrong inertia
+      nlp.log->printf(hovScalars, "linsys negative eigs mismatch: has %d expected %d.\n",
+                      n_neg_eig,  n_required_neg_eig_);
 
-        if(!perturb_calc_->compute_perturb_wrong_inertia(delta_wx, delta_wd, delta_cc, delta_cd)) {
-          nlp.log->printf(hovWarning, "linsys: computing inertia perturbation failed.\n");
-          continue_re_fact = -1;
-        }
-      } else {
-        //all is good
+      if(!perturb_calc_->compute_perturb_wrong_inertia(delta_wx, delta_wd, delta_cc, delta_cd)) {
+        nlp.log->printf(hovWarning, "linsys: computing inertia perturbation failed.\n");
+        continue_re_fact = -1;
+      }
+    } else {
+      //all is good
       continue_re_fact = 0;
     }
   } else if(n_neg_eig != 0) {
       //correct for wrong intertia
       nlp.log->printf(hovScalars,  "linsys has wrong inertia (no constraints): factoriz "
-               "ret code %d\n.", n_neg_eig);
+                      "ret code %d\n.", n_neg_eig);
       if(!perturb_calc_->compute_perturb_wrong_inertia(delta_wx, delta_wd, delta_cc, delta_cd)) {
         nlp.log->printf(hovWarning, "linsys: computing inertia perturbation failed (2).\n");
         continue_re_fact = -1;
@@ -101,5 +106,39 @@ int hiopFactAcceptorIC::requireReFactorization(const hiopNlpFormulation& nlp, co
   }
   return continue_re_fact;
 }
+
+int hiopFactAcceptorInertiaFreeDWD::requireReFactorization(const hiopNlpFormulation& nlp,
+                                                           const int& n_neg_eig,
+                                                           double& delta_wx,
+                                                           double& delta_wd,
+                                                           double& delta_cc,
+                                                           double& delta_cd,
+                                                           const bool force_reg)
+{
+  int continue_re_fact{1};
+
+  if(n_neg_eig < 0) {
+    //matrix singular
+    nlp.log->printf(hovScalars, "linsys is singular.\n");
+
+    if(!perturb_calc_->compute_perturb_singularity(delta_wx, delta_wd, delta_cc, delta_cd)) {
+      continue_re_fact = -1;
+    }
+  } else {
+    if(!force_reg) {
+      // skip inertia test and accept current factorization (we do curvature test after backsolve)
+      continue_re_fact = 0;
+    } else {
+      // add regularization and accept current factorization (we do curvature test after backsolve)
+      nlp.log->printf(hovScalars,  "linsys has wrong curvature. \n");
+      if(!perturb_calc_->compute_perturb_wrong_inertia(delta_wx, delta_wd, delta_cc, delta_cd)) {
+        nlp.log->printf(hovWarning, "linsys: computing inertia perturbation failed (2).\n");
+      }
+    }
+  }
+
+  return continue_re_fact;
+}
   
+
 } //end of namespace

--- a/src/Optimization/hiopFactAcceptor.cpp
+++ b/src/Optimization/hiopFactAcceptor.cpp
@@ -4,7 +4,7 @@
 //
 // This file is part of HiOp. For details, see https://github.com/LLNL/hiop. HiOp 
 // is released under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause). 
-// Please also read �Additional BSD Notice� below.
+// Please also read "Additional BSD Notice" below.
 //
 // Redistribution and use in source and binary forms, with or without modification, 
 // are permitted provided that the following conditions are met:

--- a/src/Optimization/hiopFactAcceptor.hpp
+++ b/src/Optimization/hiopFactAcceptor.hpp
@@ -85,8 +85,13 @@ public:
    * Returns '0' if current factorization is ok
    * Returns '-1' if current factorization failed due to singularity
    */
-  virtual int requireReFactorization(const hiopNlpFormulation& nlp, const int& n_neg_eig,
-                                     double& delta_wx, double& delta_wd, double& delta_cc, double& delta_cd) = 0;
+  virtual int requireReFactorization(const hiopNlpFormulation& nlp,
+                                     const int& n_neg_eig,
+                                     double& delta_wx,
+                                     double& delta_wd,
+                                     double& delta_cc,
+                                     double& delta_cd,
+                                     const bool force_reg=false) = 0;
       
 protected:  
   hiopPDPerturbation* perturb_calc_;
@@ -113,11 +118,39 @@ public:
                                      double& delta_wx,
                                      double& delta_wd,
                                      double& delta_cc,
-                                     double& delta_cd);
+                                     double& delta_cd,
+                                     const bool force_reg=false);
  
 protected:
   int n_required_neg_eig_;    
 };
-  
+
+class hiopFactAcceptorInertiaFreeDWD : public hiopFactAcceptor
+{
+public:
+  /** 
+   * Default constructor 
+   * Check inertia condition to determine if a factorization is acceptable or not
+   */
+  hiopFactAcceptorInertiaFreeDWD(hiopPDPerturbation* p, const size_type n_required_neg_eig)
+    : hiopFactAcceptor(p)
+  {}
+
+  virtual ~hiopFactAcceptorInertiaFreeDWD() 
+  {}
+   
+  virtual int requireReFactorization(const hiopNlpFormulation& nlp,
+                                     const int& n_neg_eig, 
+                                     double& delta_wx,
+                                     double& delta_wd,
+                                     double& delta_cc,
+                                     double& delta_cd,
+                                     const bool force_reg=false);
+ 
+protected:
+  int n_required_neg_eig_;
+
+};
+
 } //end of namespace
 #endif

--- a/src/Optimization/hiopKKTLinSys.hpp
+++ b/src/Optimization/hiopKKTLinSys.hpp
@@ -78,20 +78,17 @@ public:
   virtual bool update(const hiopIterate* iter,
 		      const hiopVector* grad_f,
 		      const hiopMatrix* Jac_c, const hiopMatrix* Jac_d, hiopMatrix* Hess) = 0;
-
-  /* update the regularization based on inertia-free approach */  
-  virtual bool inertia_free_update(const size_type num_factor,
-                                   const hiopIterate* dir,
-                                   const hiopVector* grad_f,
-                                   const hiopMatrix* Jac_c,
-                                   const hiopMatrix* Jac_d,
-                                   hiopMatrix* Hess) = 0;
   
   /* forms the residual of the underlying linear system, uses the factorization
    * computed by 'update' to compute the "reduced-space" search directions by solving
    * with the factors, then computes the "full-space" directions */
   virtual bool computeDirections(const hiopResidual* resid, hiopIterate* direction) = 0;
   virtual bool compute_directions_for_full_space(const hiopResidual* resid, hiopIterate* direction);
+
+  virtual bool factorize_inertia_free() = 0;
+
+  /* curvature test for inertia-free approach */  
+  virtual bool test_direction(const hiopIterate* dir, hiopMatrix* Hess) = 0;
 
   virtual void set_PD_perturb_calc(hiopPDPerturbation* p)
   {
@@ -156,18 +153,14 @@ public:
                       const hiopMatrix* Jac_d,
                       hiopMatrix* Hess) = 0;
 
-  /* update the regularization based on inertia-free approach */  
-  virtual bool inertia_free_update(const size_type num_factor,
-                                   const hiopIterate* dir,
-                                   const hiopVector* grad_f,
-                                   const hiopMatrix* Jac_c,
-                                   const hiopMatrix* Jac_d,
-                                   hiopMatrix* Hess) = 0;
-
   virtual bool computeDirections(const hiopResidual* resid, hiopIterate* direction) = 0;
 
-  virtual bool factorize(const bool keep_delta = false,
-                         const size_type num_factor = 0);
+  virtual bool factorize();
+  
+  virtual bool factorize_inertia_free();
+
+  /* curvature test for inertia-free approach */  
+  virtual bool test_direction(const hiopIterate* dir, hiopMatrix* Hess) = 0;
   
   /**
    * @brief factorize the matrix and check curvature
@@ -219,12 +212,7 @@ public:
 		      const hiopVector* grad_f,
 		      const hiopMatrix* Jac_c, const hiopMatrix* Jac_d, hiopMatrix* Hess) = 0;
 
-  virtual bool inertia_free_update(const size_type num_factor,
-                                   const hiopIterate* dir,
-                                   const hiopVector* grad_f,
-                                   const hiopMatrix* Jac_c,
-                                   const hiopMatrix* Jac_d,
-                                   hiopMatrix* Hess);
+  virtual bool test_direction(const hiopIterate* dir, hiopMatrix* Hess);
 
   virtual bool computeDirections(const hiopResidual* resid, hiopIterate* direction) = 0;
 
@@ -458,12 +446,7 @@ public:
                       const hiopVector* grad_f,
                       const hiopMatrix* Jac_c, const hiopMatrix* Jac_d, hiopMatrix* Hess);
 
-  virtual bool inertia_free_update(const size_type num_factor,
-                                   const hiopIterate* dir,
-                                   const hiopVector* grad_f,
-                                   const hiopMatrix* Jac_c,
-                                   const hiopMatrix* Jac_d,
-                                   hiopMatrix* Hess)
+  virtual bool test_direction(const hiopIterate* dir, hiopMatrix* Hess)
   {
     assert(false && "not implemented yet!");
   }

--- a/src/Optimization/hiopKKTLinSysDense.hpp
+++ b/src/Optimization/hiopKKTLinSysDense.hpp
@@ -82,7 +82,7 @@ public:
     delete rhsXYcYd;
   }
 
-  virtual bool updateMatrix(const double& delta_wx, const double& delta_wd,
+  virtual bool build_kkt_matrix(const double& delta_wx, const double& delta_wd,
                             const double& delta_cc, const double& delta_cd)
   {
     assert(nlp_);
@@ -242,7 +242,7 @@ public:
   * [    Jc        0     0      0    ] [dyc] = [   ryc    ]
   * [    Jd       -I     0      0    ] [dyd]   [   ryd    ]
   */
-  virtual bool updateMatrix( const double& delta_wx, const double& delta_wd,
+  virtual bool build_kkt_matrix( const double& delta_wx, const double& delta_wd,
                              const double& delta_cc, const double& delta_cd)
   {
     assert(nlp_);

--- a/src/Optimization/hiopKKTLinSysDense.hpp
+++ b/src/Optimization/hiopKKTLinSysDense.hpp
@@ -82,8 +82,10 @@ public:
     delete rhsXYcYd;
   }
 
-  virtual bool build_kkt_matrix(const double& delta_wx, const double& delta_wd,
-                            const double& delta_cc, const double& delta_cd)
+  virtual bool build_kkt_matrix(const double& delta_wx,
+                                const double& delta_wd,
+                                const double& delta_cc,
+                                const double& delta_cd)
   {
     assert(nlp_);
 
@@ -242,8 +244,10 @@ public:
   * [    Jc        0     0      0    ] [dyc] = [   ryc    ]
   * [    Jd       -I     0      0    ] [dyd]   [   ryd    ]
   */
-  virtual bool build_kkt_matrix( const double& delta_wx, const double& delta_wd,
-                             const double& delta_cc, const double& delta_cd)
+  virtual bool build_kkt_matrix(const double& delta_wx,
+                                const double& delta_wd,
+                                const double& delta_cc,
+                                const double& delta_cd)
   {
     assert(nlp_);
    

--- a/src/Optimization/hiopKKTLinSysMDS.cpp
+++ b/src/Optimization/hiopKKTLinSysMDS.cpp
@@ -168,8 +168,10 @@ namespace hiop
   }
 
 
-  bool hiopKKTLinSysCompressedMDSXYcYd::build_kkt_matrix(const double& delta_wx, const double& delta_wd,
-                                                     const double& delta_cc, const double& delta_cd)
+  bool hiopKKTLinSysCompressedMDSXYcYd::build_kkt_matrix(const double& delta_wx, 
+                                                         const double& delta_wd,
+                                                         const double& delta_cc,
+                                                         const double& delta_cd)
   {
     assert(linSys_);
     hiopLinSolverIndefDense* linSys = dynamic_cast<hiopLinSolverIndefDense*> (linSys_);

--- a/src/Optimization/hiopKKTLinSysMDS.cpp
+++ b/src/Optimization/hiopKKTLinSysMDS.cpp
@@ -168,7 +168,7 @@ namespace hiop
   }
 
 
-  bool hiopKKTLinSysCompressedMDSXYcYd::updateMatrix(const double& delta_wx, const double& delta_wd,
+  bool hiopKKTLinSysCompressedMDSXYcYd::build_kkt_matrix(const double& delta_wx, const double& delta_wd,
                                                      const double& delta_cc, const double& delta_cd)
   {
     assert(linSys_);

--- a/src/Optimization/hiopKKTLinSysMDS.hpp
+++ b/src/Optimization/hiopKKTLinSysMDS.hpp
@@ -107,7 +107,7 @@ public:
 		      const hiopMatrix* Jac_c, const hiopMatrix* Jac_d,
 		      hiopMatrix* Hess);
 
-  virtual bool updateMatrix(const double& delta_wx, const double& delta_wd,
+  virtual bool build_kkt_matrix(const double& delta_wx, const double& delta_wd,
                             const double& delta_cc, const double& delta_cd);
 
   virtual bool solveCompressed(hiopVector& rx, hiopVector& ryc, hiopVector& ryd,

--- a/src/Optimization/hiopKKTLinSysMDS.hpp
+++ b/src/Optimization/hiopKKTLinSysMDS.hpp
@@ -107,8 +107,10 @@ public:
 		      const hiopMatrix* Jac_c, const hiopMatrix* Jac_d,
 		      hiopMatrix* Hess);
 
-  virtual bool build_kkt_matrix(const double& delta_wx, const double& delta_wd,
-                            const double& delta_cc, const double& delta_cd);
+  virtual bool build_kkt_matrix(const double& delta_wx,
+                                const double& delta_wd,
+                                const double& delta_cc,
+                                const double& delta_cd);
 
   virtual bool solveCompressed(hiopVector& rx, hiopVector& ryc, hiopVector& ryd,
                                hiopVector& dx, hiopVector& dyc, hiopVector& dyd);

--- a/src/Optimization/hiopKKTLinSysSparse.cpp
+++ b/src/Optimization/hiopKKTLinSysSparse.cpp
@@ -524,7 +524,7 @@ namespace hiop
       if(nlp_->options->GetString("compute_mode")=="cpu")
       {
         nlp_->log->printf(hovWarning,
-                         "KKT_SPARSE_XYcYd linsys: alloc sparse solver with matrix size %d (%d cons)\n",
+                         "KKT_SPARSE_XDYcYd linsys: alloc sparse solver with matrix size %d (%d cons)\n",
                           n, neq+nineq);
 
         auto linear_solver = nlp_->options->GetString("linear_solver_sparse");

--- a/src/Optimization/hiopKKTLinSysSparse.cpp
+++ b/src/Optimization/hiopKKTLinSysSparse.cpp
@@ -81,7 +81,7 @@ namespace hiop
     delete Hx_;
   }
 
-  bool hiopKKTLinSysCompressedSparseXYcYd::updateMatrix(const double& delta_wx, const double& delta_wd,
+  bool hiopKKTLinSysCompressedSparseXYcYd::build_kkt_matrix(const double& delta_wx, const double& delta_wd,
                                                         const double& delta_cc, const double& delta_cd)
   {
     HessSp_ = dynamic_cast<hiopMatrixSymSparseTriplet*>(Hess_);
@@ -348,7 +348,7 @@ namespace hiop
     delete Hd_;
   }
 
-  bool hiopKKTLinSysCompressedSparseXDYcYd::updateMatrix(const double& delta_wx, const double& delta_wd,
+  bool hiopKKTLinSysCompressedSparseXDYcYd::build_kkt_matrix(const double& delta_wx, const double& delta_wd,
                                                          const double& delta_cc, const double& delta_cd)
   {
     HessSp_ = dynamic_cast<hiopMatrixSymSparseTriplet*>(Hess_);
@@ -640,7 +640,7 @@ namespace hiop
     return dynamic_cast<hiopLinSolverNonSymSparse*> (linSys_);
   }
 
-  bool hiopKKTLinSysSparseFull::updateMatrix(const double& delta_wx, const double& delta_wd,
+  bool hiopKKTLinSysSparseFull::build_kkt_matrix(const double& delta_wx, const double& delta_wd,
                                              const double& delta_cc, const double& delta_cd)
   {
     HessSp_ = dynamic_cast<hiopMatrixSymSparseTriplet*>(Hess_);

--- a/src/Optimization/hiopKKTLinSysSparse.cpp
+++ b/src/Optimization/hiopKKTLinSysSparse.cpp
@@ -81,8 +81,10 @@ namespace hiop
     delete Hx_;
   }
 
-  bool hiopKKTLinSysCompressedSparseXYcYd::build_kkt_matrix(const double& delta_wx, const double& delta_wd,
-                                                        const double& delta_cc, const double& delta_cd)
+  bool hiopKKTLinSysCompressedSparseXYcYd::build_kkt_matrix(const double& delta_wx,
+                                                            const double& delta_wd,
+                                                            const double& delta_cc,
+                                                            const double& delta_cd)
   {
     HessSp_ = dynamic_cast<hiopMatrixSymSparseTriplet*>(Hess_);
     if(!HessSp_) { assert(false); return false; }
@@ -348,8 +350,10 @@ namespace hiop
     delete Hd_;
   }
 
-  bool hiopKKTLinSysCompressedSparseXDYcYd::build_kkt_matrix(const double& delta_wx, const double& delta_wd,
-                                                         const double& delta_cc, const double& delta_cd)
+  bool hiopKKTLinSysCompressedSparseXDYcYd::build_kkt_matrix(const double& delta_wx,
+                                                             const double& delta_wd,
+                                                             const double& delta_cc,
+                                                             const double& delta_cd)
   {
     HessSp_ = dynamic_cast<hiopMatrixSymSparseTriplet*>(Hess_);
     if(!HessSp_) { assert(false); return false; }
@@ -640,8 +644,10 @@ namespace hiop
     return dynamic_cast<hiopLinSolverNonSymSparse*> (linSys_);
   }
 
-  bool hiopKKTLinSysSparseFull::build_kkt_matrix(const double& delta_wx, const double& delta_wd,
-                                             const double& delta_cc, const double& delta_cd)
+  bool hiopKKTLinSysSparseFull::build_kkt_matrix(const double& delta_wx,
+                                                 const double& delta_wd,
+                                                 const double& delta_cc,
+                                                 const double& delta_cd)
   {
     HessSp_ = dynamic_cast<hiopMatrixSymSparseTriplet*>(Hess_);
     if(!HessSp_) { assert(false); return false; }

--- a/src/Optimization/hiopKKTLinSysSparse.hpp
+++ b/src/Optimization/hiopKKTLinSysSparse.hpp
@@ -78,8 +78,10 @@ public:
   hiopKKTLinSysCompressedSparseXYcYd(hiopNlpFormulation* nlp);
   virtual ~hiopKKTLinSysCompressedSparseXYcYd();
 
-  virtual bool build_kkt_matrix(const double& delta_wx, const double& delta_wd,
-                            const double& delta_cc, const double& delta_cd);
+  virtual bool build_kkt_matrix(const double& delta_wx,
+                                const double& delta_wd,
+                                const double& delta_cc,
+                                const double& delta_cd);
 
   virtual bool solveCompressed(hiopVector& rx, hiopVector& ryc, hiopVector& ryd,
                                hiopVector& dx, hiopVector& dyc, hiopVector& dyd);
@@ -138,8 +140,10 @@ public:
   hiopKKTLinSysCompressedSparseXDYcYd(hiopNlpFormulation* nlp);
   virtual ~hiopKKTLinSysCompressedSparseXDYcYd();
 
-  virtual bool build_kkt_matrix(const double& delta_wx, const double& delta_wd,
-                            const double& delta_cc, const double& delta_cd);
+  virtual bool build_kkt_matrix(const double& delta_wx,
+                                const double& delta_wd,
+                                const double& delta_cc,
+                                const double& delta_cd);
 
   virtual bool solveCompressed(hiopVector& rx, hiopVector& rd, hiopVector& ryc, hiopVector& ryd,
                                hiopVector& dx, hiopVector& dd, hiopVector& dyc, hiopVector& dyd);
@@ -209,8 +213,10 @@ public:
 
   virtual ~hiopKKTLinSysSparseFull();
 
-  virtual bool build_kkt_matrix(const double& delta_wx, const double& delta_wd,
-                            const double& delta_cc, const double& delta_cd);
+  virtual bool build_kkt_matrix(const double& delta_wx,
+                                const double& delta_wd,
+                                const double& delta_cc,
+                                const double& delta_cd);
 
   bool solve(hiopVector& rx, hiopVector& ryc, hiopVector& ryd, hiopVector& rd,
              hiopVector& rvl, hiopVector& rvu, hiopVector& rzl, hiopVector& rzu,

--- a/src/Optimization/hiopKKTLinSysSparse.hpp
+++ b/src/Optimization/hiopKKTLinSysSparse.hpp
@@ -78,7 +78,7 @@ public:
   hiopKKTLinSysCompressedSparseXYcYd(hiopNlpFormulation* nlp);
   virtual ~hiopKKTLinSysCompressedSparseXYcYd();
 
-  virtual bool updateMatrix(const double& delta_wx, const double& delta_wd,
+  virtual bool build_kkt_matrix(const double& delta_wx, const double& delta_wd,
                             const double& delta_cc, const double& delta_cd);
 
   virtual bool solveCompressed(hiopVector& rx, hiopVector& ryc, hiopVector& ryd,
@@ -138,7 +138,7 @@ public:
   hiopKKTLinSysCompressedSparseXDYcYd(hiopNlpFormulation* nlp);
   virtual ~hiopKKTLinSysCompressedSparseXDYcYd();
 
-  virtual bool updateMatrix(const double& delta_wx, const double& delta_wd,
+  virtual bool build_kkt_matrix(const double& delta_wx, const double& delta_wd,
                             const double& delta_cc, const double& delta_cd);
 
   virtual bool solveCompressed(hiopVector& rx, hiopVector& rd, hiopVector& ryc, hiopVector& ryd,
@@ -209,7 +209,7 @@ public:
 
   virtual ~hiopKKTLinSysSparseFull();
 
-  virtual bool updateMatrix(const double& delta_wx, const double& delta_wd,
+  virtual bool build_kkt_matrix(const double& delta_wx, const double& delta_wd,
                             const double& delta_cc, const double& delta_cd);
 
   bool solve(hiopVector& rx, hiopVector& ryc, hiopVector& ryd, hiopVector& rd,

--- a/src/Utils/hiopOptions.cpp
+++ b/src/Utils/hiopOptions.cpp
@@ -818,7 +818,14 @@ void hiopOptionsNLP::register_options()
                         "inertia_correction",
                         range,
                         "The criteria used to accept a factorization: inertia_correction (default option) "
-                        " inertia_free (to be supported soon)");
+                        "and inertia_free.");
+    register_num_option("neg_curv_test_fact",
+                        1e-11,
+                        0.,
+                        1e+20,
+                        "Apply curvature test to check if a factorization is acceptable. "
+                        "This is the scaling factor which used to determines if the "
+                        "direction is considered to be sufficiently positive. (1e-11 by default)");
   }  
   //computations
   {

--- a/src/Utils/hiopOptions.cpp
+++ b/src/Utils/hiopOptions.cpp
@@ -824,7 +824,7 @@ void hiopOptionsNLP::register_options()
                         0.,
                         1e+20,
                         "Apply curvature test to check if a factorization is acceptable. "
-                        "This is the scaling factor which used to determines if the "
+                        "This is the scaling factor used to determines if the "
                         "direction is considered to be sufficiently positive. (1e-11 by default)");
   }  
   //computations


### PR DESCRIPTION
Add inertia-free approach to HiOp.
Only the dWd curvature test is implemented. (see paper [An Inertia-free Filter Line-search Algorithm For Large-scale Nonlinear Programming](https://link.springer.com/article/10.1007/s10589-015-9820-y)
The current inertia-free test only applies to option the KKT linear system with option `xdycyd` or `xycyd'

Add one test problem `nlpSparse_Ex7_2` to test inertia-free approach.

@pelesh @cnpetra 