### PR TITLE
fix zero-length dense matrix

### DIFF
--- a/src/LinAlg/hiopMatrixRajaDense.cpp
+++ b/src/LinAlg/hiopMatrixRajaDense.cpp
@@ -295,6 +295,10 @@ void hiopMatrixRajaDense::copyRowsFrom(
   int num_rows,
   int row_dest)
 {
+  if(num_rows==0) {
+    return;
+  } 
+
   const auto& src = dynamic_cast<const hiopMatrixRajaDense&>(srcmat);
 #ifdef HIOP_DEEPCHECKS
   assert(row_dest >= 0);


### PR DESCRIPTION
This PR fix a bug occurred when we have zero-length dense Jacobian matrix and it is copied in the feasibility restoration problem.

