### PR TITLE
Add return value to function hiopKKTLinSysFull::test_direction

### DIFF
--- a/src/Optimization/hiopKKTLinSys.hpp
+++ b/src/Optimization/hiopKKTLinSys.hpp
@@ -449,6 +449,7 @@ public:
   virtual bool test_direction(const hiopIterate* dir, hiopMatrix* Hess)
   {
     assert(false && "not implemented yet!");
+    return false;
   }
 
   virtual bool computeDirections(const hiopResidual* resid, hiopIterate* direction);


### PR DESCRIPTION
Add missing return value to function `hiopKKTLinSysFull::test_direction`

CLOSE #328
