### PR TITLE
fix uninitialized variable

### DIFF
--- a/src/LinAlg/hiopMatrixRajaDense.cpp
+++ b/src/LinAlg/hiopMatrixRajaDense.cpp
@@ -192,6 +192,11 @@ hiopMatrixRajaDense::hiopMatrixRajaDense(const hiopMatrixRajaDense& dm)
     data_host_  = static_cast<double*>(hostalloc.allocate(n_local_*max_rows_*sizeof(double)));
     yglob_host_ = static_cast<double*>(hostalloc.allocate(m_local_ * sizeof(double)));
     ya_host_    = static_cast<double*>(hostalloc.allocate(m_local_ * sizeof(double)));
+    buff_mxnlocal_host_ = nullptr;
+    if(dm.buff_mxnlocal_host_ != nullptr)
+    {
+      buff_mxnlocal_host_ = static_cast<double*>(hostalloc.allocate(sizeof(double)*max_rows_*n_local_));
+    }
   }
   else
   {
@@ -199,6 +204,11 @@ hiopMatrixRajaDense::hiopMatrixRajaDense(const hiopMatrixRajaDense& dm)
     // If memory space is not on device, these buffers are allocated in memory space
     yglob_host_ = static_cast<double*>(devalloc.allocate(m_local_ * sizeof(double)));
     ya_host_    = static_cast<double*>(devalloc.allocate(m_local_ * sizeof(double)));
+    buff_mxnlocal_host_ = nullptr;
+    if(dm.buff_mxnlocal_host_ != nullptr)
+    {
+      buff_mxnlocal_host_ = static_cast<double*>(devalloc.allocate(sizeof(double)*max_rows_*n_local_));
+    }
   }
 }
 


### PR DESCRIPTION
A pointer is not initialized in function `hiopMatrixRajaDense::alloc_clone()`. 
As a result, Umpire fails to deconstruct this uninitialized pointer and HiOp terminates with error messages.

It happens only when all the following 3 conditions hold:
1. FR is activated
2. LSQ is used for dual initialization
3. HIOP_DEEPCHECKS = ON 

