### PR TITLE
Compute scaling factor from the user-specified initial point

### DIFF
--- a/src/Optimization/hiopAlgFilterIPM.cpp
+++ b/src/Optimization/hiopAlgFilterIPM.cpp
@@ -358,16 +358,6 @@ startingProcedure(hiopIterate& it_ini,
     warmstart_avail = duals_avail = slacks_avail = false;
   }
 
-  nlp->runStats.tmSolverInternal.start();
-  nlp->runStats.tmStartingPoint.start();
-
-  if(!warmstart_avail) {
-    it_ini.projectPrimalsXIntoBounds(kappa1, kappa2);
-  }
-
-  nlp->runStats.tmStartingPoint.stop();
-  nlp->runStats.tmSolverInternal.stop();
-
   // before evaluating the NLP, make sure that iterate, including dual variables are initialized
   // to zero; many of these will be updated later in this method, but we want to make sure
   // that the user's NLP evaluator functions, in particular the Hessian of the Lagrangian,
@@ -387,7 +377,20 @@ startingProcedure(hiopIterate& it_ini,
     return false;
   }
 
-  if(nlp->apply_scaling(c, d, gradf, Jac_c, Jac_d)){
+  bool do_nlp_scaling = nlp->apply_scaling(c, d, gradf, Jac_c, Jac_d);
+
+  nlp->runStats.tmSolverInternal.start();
+  nlp->runStats.tmStartingPoint.start();
+
+  if(!warmstart_avail) {
+    it_ini.projectPrimalsXIntoBounds(kappa1, kappa2);
+  }
+
+  nlp->runStats.tmStartingPoint.stop();
+  nlp->runStats.tmSolverInternal.stop();
+
+
+  if(do_nlp_scaling){
     // do function evaluation again after add scaling
     if(!this->evalNlp_noHess(it_ini, f, c, d, gradf, Jac_c, Jac_d)) {
       nlp->log->printf(hovError, "Failure in evaluating user provided NLP functions.");

--- a/src/Optimization/hiopNlpFormulation.cpp
+++ b/src/Optimization/hiopNlpFormulation.cpp
@@ -256,25 +256,29 @@ bool hiopNlpFormulation::finalizeInitialization()
 #endif
 
   for(int i=0;i<nlocal; i++) {
-    if(xl_vec[i]>-1e20) { 
-      ixl_vec[i]=1.; 
+    if(xl_vec[i] > -1e20) {
+      ixl_vec[i] = 1.;
       n_bnds_low_local++;
-      if(xu_vec[i]< 1e20) {
+      if(xu_vec[i] < 1e20) {
         n_bnds_lu++;
       }
-    } else ixl_vec[i]=0.;
+    } else {
+      ixl_vec[i]=0.;
+    }
 
-    if(xu_vec[i]< 1e20) { 
-      ixu_vec[i]=1.; 
+    if(xu_vec[i] < 1e20) {
+      ixu_vec[i] = 1.;
       n_bnds_upp_local++;
-    } else ixu_vec[i]=0.;
+    } else {
+      ixu_vec[i]=0.;
+    }
 
 #ifdef HIOP_DEEPCHECKS
     assert(xl_vec[i] <= xu_vec[i] && "please fix the inconsistent bounds, otherwise the problem is infeasible");
 #endif
 
     //if(xl_vec[i]==xu_vec[i]) {
-    if(fabs(xl_vec[i]-xu_vec[i]) <= fixedVarTol*fmax(1.,fabs(xu_vec[i]))) {
+    if( xu_vec[i]<1e20 && fabs(xl_vec[i]-xu_vec[i]) <= fixedVarTol*fmax(1.,fabs(xu_vec[i]))) {
       nfixed_vars_local++;
     } else {
 #ifdef HIOP_DEEPCHECKS


### PR DESCRIPTION
This PR fixes the following issues:
1. compute scaling factor from user-specified initial point, before projecting the initial point to the relaxed boundaries. 
2. fix a bug where free variable can be treated as a fixed variable. This bug only happens when `lb=-inf` and `ub=inf`.

CLOSE #335 
CLOSE #339 