### PR TITLE
update matlab matrix reader for the input files without rhs and sol

### DIFF
--- a/src/LinAlg/load_kkt_mat.m
+++ b/src/LinAlg/load_kkt_mat.m
@@ -13,8 +13,22 @@ nnz=A(5); % number of nnz of matrix (or of the upper triangle for symmetric matr
 rowp = A(6:m+6); % row pointers in colidx and vals (see below)
 colidx=A(m+7:nnz+m+6); % column indexes for each nz
 vals=A(nnz+m+7:nnz+nnz+m+6); % values for each nz
-rhs=A(nnz+nnz+m+7:nnz+nnz+m+m+6); % rhs 
-sol=A(nnz+nnz+m+m+7:nnz+nnz+m+m+m+6); % solution
+has_rhs = true;
+try
+    rhs=A(nnz+nnz+m+7:nnz+nnz+m+m+6); % rhs
+catch
+    warning('Cannot find rhs from the file. Set rhs as a vector of ones.');
+    rhs = ones(m,1);
+    has_rhs = false;
+end
+has_sol = true;
+try
+    sol=A(nnz+nnz+m+m+7:nnz+nnz+m+m+m+6); % solution
+catch
+    warning('Cannot find sol from the file.');
+    has_sol = false;
+end
+
 fprintf('Loaded a matrix of size %d with %d nonzeros from "%s"\n', ...
     m, nnz, filename);
 
@@ -45,6 +59,8 @@ end
     
 %% solve using Matlab and check the residuals of the Matlab solution 
 %% and of the solution from .iajaaa file
-sol2 = M\rhs;
-fprintf('residuals norm: Matlab sol %.5e   sol from file: %.5e\n', ...
-    norm(M* sol2 - rhs), norm(M* sol - rhs));
+if has_sol == true
+    sol2 = M\rhs;
+    fprintf('residuals norm: Matlab sol %.5e   sol from file: %.5e\n', ...
+        norm(M* sol2 - rhs), norm(M* sol - rhs));
+end


### PR DESCRIPTION
The current matlab reader returns error when the vectors `rhs` and `sol` are not exported from hiop.
This may occur when hiop needs to add regularization to correct inertia, e.g., `kkt_linsys_0.iajaaa` prints the 1st matrix used in the factorization routine. If its inertia is not correct, HiOp won't go to the back-solve routine, where the right-hand-side(rhs) and solution(sol) are printed. 
Instead,  `rhs` and `sol` will be printed in the file `kkt_linsys_<xx>.iajaaa` when the matrix has correct inertia.

This PR fixes the matlab code, to read the matrix without regularization.