### PR TITLE
replaced int* with hiopVectorInt in PriDec solver

### DIFF
--- a/src/Drivers/nlpPriDec_ex8.cpp
+++ b/src/Drivers/nlpPriDec_ex8.cpp
@@ -61,7 +61,6 @@ Ex8::Ex8(int ns_, int S_, bool include, hiopInterfacePriDecProblem::RecourseAppr
 
 Ex8::~Ex8()
 {
-  //delete evaluator_;
 }
  
 bool Ex8::get_prob_sizes(size_type& n, size_type& m)
@@ -247,11 +246,11 @@ solve_master(hiopVector& x,
     printf("solver returned negative solve status: %d (with objective is %18.12e)\n", status, obj_);
     return status;
   }
-  if(sol_==NULL) {
+  if(sol_ == nullptr) {
     sol_ = new double[n_];
   }
 
-  memcpy(sol_,x_vec, n_*sizeof(double));
+  memcpy(sol_, x_vec, n_*sizeof(double));
   //assert("for debugging" && false); //for debugging purpose
   return Solve_Success;
 

--- a/src/Drivers/nlpPriDec_ex8.cpp
+++ b/src/Drivers/nlpPriDec_ex8.cpp
@@ -61,7 +61,7 @@ Ex8::Ex8(int ns_, int S_, bool include, hiopInterfacePriDecProblem::RecourseAppr
 
 Ex8::~Ex8()
 {
-  delete evaluator_;
+  //delete evaluator_;
 }
  
 bool Ex8::get_prob_sizes(size_type& n, size_type& m)

--- a/src/Drivers/nlpPriDec_ex8.hpp
+++ b/src/Drivers/nlpPriDec_ex8.hpp
@@ -121,6 +121,7 @@ public:
   }
   virtual ~PriDecMasterProblemEx8()
   {
+    delete[] sol_;
     delete my_nlp;
   }
   

--- a/src/Drivers/nlpPriDec_ex8_driver.cpp
+++ b/src/Drivers/nlpPriDec_ex8_driver.cpp
@@ -142,6 +142,9 @@ int main(int argc, char **argv)
       printf("Solve was successfull. Optimal value: %12.5e\n",
              pridec_solver.getObjective());
   }
+
+  delete[] list;
+  
   if(selfCheck) {
     if(rank==0) {
       if(!self_check(nx,S, pridec_solver.getObjective()))

--- a/src/Drivers/nlpPriDec_ex9.cpp
+++ b/src/Drivers/nlpPriDec_ex9.cpp
@@ -169,6 +169,7 @@ bool PriDecMasterProblemEx9::eval_f_rterm(size_t idx, const int& n, const double
   #endif
 
   delete[] xi;
+  delete ex9_recourse;
   return true;
 };
 

--- a/src/Drivers/nlpPriDec_ex9_user_basecase.hpp
+++ b/src/Drivers/nlpPriDec_ex9_user_basecase.hpp
@@ -12,7 +12,6 @@ public:
 
   virtual ~PriDecBasecaseProblemEx9()
   {
-    delete rec_evaluator_;
   }
 
   bool eval_f(const size_type& n, const double* x, bool new_x, double& obj_value)

--- a/src/Interface/hiopInterfacePrimalDecomp.hpp
+++ b/src/Interface/hiopInterfacePrimalDecomp.hpp
@@ -167,14 +167,19 @@ public:
     hiopVector* get_rhess() const;
     hiopVector* get_x0() const;
   protected:
-    int nc_,S_;
-    //TODO: this may need to by a hiopVectorInt since seems to get on the device eventually.
+    int nc_, S_;
     hiopVectorInt* xc_idx_;
     double rval_;
     hiopVector* rgrad_;
     hiopVector* rhess_; //diagonal Hessian vector
     hiopVector* x0_; //current solution
 
+    /// working buffer in the size of coupling variables (same size as x0_, rgrad_, and rhess_)
+    hiopVector* vec_work_coupling_;
+
+    /// working buffer in the size of the basecase (primal variables)
+    hiopVector* vec_work_basecase_;
+    
     /// memory space of the PriDec solver (must match the memory space of the NLP solver)
     std::string mem_space_;
   };

--- a/src/Interface/hiopInterfacePrimalDecomp.hpp
+++ b/src/Interface/hiopInterfacePrimalDecomp.hpp
@@ -159,18 +159,17 @@ public:
     void set_rgrad(const int n, const hiopVector& rgrad);
     void set_rhess(const int n, const hiopVector& rhess);
     void set_x0(const int n, const hiopVector& x0);
-    void set_xc_idx(const int* idx);
+    //void set_xc_idx(const int* idx);
 
     int get_S() const; 
     double get_rval() const;
     hiopVector* get_rgrad() const;
     hiopVector* get_rhess() const;
     hiopVector* get_x0() const;
-    int* get_xc_idx() const; 
   protected:
     int nc_,S_;
     //TODO: this may need to by a hiopVectorInt since seems to get on the device eventually.
-    int* xc_idx_;
+    hiopVectorInt* xc_idx_;
     double rval_;
     hiopVector* rgrad_;
     hiopVector* rhess_; //diagonal Hessian vector

--- a/src/LinAlg/hiopVector.hpp
+++ b/src/LinAlg/hiopVector.hpp
@@ -60,8 +60,7 @@ class hiopVector
 {
 public:
   hiopVector()
-    : n_(0),
-      is_attached_(false)
+    : n_(0)
   {
   }
   virtual ~hiopVector() {};
@@ -72,16 +71,6 @@ public:
   /// @brief Set all elements that are not zero in ix to  c, and the rest to 0
   virtual void setToConstant_w_patternSelect( double c, const hiopVector& ix)=0;
 
-  /**
-   * Attaches this to the double array pdata in the sense that pdata will be used as the internal 
-   * container array (of size n). The pointer pdata will not be deleted when the class' destructor is called.
-   * 
-   * Note that this method only supports local/non-distributed vectors.
-   *
-   * @pre The input double pointer pdata must be allocated to hold at least n doubles.
-   */
-  virtual void attach_to(double* pdata, int n) = 0;
-  
   // TODO: names of copyTo/FromStarting methods are quite confusing 
   //maybe startingAtCopyFromStartingAt startingAtCopyToStartingAt ?
   /// @brief Copy the elements of v
@@ -333,9 +322,12 @@ public:
                                  const hiopInterfaceBase::NonlinearityType arr_src) const = 0;
 protected:
   size_type n_; //we assume sequential data
-  bool is_attached_;
 protected:
-  hiopVector(const hiopVector& v) : n_(v.n_) {};
+  /// for internal use only; derived classes may use copy constructor and always allocate data_
+  hiopVector(const hiopVector& v)
+    : n_(v.n_)
+  {
+  };
 };
 
 }

--- a/src/LinAlg/hiopVectorInt.hpp
+++ b/src/LinAlg/hiopVectorInt.hpp
@@ -88,6 +88,18 @@ public:
 
   /// @brief Set all elements  to  c
   virtual void set_to_constant( const index_type c ) = 0;
+
+  /**
+   * @brief Set the vector entries to be a linear space of starting at i0 containing evenly 
+   * incremented integers up to i0+(n-1)di, when n is the length of this vector
+   *
+   * @pre The elements of the linear space should not overflow the index_type type
+   *  
+   * @param i0 the starting element in the linear space (entry 0 in vector)
+   * @param di the increment for subsequent entries in the vector
+   *
+   */ 
+  virtual void linspace(const index_type& i0, const index_type& di) = 0;
 };
 
 } // namespace hiop

--- a/src/LinAlg/hiopVectorIntRaja.cpp
+++ b/src/LinAlg/hiopVectorIntRaja.cpp
@@ -137,4 +137,24 @@ void hiopVectorIntRaja::set_to_constant(const index_type c)
     });
 }
 
+/**
+ * @brief Set the vector entries to be a linear space of starting at i0 containing evenly 
+ * incremented integers up to i0+(n-1)di, when n is the length of this vector
+ *
+ * @pre The elements of the linear space should not overflow the index_type type
+ *  
+ * @param i0 the starting element in the linear space (entry 0 in vector)
+ * @param di the increment for subsequent entries in the vector
+ *
+ */ 
+void hiopVectorIntRaja::linspace(const index_type& i0, const index_type& di)
+{
+  index_type* data = buf_;
+  RAJA::forall<hiop_raja_exec>(RAJA::RangeSegment(0, sz_),
+    RAJA_LAMBDA(RAJA::Index_type i)
+    {
+      data[i] = i0+i*di;
+    });
+}
+  
 } // namespace hiop

--- a/src/LinAlg/hiopVectorIntRaja.hpp
+++ b/src/LinAlg/hiopVectorIntRaja.hpp
@@ -102,6 +102,18 @@ public:
 
   /// @brief Set all elements  to  c
   virtual void set_to_constant(const index_type c);
+
+  /**
+   * @brief Set the vector entries to be a linear space of starting at i0 containing evenly 
+   * incremented integers up to i0+(n-1)di, when n is the length of this vector
+   *
+   * @pre The elements of the linear space should not overflow the index_type type
+   *  
+   * @param i0 the starting element in the linear space (entry 0 in vector)
+   * @param di the increment for subsequent entries in the vector
+   *
+   */ 
+  virtual void linspace(const index_type& i0, const index_type& di);
 };
 
 } // namespace hiop

--- a/src/LinAlg/hiopVectorIntSeq.cpp
+++ b/src/LinAlg/hiopVectorIntSeq.cpp
@@ -89,4 +89,23 @@ void hiopVectorIntSeq::set_to_constant(const index_type c)
   }
 }
 
+/**
+ * @brief Set the vector entries to be a linear space of starting at i0 containing evenly 
+ * incremented integers up to i0+(n-1)di, when n is the length of this vector
+ *
+ * @pre The elements of the linear space should not overflow the index_type type
+ *  
+ * @param i0 the starting element in the linear space (entry 0 in vector)
+ * @param di the increment for subsequent entries in the vector
+ *
+ */ 
+void hiopVectorIntSeq::linspace(const index_type& i0, const index_type& di)
+{
+  index_type last = i0;
+  for(int i=0; i<sz_; ++i) {
+    buf_[i] = last;
+    last += di;
+  }
+}
+  
 } // namespace hiop

--- a/src/LinAlg/hiopVectorIntSeq.hpp
+++ b/src/LinAlg/hiopVectorIntSeq.hpp
@@ -88,6 +88,18 @@ public:
 
   /// @brief Set all elements  to  c
   virtual void set_to_constant(const index_type c);
+
+  /**
+   * @brief Set the vector entries to be a linear space of starting at i0 containing evenly 
+   * incremented integers up to i0+(n-1)di, when n is the length of this vector
+   *
+   * @pre The elements of the linear space should not overflow the index_type type
+   *  
+   * @param i0 the starting element in the linear space (entry 0 in vector)
+   * @param di the increment for subsequent entries in the vector
+   *
+   */ 
+  virtual void linspace(const index_type& i0, const index_type& di);
 };
 
 } // namespace hiop

--- a/src/LinAlg/hiopVectorPar.cpp
+++ b/src/LinAlg/hiopVectorPar.cpp
@@ -153,8 +153,8 @@ void hiopVectorPar::copy_from_indexes(const hiopVector& vv, const hiopVectorInt&
   assert(indexes.size() == n_local_);
   
   const index_type* index_arr = indexes.local_data_const();
-  int nv = v.get_local_size();
-  for(int i=0; i<n_local_; i++) {
+  size_type nv = v.get_local_size();
+  for(index_type i=0; i<n_local_; i++) {
     assert(index_arr[i]<nv);
     this->data_[i] = v.data_[index_arr[i]];
   }
@@ -236,7 +236,9 @@ void hiopVectorPar::copyToStarting(hiopVector& v_, int start_index/*_in_dest*/) 
   memcpy(v.data_+start_index, data_, n_local_*sizeof(double)); 
 }
 
-void hiopVectorPar::copyToStartingAt_w_pattern(hiopVector& v_, int start_index/*_in_dest*/, const hiopVector& select) const
+void hiopVectorPar::copyToStartingAt_w_pattern(hiopVector& v_,
+                                               index_type start_index/*_in_dest*/,
+                                               const hiopVector& select) const
 {
   const hiopVectorPar& v = dynamic_cast<const hiopVectorPar&>(v_);
   const hiopVectorPar& ix = dynamic_cast<const hiopVectorPar&>(select);
@@ -244,8 +246,10 @@ void hiopVectorPar::copyToStartingAt_w_pattern(hiopVector& v_, int start_index/*
   const double* ix_vec = ix.data_;
   int find_nnz = 0;
   
-  for(int i=0; i<n_local_; i++)
-    if(ix_vec[i]==1.) v.data_[start_index+(find_nnz++)] = data_[i];
+  for(index_type i=0; i<n_local_; i++)
+    if(ix_vec[i]==1.) {
+      v.data_[start_index+(find_nnz++)] = data_[i];
+    }
   assert(find_nnz + start_index <= v.n_local_);
 }
 
@@ -339,8 +343,11 @@ startingAtCopyToStartingAt(int start_idx_in_src, hiopVector& dest_, int start_id
   memcpy(dest.data_+start_idx_dest, this->data_+start_idx_in_src, num_elems*sizeof(double));
 }
 
-void hiopVectorPar::
-startingAtCopyToStartingAt_w_pattern(int start_idx_in_src, hiopVector& dest_, int start_idx_dest, const hiopVector& selec_dest, int num_elems/*=-1*/) const
+void hiopVectorPar::startingAtCopyToStartingAt_w_pattern(index_type start_idx_in_src,
+                                                         hiopVector& dest_,
+                                                         index_type start_idx_dest,
+                                                         const hiopVector& selec_dest,
+                                                         size_type num_elems/*=-1*/) const
 {
   assert(start_idx_in_src>=0 && start_idx_in_src<=n_local_);
   const hiopVectorPar& dest = dynamic_cast<hiopVectorPar&>(dest_);
@@ -575,7 +582,7 @@ void hiopVectorPar::axpy(double alpha, const hiopVector& x_in)
 {
   const hiopVectorPar& x = dynamic_cast<const hiopVectorPar&>(x_in);
   int one = 1;
-  int n=n_local_;
+  int n = n_local_;
   DAXPY( &n, &alpha, x.data_, &one, data_, &one );
 }
 
@@ -591,7 +598,7 @@ void hiopVectorPar::axpy(double alpha, const hiopVector& x, const hiopVectorInt&
   const double* xd = xx.local_data_const();
   const index_type* id = idxs.local_data_const();
   
-  for(int j=0; j<idxs.size(); ++j) {
+  for(index_type j=0; j<idxs.size(); ++j) {
     assert(id[j]<n_local_);
     data_[id[j]] += alpha*xd[j];
   }

--- a/src/LinAlg/hiopVectorPar.cpp
+++ b/src/LinAlg/hiopVectorPar.cpp
@@ -87,30 +87,21 @@ hiopVectorPar::hiopVectorPar(const size_type& glob_n, index_type* col_part/*=NUL
   data_ = new double[n_local_];
 }
 
+/// internal use only: allocates data_
 hiopVectorPar::hiopVectorPar(const hiopVectorPar& v)
 {
-  n_local_=v.n_local_; n_ = v.n_;
-  glob_il_=v.glob_il_; glob_iu_=v.glob_iu_;
-  comm_=v.comm_;
-  data_=new double[n_local_];  
-}
-
-void hiopVectorPar::attach_to(double* pdata, int n)
-{
-  n_ = n;
-  n_local_ = n_;
-  glob_il_ = 0;
-  glob_iu_ = n_;
-  data_ = pdata;
-  is_attached_ = true;
+  n_local_ = v.n_local_;
+  n_ = v.n_;
+  glob_il_ = v.glob_il_;
+  glob_iu_ = v.glob_iu_;
+  comm_ = v.comm_;
+  data_ = new double[n_local_];  
 }
   
 hiopVectorPar::~hiopVectorPar()
 {
-  if(~is_attached_) {
-    delete[] data_;
-    data_=NULL;
-  }
+  delete[] data_;
+  data_ = nullptr;
 }
 
 hiopVector* hiopVectorPar::alloc_clone() const
@@ -602,7 +593,7 @@ void hiopVectorPar::axpy(double alpha, const hiopVector& x, const hiopVectorInt&
   
   for(int j=0; j<idxs.size(); ++j) {
     assert(id[j]<n_local_);
-    data_[id[j]] = xd[j];
+    data_[id[j]] += alpha*xd[j];
   }
 
 }

--- a/src/LinAlg/hiopVectorPar.hpp
+++ b/src/LinAlg/hiopVectorPar.hpp
@@ -72,14 +72,6 @@ public:
   virtual void setToConstant( double c );
   virtual void setToConstant_w_patternSelect(double c, const hiopVector& select);
 
-  /**
-   * Attaches this to the double array pdata in the sense that pdata will be used as the internal 
-   * container array (of size n). The pointer pdata will not be deleted when the class' destructor is called.
-   * 
-   * @pre The input double pointer pdata must be allocated to hold at least n doubles.
-   */
-  virtual void attach_to(double* pdata, int n);
-
   virtual void copyFrom(const hiopVector& v );
   virtual void copyFrom(const double* v_local_data); //v should be of length at least n_local_
   

--- a/src/LinAlg/hiopVectorPar.hpp
+++ b/src/LinAlg/hiopVectorPar.hpp
@@ -71,12 +71,39 @@ public:
   virtual void setToZero();
   virtual void setToConstant( double c );
   virtual void setToConstant_w_patternSelect(double c, const hiopVector& select);
+
+  /**
+   * Attaches this to the double array pdata in the sense that pdata will be used as the internal 
+   * container array (of size n). The pointer pdata will not be deleted when the class' destructor is called.
+   * 
+   * @pre The input double pointer pdata must be allocated to hold at least n doubles.
+   */
+  virtual void attach_to(double* pdata, int n);
+
   virtual void copyFrom(const hiopVector& v );
   virtual void copyFrom(const double* v_local_data); //v should be of length at least n_local_
   
-  /// @brief Copy from the indices in index_in_src in v
-  virtual void copyFrom(const int* index_in_src, const hiopVector& v);
-  virtual void copyFrom(const int* index_in_src, const double* v);
+  /**
+   * @brief Copy from src the elements specified by the indices in index_in_src. 
+   *
+   * @pre All vectors must reside in the same memory space. 
+   * @pre Size of src must be greater or equal than size of this
+   * @pre Size of index_in_src must be equal to size of this
+   * @pre Elements of index_in_src must be valid (zero-based) indexes in src
+   *
+   */
+  virtual void copy_from_indexes(const hiopVector& src, const hiopVectorInt& index_in_src);
+
+  /**
+   * @brief Copy from src the elements specified by the indices in index_in_src. 
+   *
+   * @pre All vectors and arrays must reside in the same memory space. 
+   * @pre Size of src must be greater or equal than size of this
+   * @pre Size of index_in_src must be equal to size of this
+   * @pre Elements of index_in_src must be valid (zero-based) indexes in src
+   *
+   */
+  virtual void copy_from_indexes(const double* src, const hiopVectorInt& index_in_src);
   
   /// @brief Copy the 'n' elements of v starting at 'start_index_in_this' in 'this'
   virtual void copyFromStarting(int start_index_in_this, const double* v, int n);
@@ -127,7 +154,11 @@ public:
 					  hiopVector& dest,
 					  int start_idx_dest,
 					  int num_elems=-1) const;
-  virtual void startingAtCopyToStartingAt_w_pattern(int start_idx_in_src, hiopVector& dest, int start_idx_dest, const hiopVector& selec_dest, int num_elems=-1) const;
+  
+  virtual void startingAtCopyToStartingAt_w_pattern(int start_idx_in_src,
+                                                    hiopVector& dest, int start_idx_dest,
+                                                    const hiopVector& selec_dest,
+                                                    int num_elems=-1) const;
 
   virtual double twonorm() const;
   virtual double dotProductWith( const hiopVector& v ) const;
@@ -149,6 +180,20 @@ public:
   virtual void scale( double alpha );
   /// @brief this += alpha * x
   virtual void axpy  ( double alpha, const hiopVector& x );
+
+  /**
+   * @brief Performs axpy, this += alpha*x, on the indexes in this specified by i.
+   * 
+   * @param alpha scaling factor 
+   * @param x vector of doubles to be axpy-ed to this (size equal to size of i and less than or equal to size of this)
+   * @param i vector of indexes in this to which the axpy operation is performed (size equal to size of x and less than 
+   * or equal to size of this)
+   *
+   * @pre The entries of i must be valid (zero-based) indexes in this
+   *
+   */
+  virtual void axpy(double alpha, const hiopVector& x, const hiopVectorInt& i);
+  
   /// @brief this += alpha * x * z
   virtual void axzpy ( double alpha, const hiopVector& x, const hiopVector& z );
   /// @brief this += alpha * x / z

--- a/src/LinAlg/hiopVectorRajaPar.cpp
+++ b/src/LinAlg/hiopVectorRajaPar.cpp
@@ -278,7 +278,7 @@ void hiopVectorRajaPar::copy_from(const hiopVector& vec, const hiopVectorInt& in
 {
   const hiopVectorRajaPar& v = dynamic_cast<const hiopVectorRajaPar&>(vec);
   const hiopVectorIntRaja& indexes = dynamic_cast<const hiopVectorIntRaja&>(index_in_src);
-  int nv = v.get_local_size();
+  size_type nv = v.get_local_size();
 
   assert(indexes.size() == n_local_);
   
@@ -324,7 +324,7 @@ void hiopVectorRajaPar::copy_from_indexes(const hiopVector& vv, const hiopVector
   double* dd = data_dev_;
   double* vd = v.data_dev_;
 
-  int nv = v.get_local_size();
+  size_type nv = v.get_local_size();
   
   RAJA::forall< hiop_raja_exec >(RAJA::RangeSegment(0, n_local_),
     RAJA_LAMBDA(RAJA::Index_type i)
@@ -700,8 +700,11 @@ void hiopVectorRajaPar::startingAtCopyToStartingAt(
   rm.copy(dest.data_dev_ + start_idx_dest, this->data_dev_ + start_idx_in_src, num_elems*sizeof(double));
 }
 
-void hiopVectorRajaPar::
-startingAtCopyToStartingAt_w_pattern(int start_idx_in_src, hiopVector& destination, int start_idx_dest, const hiopVector& selec_dest, int num_elems/*=-1*/) const
+void hiopVectorRajaPar::startingAtCopyToStartingAt_w_pattern(index_type start_idx_in_src,
+                                                             hiopVector& destination,
+                                                             index_type start_idx_dest,
+                                                             const hiopVector& selec_dest,
+                                                             size_type num_elems/*=-1*/) const
 {
 #if 0  
   hiopVectorRajaPar& dest = dynamic_cast<hiopVectorRajaPar&>(destination);

--- a/src/LinAlg/hiopVectorRajaPar.cpp
+++ b/src/LinAlg/hiopVectorRajaPar.cpp
@@ -284,7 +284,7 @@ void hiopVectorRajaPar::copy_from(const hiopVector& vec, const hiopVectorInt& in
   
   double* dd = data_dev_;
   double* vd = v.data_dev_;
-  index_type* id = const_cast<index_type*>(indexes.local_data());
+  index_type* id = const_cast<index_type*>(indexes.local_data_const());
 
   RAJA::forall< hiop_raja_exec >(RAJA::RangeSegment(0, n_local_),
     RAJA_LAMBDA(RAJA::Index_type i)
@@ -303,7 +303,7 @@ void hiopVectorRajaPar::copy_from(const double* vec, const hiopVectorInt& index_
   assert(vec);
   double* dd = data_dev_;
   double* vd = const_cast<double*>(vec);
-  index_type* id = const_cast<index_type*>(indexes.local_data());
+  index_type* id = const_cast<index_type*>(indexes.local_data_const());
 
   RAJA::forall< hiop_raja_exec >(RAJA::RangeSegment(0, n_local_),
     RAJA_LAMBDA(RAJA::Index_type i)
@@ -320,7 +320,7 @@ void hiopVectorRajaPar::copy_from_indexes(const hiopVector& vv, const hiopVector
 
   assert(indexes.size() == n_local_);
   
-  index_type* id = const_cast<index_type*>(indexes.local_data());
+  index_type* id = const_cast<index_type*>(indexes.local_data_const());
   double* dd = data_dev_;
   double* vd = v.data_dev_;
 
@@ -343,13 +343,13 @@ void hiopVectorRajaPar::copy_from_indexes(const double* vv, const hiopVectorInt&
 
   const hiopVectorIntRaja& indexes = dynamic_cast<const hiopVectorIntRaja&>(index_in_src);
   assert(indexes.size() == n_local_);
-  index_type* id = const_cast<index_type*>(indexes.local_data());
+  index_type* id = const_cast<index_type*>(indexes.local_data_const());
   double* dd = data_dev_;
   
   RAJA::forall< hiop_raja_exec >(RAJA::RangeSegment(0, n_local_),
     RAJA_LAMBDA(RAJA::Index_type i)
     {
-      dd[i] = vd[id[i]];
+      dd[i] = vv[id[i]];
     }); 
 }
 
@@ -1143,7 +1143,7 @@ void hiopVectorRajaPar::axpy(double alpha, const hiopVector& xvec, const hiopVec
   
   double* dd = data_dev_;
   double* xd = const_cast<double*>(x.data_dev_);
-  index_type* id = const_cast<index_type*>(idxs.local_data());
+  index_type* id = const_cast<index_type*>(idxs.local_data_const());
 
   RAJA::forall< hiop_raja_exec >( RAJA::RangeSegment(0, n_local_),
     RAJA_LAMBDA(RAJA::Index_type i)

--- a/src/LinAlg/hiopVectorRajaPar.hpp
+++ b/src/LinAlg/hiopVectorRajaPar.hpp
@@ -81,10 +81,28 @@ public:
   virtual void copyFrom(const hiopVector& v );
   virtual void copyFrom(const double* v_local_data); //v should be of length at least n_local
 
-  /// @brief Copy from the indices in index_in_src in v
-  virtual void copyFrom(const int* index_in_src, const hiopVector& v);
-  virtual void copyFrom(const int* index_in_src, const double* v);
+  /**
+   * @brief Copy from src the elements specified by the indices in index_in_src. 
+   *
+   * @pre All vectors must reside in the same memory space. 
+   * @pre Size of src must be greater or equal than size of this
+   * @pre Size of index_in_src must be equal to size of this
+   * @pre Elements of index_in_src must be valid (zero-based) indexes in src
+   *
+   */
+  virtual void copy_from(const hiopVector& src, const hiopVectorInt& index_in_src);
 
+  /**
+   * @brief Copy from src the elements specified by the indices in index_in_src. 
+   *
+   * @pre All vectors and arrays must reside in the same memory space. 
+   * @pre Size of src must be greater or equal than size of this
+   * @pre Size of index_in_src must be equal to size of this
+   * @pre Elements of index_in_src must be valid (zero-based) indexes in src
+   *
+   */
+  virtual void copy_from(const double* src, const hiopVectorInt& index_in_src);
+  
   /** Copy the 'n' elements of v starting at 'start_index_in_this' in 'this' */
   virtual void copyFromStarting(int start_index_in_this, const double* v, int n);
   virtual void copyFromStarting(int start_index_in_src, const hiopVector& v);

--- a/src/LinAlg/hiopVectorRajaPar.hpp
+++ b/src/LinAlg/hiopVectorRajaPar.hpp
@@ -80,6 +80,18 @@ public:
   virtual void setToConstant_w_patternSelect(double c, const hiopVector& select);
   virtual void copyFrom(const hiopVector& v );
   virtual void copyFrom(const double* v_local_data); //v should be of length at least n_local
+  virtual void copy_from(const hiopVector& src, const hiopVectorInt& index_in_src);
+  
+  /**
+   * @brief Copy from src the elements specified by the indices in index_in_src. 
+   *
+   * @pre All vectors must reside in the same memory space. 
+   * @pre Size of src must be greater or equal than size of this
+   * @pre Size of index_in_src must be equal to size of this
+   * @pre Elements of index_in_src must be valid (zero-based) indexes in src
+   *
+   */
+  virtual void copy_from_indexes(const hiopVector& src, const hiopVectorInt& index_in_src);
 
   /**
    * @brief Copy from src the elements specified by the indices in index_in_src. 
@@ -90,7 +102,17 @@ public:
    * @pre Elements of index_in_src must be valid (zero-based) indexes in src
    *
    */
-  virtual void copy_from(const hiopVector& src, const hiopVectorInt& index_in_src);
+
+  /**
+   * @brief Copy from src the elements specified by the indices in index_in_src. 
+   *
+   * @pre All vectors and arrays must reside in the same memory space. 
+   * @pre Size of src must be greater or equal than size of this
+   * @pre Size of index_in_src must be equal to size of this
+   * @pre Elements of index_in_src must be valid (zero-based) indexes in src
+   *
+   */
+  virtual void copy_from_indexes(const double* src, const hiopVectorInt& index_in_src);
 
   /**
    * @brief Copy from src the elements specified by the indices in index_in_src. 
@@ -134,7 +156,11 @@ public:
    * either source ('this') or destination ('dest') is reached
    * if 'selec_dest' is given, the values are copy to 'dest' where the corresponding entry in 'selec_dest' is nonzero */
   virtual void startingAtCopyToStartingAt(int start_idx_in_src, hiopVector& dest, int start_idx_dest, int num_elems=-1) const;
-  virtual void startingAtCopyToStartingAt_w_pattern(int start_idx_in_src, hiopVector& dest, int start_idx_dest, const hiopVector& selec_dest, int num_elems=-1) const;
+  virtual void startingAtCopyToStartingAt_w_pattern(int start_idx_in_src,
+                                                    hiopVector& dest,
+                                                    int start_idx_dest,
+                                                    const hiopVector& selec_dest,
+                                                    int num_elems=-1) const;
 
   virtual double twonorm() const;
   virtual double dotProductWith( const hiopVector& v ) const;
@@ -155,6 +181,21 @@ public:
   virtual void scale( double alpha );
   /** this += alpha * x */
   virtual void axpy  ( double alpha, const hiopVector& x );
+
+  /**
+   * @brief Performs axpy, this += alpha*x, on the indexes in this specified by i.
+   * 
+   * @param alpha scaling factor 
+   * @param x vector of doubles to be axpy-ed to this (size equal to size of i and less than or equal to size of this)
+   * @param i vector of indexes in this to which the axpy operation is performed (size equal to size of x and less than 
+   * or equal to size of this)
+   *
+   * @pre The entries of i must be valid (zero-based) indexes in this
+   *
+   */
+  virtual void axpy(double alpha, const hiopVector& x, const hiopVectorInt& i);
+  
+  
   /** this += alpha * x * z */
   virtual void axzpy ( double alpha, const hiopVector& x, const hiopVector& z );
   /** this += alpha * x / z */

--- a/src/LinAlg/hiopVectorRajaPar.hpp
+++ b/src/LinAlg/hiopVectorRajaPar.hpp
@@ -155,12 +155,14 @@ public:
    * If num_elems>=0, 'num_elems' will be copied; if num_elems<0, elements will be copied till the end of
    * either source ('this') or destination ('dest') is reached
    * if 'selec_dest' is given, the values are copy to 'dest' where the corresponding entry in 'selec_dest' is nonzero */
-  virtual void startingAtCopyToStartingAt(int start_idx_in_src, hiopVector& dest, int start_idx_dest, int num_elems=-1) const;
-  virtual void startingAtCopyToStartingAt_w_pattern(int start_idx_in_src,
+  virtual void startingAtCopyToStartingAt(index_type start_idx_in_src,
+                                          hiopVector& dest, index_type start_idx_dest,
+                                          size_type num_elems=-1) const;
+  virtual void startingAtCopyToStartingAt_w_pattern(index_type start_idx_in_src,
                                                     hiopVector& dest,
-                                                    int start_idx_dest,
+                                                    index_type start_idx_dest,
                                                     const hiopVector& selec_dest,
-                                                    int num_elems=-1) const;
+                                                    size_type num_elems=-1) const;
 
   virtual double twonorm() const;
   virtual double dotProductWith( const hiopVector& v ) const;

--- a/src/Optimization/hiopAlgPrimalDecomp.cpp
+++ b/src/Optimization/hiopAlgPrimalDecomp.cpp
@@ -850,8 +850,8 @@ void hiopAlgPrimalDecomposition::set_alpha_max(const double alp_max)
           //for(int i=0;i<n_;i++) printf("x %d %18.12e ",i,x_[i]);
           //printf("\n ");
         }
-	base_val = master_prob_->get_objective();
-	base_valm1 = master_prob_->get_objective();
+        base_val = master_prob_->get_objective();
+        base_valm1 = master_prob_->get_objective();
       }
 
       // send base case solutions to all ranks
@@ -873,11 +873,11 @@ void hiopAlgPrimalDecomposition::set_alpha_max(const double alp_max)
       // master rank communication
       if(my_rank_ == 0) {
         // array for number of indices, currently the indices are in [0,S_] 
-        // this is subjected to change	
+        // this is subjected to change
         rval = 0.;
-	grad_r->setToZero();
+        grad_r->setToZero();
         
-	std::vector<int> cont_idx(S_);
+        std::vector<int> cont_idx(S_);
         for(int i=0; i<S_; i++) {
           cont_idx[i] = i;
         }
@@ -908,8 +908,8 @@ void hiopAlgPrimalDecomposition::set_alpha_max(const double alp_max)
         // Both finish_flag and last_loop are used to deal with the final round remaining contingencies.
         // Some ranks are finished while others are not. The loop needs to continue to fetch the results. 
         //hiopVectorInt* finish_flag = LinearAlgebraFactory::createVectorInt(comm_size_);
-	//finish_flag->setToZero();
-	std::vector<int> finish_flag(comm_size_);
+        //finish_flag->setToZero();
+        std::vector<int> finish_flag(comm_size_);
         for(int i=0;i<comm_size_;i++) {
           finish_flag[i]=0;
         }
@@ -997,11 +997,11 @@ void hiopAlgPrimalDecomposition::set_alpha_max(const double alp_max)
         // compute the recourse function values and gradients
         rec_val = 0.;
 
-	grad_acc->setToZero();
+        grad_acc->setToZero();
         double aux=0.;
 
         if(nc_<n_) {
-	  x0->copy_from_indexes(*x_, *xc_idx_);
+          x0->copy_from_indexes(*x_, *xc_idx_);
         } else {
           assert(nc_==n_);
           x0->copyFromStarting(0, *x_);
@@ -1017,7 +1017,7 @@ void hiopAlgPrimalDecomposition::set_alpha_max(const double alp_max)
           rec_val += aux;
         }
         //printf("recourse value: is %18.12e)\n", rec_val);
-	hiopVector* grad_aux = x0->alloc_clone();
+        hiopVector* grad_aux = x0->alloc_clone();
         grad_aux->setToZero(); 
 
         for(int ri=0; ri<cont_idx.size(); ri++) {
@@ -1030,8 +1030,8 @@ void hiopAlgPrimalDecomposition::set_alpha_max(const double alp_max)
         }
         rec_prob[my_rank_]->set_value(rec_val);
 
-	delete grad_aux;
-	
+        delete grad_aux;
+
         rec_prob[my_rank_]->set_grad(grad_acc_vec);
         rec_prob[my_rank_]->post_send(2, rank_master, comm_world_);
 
@@ -1050,11 +1050,11 @@ void hiopAlgPrimalDecomposition::set_alpha_max(const double alp_max)
               break;
             }
             rec_val = 0.;
-	    grad_acc->setToZero();
+            grad_acc->setToZero();
 
             double aux=0.;
             if(nc_<n_) {
-	      x0->copy_from_indexes(*x_, *xc_idx_);
+              x0->copy_from_indexes(*x_, *xc_idx_);
             } else {
               assert(nc_==n_);
               x0->copyFromStarting(0, *x_);
@@ -1070,7 +1070,7 @@ void hiopAlgPrimalDecomposition::set_alpha_max(const double alp_max)
               rec_val += aux;
             }
             //printf("recourse value: is %18.12e)\n", rec_val);
-	    hiopVector* grad_aux = x0->alloc_clone();
+            hiopVector* grad_aux = x0->alloc_clone();
             grad_aux->setToZero(); 
 
             for(int ri=0; ri<cont_idx.size(); ri++) {
@@ -1096,7 +1096,7 @@ void hiopAlgPrimalDecomposition::set_alpha_max(const double alp_max)
             req_cont_idx->post_recv(1, rank_master, comm_world_);
             //ierr = MPI_Irecv(&cont_idx[0], 1, MPI_INT, rank_master, 1, comm_world_, &request_[0]);
 
-	    delete grad_aux;
+            delete grad_aux;
           }
         }
       }
@@ -1108,19 +1108,19 @@ void hiopAlgPrimalDecomposition::set_alpha_max(const double alp_max)
           MPI_Wait(&req_cont_idx->request_, &status_);
         }
         
-	recourse_val = rval;
+        recourse_val = rval;
 
         if(ver_ >=outlevel2) {
           printf("real rval %18.12e\n",rval);
-	}
+        }
         MPI_Status mpi_status; 
 
         for(int i=0; i<nc_; i++) {
           hess_appx_vec[i] = 1.0;
-	}
-    
+        }
+
         if(nc_<n_) {
-	  x0->copy_from_indexes(*x_, *xc_idx_);
+          x0->copy_from_indexes(*x_, *xc_idx_);
         } else {
           assert(nc_==n_);
           x0->copyFromStarting(0, *x_);
@@ -1136,19 +1136,19 @@ void hiopAlgPrimalDecomposition::set_alpha_max(const double alp_max)
           }
           for(int i=0; i<nc_; i++) {
             hess_appx_vec[i] = alp_temp;
-	  }
+          }
         } else {
           //grad_r->print();
 
-	  hess_appx_2->update_hess_coeff(*x0, *grad_r, rval);
+          hess_appx_2->update_hess_coeff(*x0, *grad_r, rval);
           //update base case objective, this requires updated skm1 and ykm1
-	  base_valm1 = base_val;
-	  base_val = hess_appx_2->compute_base(master_prob_->get_objective());
+          base_valm1 = base_val;
+          base_val = hess_appx_2->compute_base(master_prob_->get_objective());
 
           //hess_appx_2->update_ratio();
           hess_appx_2->update_ratio(base_val, base_valm1);
           
-	  //double alp_temp = hess_appx_2->get_alpha_f(*grad_r);
+          //double alp_temp = hess_appx_2->get_alpha_f(*grad_r);
           double alp_temp = hess_appx_2->get_alpha_tr();
           //double alp_temp2 = hess_appx_2->get_alpha_BB();
           if(ver_ >=outlevel2) {
@@ -1166,7 +1166,7 @@ void hiopAlgPrimalDecomposition::set_alpha_max(const double alp_max)
           convg = std::min(convg_f,convg_g);
           for(int i=0; i<nc_; i++) {
             hess_appx_vec[i] = alp_temp;
-	  }
+          }
 
         }
 
@@ -1183,9 +1183,9 @@ void hiopAlgPrimalDecomposition::set_alpha_max(const double alp_max)
         if(ver_ >=outlevel1 && it>0) {
           //printf("iteration         sub_obj              res               step_size           convg\n");
           printf("iteration          objective                 residual                   "   
-	         "step_size                   convg\n");
+                 "step_size                   convg\n");
           printf("%d            %18.12e          %18.12e             %18.12e          "
-	         "%18.12e\n", it, base_val+recourse_val,convg_f,dinf, convg_g);
+                 "%18.12e\n", it, base_val+recourse_val,convg_f,dinf, convg_g);
           fflush(stdout);
         }
 
@@ -1218,9 +1218,8 @@ void hiopAlgPrimalDecomposition::set_alpha_max(const double alp_max)
           printf( "Elapsed time for entire iteration %d is %f\n",it, t2 - t1 );  
         }
         // print out the iteration from the master rank
-	dinf = step_size_inf(nc_, *xc_idx_, *x_, *x0);
-	
-
+        dinf = step_size_inf(nc_, *xc_idx_, *x_, *x0);
+        
       } else {
         // evaluator ranks do nothing     
       }
@@ -1237,7 +1236,7 @@ void hiopAlgPrimalDecomposition::set_alpha_max(const double alp_max)
       assert(ierr == MPI_SUCCESS);
       
       for(auto it : rec_prob) {
-	delete it;
+        delete it;
       }
 
       delete req_cont_idx;
@@ -1332,7 +1331,7 @@ hiopSolveStatus hiopAlgPrimalDecomposition::run_single()
       base_valm1 = base_val;
     }
 
-    // array for number of indices, this is subjected to change	
+    // array for number of indices, this is subjected to change
     rval = 0.;
     grad_r->setToZero();
 
@@ -1355,7 +1354,7 @@ hiopSolveStatus hiopAlgPrimalDecomposition::run_single()
       double aux=0.;
       bret = master_prob_->eval_f_rterm(idx_temp, nc_, x0_vec, aux); //need to add extra time here
       if(!bret) {
-	//todo
+        //todo
       }
       rval += aux;
       //assert("for debugging" && false); //for debugging purpose

--- a/src/Optimization/hiopAlgPrimalDecomp.cpp
+++ b/src/Optimization/hiopAlgPrimalDecomp.cpp
@@ -1283,8 +1283,8 @@ hiopSolveStatus hiopAlgPrimalDecomposition::run_single()
   double rval = 0.;
   //double grad_r[nc_];
   hiopVector* grad_r;
-  grad_r =LinearAlgebraFactory::create_vector(options_->GetString("mem_space"), nc_) ; 
-  double* grad_r_vec=grad_r->local_data_host();
+  grad_r = LinearAlgebraFactory::create_vector(options_->GetString("mem_space"), nc_) ; 
+  double* grad_r_vec = grad_r->local_data_host();
   
   hiopVector* hess_appx;
   hess_appx = grad_r->alloc_clone();
@@ -1334,9 +1334,9 @@ hiopSolveStatus hiopAlgPrimalDecomposition::run_single()
     rval = 0.;
     grad_r->setToZero();
 
-    int* cont_idx = new int[S_];
-    for(int i=0;i<S_;i++) {
-      cont_idx[i]=i;
+    std::vector<int> cont_idx(S_);
+    for(int i=0; i<S_; i++) {
+      cont_idx[i] = i;
     }
     // The number of contigencies should be larger than the number of processors, which is 1
     // idx is the next contingency to be sent out from the master
@@ -1353,7 +1353,7 @@ hiopSolveStatus hiopAlgPrimalDecomposition::run_single()
       double aux=0.;
       bret = master_prob_->eval_f_rterm(idx_temp, nc_, x0_vec, aux); //need to add extra time here
       if(!bret) {
-            //todo
+	//todo
       }
       rval += aux;
       //assert("for debugging" && false); //for debugging purpose
@@ -1473,7 +1473,13 @@ hiopSolveStatus hiopAlgPrimalDecomposition::run_single()
     //printf("count  %d \n", accp_count);
     if(stopping_criteria(it, convg)){break;}
   }
-    return Solve_Success;    
+
+  delete grad_r;
+  delete hess_appx;
+  delete x0;
+  delete hess_appx_2;
+  delete evaluator;
+  return Solve_Success;    
 }
 
 }//end namespace

--- a/src/Optimization/hiopAlgPrimalDecomp.cpp
+++ b/src/Optimization/hiopAlgPrimalDecomp.cpp
@@ -875,9 +875,9 @@ void hiopAlgPrimalDecomposition::set_alpha_max(const double alp_max)
         rval = 0.;
 	grad_r->setToZero();
         
-        int* cont_idx = new int[S_];
-        for(int i=0;i<S_;i++) {
-          cont_idx[i]=i;
+	std::vector<int> cont_idx(S_);
+        for(int i=0; i<S_; i++) {
+          cont_idx[i] = i;
         }
         // The number of contigencies should be larger than the number of processors
         // Otherwise not implemented yet
@@ -898,7 +898,7 @@ void hiopAlgPrimalDecomposition::set_alpha_max(const double alp_max)
         }
         int mpi_test_flag; // for testing if the send/recv is completed
         // Posting initial receive of recourse solutions from evaluators
-        for(int r=1; r< comm_size_;r++) {
+        for(int r=1; r<comm_size_; r++) {
           //int cur_idx = cont_idx[idx];
           rec_prob[r]->post_recv(2,r,comm_world_);// 2 is the tag, r is the rank source 
           //printf("receive flag for contingency value %d)\n", mpi_test_flag);
@@ -914,7 +914,7 @@ void hiopAlgPrimalDecomposition::set_alpha_max(const double alp_max)
         int last_loop = 0;
         //printf("total idx %d\n", S_);
         t2 = MPI_Wtime(); 
-        if(ver_ >=outlevel2) {
+        if(ver_>=outlevel2) {
           printf( "Elapsed time for iteration %d for misc is %f\n",it, t2 - t1 );  
         }
         while(idx<=S_ || last_loop) { 
@@ -965,7 +965,7 @@ void hiopAlgPrimalDecomposition::set_alpha_max(const double alp_max)
         grad_r->scale(1.0/S_);
         // send end signal to all evaluators
         int cur_idx = -1;
-        for(int r=1; r< comm_size_;r++) {
+        for(int r=1; r<comm_size_; r++) {
           req_cont_idx->set_idx(-1);
           req_cont_idx->post_send(1,r,comm_world_);
         }

--- a/src/Optimization/hiopAlgPrimalDecomp.cpp
+++ b/src/Optimization/hiopAlgPrimalDecomp.cpp
@@ -649,7 +649,9 @@ hiopAlgPrimalDecomposition::~hiopAlgPrimalDecomposition()
   delete x_;
   delete options_;
   delete log_;
+#ifdef HIOP_USE_MPI
   delete [] request_;
+#endif
 }
 
 double hiopAlgPrimalDecomposition::getObjective() const

--- a/src/Optimization/hiopAlgPrimalDecomp.hpp
+++ b/src/Optimization/hiopAlgPrimalDecomp.hpp
@@ -81,7 +81,7 @@ enum MPIout {
   outlevel4=4  //print details about the algorithm
 }; 
 
-/* The main mpi engine for solving a class of problems with primal decomposition. 
+/* The main MPI solver for solving a class of problems with primal decomposition. 
  * The master problem is the user defined class that should be able to solve both
  * the base case and full problem depending whether a recourse approximation is 
  * included. 
@@ -91,15 +91,33 @@ class hiopAlgPrimalDecomposition
 {
 public:
 
-  //constructor
+  /**
+   * Creates a primal decomposition algorithm for the primal decomposable problem
+   * passed as an argument
+   *
+   * @param prob_in the primal decomposable problem
+   * @param comm_world the communicator whose ranks should be used to schedule the tasks
+   * (subproblems of the primal decomposable problem prob_in)
+   */
   hiopAlgPrimalDecomposition(hiopInterfacePriDecProblem* prob_in,
-                             MPI_Comm comm_world=MPI_COMM_WORLD);
+                             MPI_Comm comm_world = MPI_COMM_WORLD);
 
+  /**
+   * Creates a primal decomposition algorithm for the primal decomposable problem
+   * passed as an argument
+   *
+   * @param prob_in the primal decomposable problem
+   * @param nc the number of coupling variables
+   * @param xc_index array on the device  with the the indexes of the coupling variables 
+   * in the full vector (primal) variables for the basecase/master problem within the primal 
+   * decomposable problem prob_in.
+   * @param comm_world the communicator whose ranks should be used to schedule the tasks
+   * (subproblems of the primal decomposable problem prob_in)
+   */
   hiopAlgPrimalDecomposition(hiopInterfacePriDecProblem* prob_in,
                              const int nc, 
                              const int* xc_index,
-                             MPI_Comm comm_world=MPI_COMM_WORLD);
-
+                             MPI_Comm comm_world = MPI_COMM_WORLD);
 
   virtual ~hiopAlgPrimalDecomposition();
 
@@ -137,7 +155,7 @@ public:
   
   void set_acceptable_tolerance(const double tol);
  
-  double step_size_inf(const int nc, const int* idx, const hiopVector& x, const hiopVector& x0);
+  double step_size_inf(const int nc, const hiopVectorInt& idx, const hiopVector& x, const hiopVector& x0);
   
   /* Contains information of a previous solution step including function value 
    * and gradient. Used for storing the solution for the previous iteration
@@ -318,8 +336,9 @@ private:
   //level of output through the MPI engine
   size_t ver_ = 1;
 
-  //indices of the coupled x in the full x
-  int* xc_idx_;
+  /// Indices of the coupled x in the full x of the basecase/master problem
+  hiopVectorInt* xc_idx_;
+  
   //tolerance of the convergence stopping criteria. TODO: user options from options file via hiopOptions
   double tol_ = 1e-8;
 

--- a/tests/LinAlg/vectorTestsInt.hpp
+++ b/tests/LinAlg/vectorTestsInt.hpp
@@ -122,6 +122,22 @@ public:
     return fail;
   }
 
+  virtual bool vector_linspace(hiop::hiopVectorInt& x) const
+  {
+    int fail = 0;
+
+    x.set_to_constant(1);
+    x.linspace(0, 2);
+
+    for(int i=0; i<x.size(); i++) {
+      if(getLocalElement(&x, i) != 2*i) {
+        ++fail;
+      }
+    }
+    printMessage(fail, __func__);
+    return fail;
+  }
+  
   virtual bool vector_copy_from(hiop::hiopVectorInt& x, hiop::hiopVectorInt& y) const
   {
     int fail = 0;

--- a/tests/testVector.cpp
+++ b/tests/testVector.cpp
@@ -233,6 +233,8 @@ int runTests(const char* mem_space, MPI_Comm comm)
   hiopVector* x = LinearAlgebraFactory::create_vector(mem_space, Nglobal, n_partition, comm);
   hiopVector* y = LinearAlgebraFactory::create_vector(mem_space, Nglobal, n_partition, comm);
   hiopVector* z = LinearAlgebraFactory::create_vector(mem_space, Nglobal, n_partition, comm);
+
+  hiopVectorInt* v_smaller_idxs = LinearAlgebraFactory::create_vector_int(mem_space, Mlocal);
   
   hiopVectorInt* v_map = LinearAlgebraFactory::create_vector_int(mem_space, Mlocal);
   hiopVectorInt* v2_map = LinearAlgebraFactory::create_vector_int(mem_space, Mlocal);
@@ -248,6 +250,7 @@ int runTests(const char* mem_space, MPI_Comm comm)
 
   if (rank == 0)
   {
+    fail += test.vector_copy_from_indexes(*v_smaller, *v, *v_smaller_idxs);
     fail += test.vectorCopyFromStarting(*v, *v_smaller);
     fail += test.vectorStartingAtCopyFromStartingAt(*v_smaller, *v);
     fail += test.vectorCopyToStarting(*v, *v_smaller);
@@ -313,6 +316,7 @@ int runTests(const char* mem_space, MPI_Comm comm)
   delete x;
   delete y;
   delete z;
+  delete v_smaller_idxs;
   delete v_map;
   delete v2_map;
   delete v_smaller;
@@ -332,9 +336,6 @@ int runIntTests(const char* mem_space)
 
   T test;
   test.set_mem_space(mem_space);
-  //hiopOptions options;
-  //options.SetStringValue("mem_space", mem_space);
-  //LinearAlgebraFactory::set_mem_space(mem_space);
 
   int fail = 0;
 
@@ -345,7 +346,8 @@ int runIntTests(const char* mem_space)
   fail += test.vectorSize(*x, sz);
   fail += test.vectorGetElement(*x);
   fail += test.vectorSetElement(*x);
-
+  fail += test.vector_linspace(*x);
+  
   auto* y = LinearAlgebraFactory::create_vector_int(mem_space, sz);
   fail += test.vector_copy_from(*x, *y);
   


### PR DESCRIPTION
closes #250 and #251

Main target is to replace int arrays used for indexing with hiopVectorInt. Both Seq and RAJA implementations are done. 

The PR also fixes a number of memory leaks in the PriDec solver. Both single and MPI PriDec drivers are now leaks-free.