### PR TITLE
Export sparse config

### DIFF
--- a/cmake/HiOpConfig.cmake.in
+++ b/cmake/HiOpConfig.cmake.in
@@ -26,6 +26,7 @@ if(@HIOP_USE_RAJA@ AND NOT TARGET RAJA)
 endif()
 
 set(HiOp::SPARSE @HIOP_SPARSE@ CACHE BOOL "indicates if hiop sparse is enabled")
+set(HiOp::USE_COINHSL @HIOP_USE_COINHSL@ CACHE BOOL "indicates if coinhsl is enabled")
 
 if(@HIOP_USE_GPU@)
   if(@HIOP_USE_CUDA@)

--- a/cmake/HiOpConfig.cmake.in
+++ b/cmake/HiOpConfig.cmake.in
@@ -25,6 +25,8 @@ if(@HIOP_USE_RAJA@ AND NOT TARGET RAJA)
   find_package(umpire PATHS @umpire_DIR@)
 endif()
 
+set(HiOp::SPARSE @HIOP_SPARSE@ CACHE BOOL "indicates if hiop sparse is enabled")
+
 if(@HIOP_USE_GPU@)
   if(@HIOP_USE_CUDA@)
     include(CheckLanguage)

--- a/cmake/HiOpConfig.cmake.in
+++ b/cmake/HiOpConfig.cmake.in
@@ -26,7 +26,6 @@ if(@HIOP_USE_RAJA@ AND NOT TARGET RAJA)
 endif()
 
 set(HiOp::SPARSE @HIOP_SPARSE@ CACHE BOOL "indicates if hiop sparse is enabled")
-set(HiOp::USE_COINHSL @HIOP_USE_COINHSL@ CACHE BOOL "indicates if coinhsl is enabled")
 
 if(@HIOP_USE_GPU@)
   if(@HIOP_USE_CUDA@)


### PR DESCRIPTION
addresses issue #349 

exports the target HiOp::SPARSE so that it is accessible after install