### PR TITLE
Address some warnings reported by the c++ compilers

### DIFF
--- a/src/Drivers/Makefile_ex6
+++ b/src/Drivers/Makefile_ex6
@@ -39,8 +39,9 @@ OBJS =  IpoptAdapter_driver_ex6.o nlpSparse_ex6.o
 ADDLIBS =
 
 # CHANGEME: Additional flags for compilation (e.g., include flags)
-ADDINCFLAGS = -I/g/g92/chiang7/software/hiop_lassen/include/
+#ADDINCFLAGS = -I/g/g92/chiang7/software/hiop_lassen/include/
 #ADDINCFLAGS = -I/Users/petra1/work/projects/hiop/_dist-DEBUG/include/
+ADDINCFLAGS = -I/Users/chiang7/project/hiop/build_develop/install_db/include
 
 ##########################################################################
 #  Usually, you don't have to change anything below.  Note that if you   #
@@ -48,26 +49,37 @@ ADDINCFLAGS = -I/g/g92/chiang7/software/hiop_lassen/include/
 ##########################################################################
 
 # C++ Compiler command
-CXX = mpig++
+CXX = g++
 
 # C++ Compiler options
-CXXFLAGS = -g -pipe -Wparentheses -Wreturn-type -Wcast-qual -Wall -Wpointer-arith -Wwrite-strings -Wconversion -Wno-unknown-pragmas -Wno-long-long -m64 -fopenmp -fPIC -lgomp  -DIPOPT_BUILD
+# ny VM
+#CXXFLAGS = -g -pipe -Wparentheses -Wreturn-type -Wcast-qual -Wall -Wpointer-arith -Wwrite-strings -Wconversion -Wno-unknown-pragmas -Wno-long-long -m64 -fopenmp -fPIC -lgomp  -DIPOPT_BUILD
+# ny mac
+CXXFLAGS = -g -std=c++11 -pipe -Wparentheses -Wreturn-type -Wcast-qual -Wall -Wpointer-arith -Wwrite-strings -Wconversion -Wno-unknown-pragmas -Wno-long-long -m64 -fPIC -DIPOPT_BUILD
 # mac
 #CXXFLAGS = -g -pipe -Wparentheses -Wreturn-type -Wcast-qual -Wall -Wpointer-arith -Wwrite-strings -Wconversion -Wno-unknown-pragmas -Wno-long-long -m64 -I/home/petra1/intel_mkl2019/compilers_and_libraries_2019.2.187/linux/mkl/include -fPIC -DIPOPT_BUILD 
 
 # additional C++ Compiler options for linking
-CXXLINKFLAGS = -Wl,--rpath -Wl,/g/g92/chiang7/software/lassen/COIN-OR/build/lib
+# ny VM
+#CXXLINKFLAGS = -Wl,--rpath -Wl,/g/g92/chiang7/software/lassen/COIN-OR/build/lib
+# ny mac
+CXXLINKFLAGS = -Wl,-rpath -Wl,/Users/chiang7/software/coin-or/lib
 #mac
 #CXXLINKFLAGS =  -Wl,-rpath -Wl,/Users/petra1/work/projects/go-compet/Ipopt-gollnlp/build/lib/
 
 # Include directories (we use the CYGPATH_W variables to allow compilation with Windows compilers)
-INCL = `PKG_CONFIG_PATH=/g/g92/chiang7/software/lassen/COIN-OR/build/lib/pkgconfig pkg-config --cflags ipopt` $(ADDINCFLAGS)
+# ny VM
+#INCL = `PKG_CONFIG_PATH=/g/g92/chiang7/software/lassen/COIN-OR/build/lib/pkgconfig pkg-config --cflags ipopt` $(ADDINCFLAGS)
+# ny mac
+INCL = `PKG_CONFIG_PATH=/Users/chiang7/software/coin-or/lib/pkgconfig pkg-config --cflags ipopt` $(ADDINCFLAGS)
 #mac
 #INCL = -I`$(CYGPATH_W) /Users/petra1/work/projects/go-compet/Ipopt-gollnlp/build/include/coin`  -I/Users/petra1/work/projects/go-compet/Ipopt-gollnlp/build/include/coin/ThirdParty  -I/Users/petra1/work/projects/go-compet/Ipopt-gollnlp/build/include/coin/ThirdParty   $(ADDINCFLAGS)
 
 # Linker flags
-LIBS = `PKG_CONFIG_PATH=/g/g92/chiang7/software/lassen/COIN-OR/build/lib/pkgconfig pkg-config --libs ipopt` -llapack -lblas  -ldl -lm /g/g92/chiang7/software/hiop_lassen/lib/libhiop.a
-
+# ny VM
+#LIBS = `PKG_CONFIG_PATH=/g/g92/chiang7/software/lassen/COIN-OR/build/lib/pkgconfig pkg-config --libs ipopt` -llapack -lblas  -ldl -lm /g/g92/chiang7/software/hiop_lassen/lib/libhiop.a
+# ny mac
+LIBS = `PKG_CONFIG_PATH=/Users/chiang7/software/coin-or/lib/pkgconfig pkg-config --libs ipopt` -llapack -lblas  -ldl -lm /Users/chiang7/project/hiop/build_develop/install_db/lib/libhiop.a 
 #mac
 #LIBS = -L/Users/petra1/work/projects/go-compet/Ipopt-gollnlp/build/lib -lipopt  -L/Users/petra1/work/projects/go-compet/Ipopt-gollnlp/build/lib -lcoinhsl -framework Accelerate -framework Accelerate -L/usr/local/Cellar/gcc/9.2.0_1/lib/gcc/9/gcc/x86_64-apple-darwin18/9.2.0 -L/usr/local/Cellar/gcc/9.2.0_1/lib/gcc/9/gcc/x86_64-apple-darwin18/9.2.0/../../.. -lgfortran -lSystem -lquadmath -lm  -L/Users/petra1/work/projects/go-compet/Ipopt-gollnlp/build/lib -lcoinmetis  -framework Accelerate -framework Accelerate -lm  -ldl /Users/petra1/work/projects/hiop/_dist-DEBUG/lib/libhiop.a
 

--- a/src/LinAlg/hiopMatrixComplexDense.hpp
+++ b/src/LinAlg/hiopMatrixComplexDense.hpp
@@ -207,7 +207,7 @@ namespace hiop
     }
     /* copies 'src' into this as a block starting at (i_block_start,j_block_start) */
     /* copyMatrixAsBlock */
-    void copyBlockFromMatrix(const long i_block_start, const long j_block_start,
+    void copyBlockFromMatrix(const index_type i_block_start, const index_type j_block_start,
 			     const hiopMatrixComplexDense& src)      
     {
       assert(false && "not yet implemented");

--- a/src/LinAlg/hiopMatrixDense.hpp
+++ b/src/LinAlg/hiopMatrixDense.hpp
@@ -204,7 +204,7 @@ public:
   virtual void copyRowsFrom(const hiopMatrix& src_gen, const index_type* rows_idxs, size_type n_rows){assert(false && "not implemented in base class");}
   
   /// @brief copies 'src' into this as a block starting at (i_block_start,j_block_start)
-  virtual void copyBlockFromMatrix(const long i_block_start, const long j_block_start,
+  virtual void copyBlockFromMatrix(const index_type i_block_start, const index_type j_block_start,
 			   const hiopMatrixDense& src){assert(false && "not implemented in base class");}
   
   /**
@@ -242,8 +242,8 @@ public:
   }
 #endif
 protected:
-  size_type n_global_; //total / global number of columns
   size_type m_local_;
+  size_type n_global_; //total / global number of columns
   MPI_Comm comm_;
   int myrank_;
 

--- a/src/LinAlg/hiopMatrixDenseRowMajor.cpp
+++ b/src/LinAlg/hiopMatrixDenseRowMajor.cpp
@@ -196,7 +196,7 @@ void hiopMatrixDenseRowMajor::copyRowsFrom(const hiopMatrix& src_gen, const inde
 }
 
   
-void hiopMatrixDenseRowMajor::copyBlockFromMatrix(const long i_start, const long j_start,
+void hiopMatrixDenseRowMajor::copyBlockFromMatrix(const index_type i_start, const index_type j_start,
 					  const hiopMatrixDense& srcmat)
 {
   const auto& src = dynamic_cast<const hiopMatrixDenseRowMajor&>(srcmat);
@@ -213,8 +213,8 @@ void hiopMatrixDenseRowMajor::copyBlockFromMatrix(const long i_start, const long
   assert(j_start<n_local_ || !n_local_);
   assert(i_start>=0); assert(j_start>=0);
 #endif
-  const size_t buffsize=src.n_local_*sizeof(double);
-  for(long ii=0; ii<src.m_local_; ii++)
+  const size_t buffsize = src.n_local_*sizeof(double);
+  for(index_type ii=0; ii<src.m_local_; ii++)
     memcpy(M_[ii+i_start]+j_start, src.M_[ii], buffsize);
 }
 

--- a/src/LinAlg/hiopMatrixDenseRowMajor.hpp
+++ b/src/LinAlg/hiopMatrixDenseRowMajor.hpp
@@ -199,7 +199,7 @@ public:
   void copyRowsFrom(const hiopMatrix& src_gen, const index_type* rows_idxs, size_type n_rows);
   
   /// @brief copies 'src' into this as a block starting at (i_block_start,j_block_start)
-  void copyBlockFromMatrix(const long i_block_start, const long j_block_start,
+  void copyBlockFromMatrix(const index_type i_block_start, const index_type j_block_start,
 			   const hiopMatrixDense& src);
   
   /**

--- a/src/LinAlg/hiopMatrixRajaDense.cpp
+++ b/src/LinAlg/hiopMatrixRajaDense.cpp
@@ -371,7 +371,7 @@ void hiopMatrixRajaDense::copyRowsFrom(const hiopMatrix& src_mat, const index_ty
  * @pre This method should only be used with non-distributed matrices.
  */
 void hiopMatrixRajaDense::
-copyBlockFromMatrix(const long i_start, const long j_start, const hiopMatrixDense& srcmat)
+copyBlockFromMatrix(const index_type i_start, const index_type j_start, const hiopMatrixDense& srcmat)
 {
   const auto& src = dynamic_cast<const hiopMatrixRajaDense&>(srcmat);
   assert(n_local_==n_global_ && "this method should be used only in 'serial' mode");
@@ -391,7 +391,7 @@ copyBlockFromMatrix(const long i_start, const long j_start, const hiopMatrixDens
   RAJA::View<double, RAJA::Layout<2>> Mview(this->data_dev_, m_local_, n_local_);
   RAJA::View<double, RAJA::Layout<2>> Sview(src.data_dev_, src.m_local_, src.n_local_);
   const size_t buffsize = src.n_local_ * sizeof(double);
-  for(long ii=0; ii<src.m_local_; ii++)
+  for(index_type ii=0; ii<src.m_local_; ii++)
     rm.copy(&Mview(ii + i_start, j_start), &Sview(ii, 0), buffsize);
 }
 

--- a/src/LinAlg/hiopMatrixRajaDense.hpp
+++ b/src/LinAlg/hiopMatrixRajaDense.hpp
@@ -222,7 +222,7 @@ public:
   void copyRowsFrom(const hiopMatrix& src_gen, const index_type* rows_idxs, size_type n_rows);
   
   /// @brief copies 'src' into this as a block starting at (i_block_start,j_block_start)
-  void copyBlockFromMatrix(const long i_block_start, const long j_block_start,
+  void copyBlockFromMatrix(const index_type i_block_start, const index_type j_block_start,
 			   const hiopMatrixDense& src);
   
   /**

--- a/src/LinAlg/hiopVectorPar.cpp
+++ b/src/LinAlg/hiopVectorPar.cpp
@@ -835,7 +835,7 @@ void hiopVectorPar::addLinearDampingTerm(const hiopVector& ixleft,
   assert(n_local_==(dynamic_cast<const hiopVectorPar&>(ixright) ).n_local_);
 #endif
 
-  for(long i=0; i<n_local_; i++) {
+  for(index_type i=0; i<n_local_; i++) {
     v[i] = alpha*v[i] + (ixl[i]-ixr[i])*ct;
   }
 }

--- a/src/Optimization/hiopIterate.cpp
+++ b/src/Optimization/hiopIterate.cpp
@@ -423,7 +423,7 @@ int hiopIterate::adjust_small_slacks(hiopVector& slack,
 
       num_adjusted_slack = new_s->numOfElemsLessThan(zero);
 
-      new_s->component_sgn();    // missing func
+      new_s->component_sgn();
       new_s->scale(-1.0);
 
       slack.component_max(0.0);
@@ -441,7 +441,7 @@ int hiopIterate::adjust_small_slacks(hiopVector& slack,
 
       vec1->setToConstant_w_patternSelect(1.0, select);
       vec2->copyFrom(bound);
-      vec2->component_abs();  // missing func
+      vec2->component_abs();
       vec1->component_max(*vec2);
 
       vec1->scale(scale_fact);
@@ -451,7 +451,6 @@ int hiopIterate::adjust_small_slacks(hiopVector& slack,
 
       slack.copyFrom(*new_s);
 
-//      slackselectPattern(select);
 #ifndef NDEBUG
   assert(slack.matchesPattern(select));
 #endif


### PR DESCRIPTION
Address some warnings reported by the c++ compilers.
1. use index_type instead of long
2. reorder the member objects