### PR TITLE
Install options and warnings target.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,6 +140,7 @@ target_compile_options(hiop_warnings
   -Wnull-dereference
   -Wdouble-promotion  # Warn on implicit conversion from
                       # float to double
+  -Wconversion
   )
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,6 +158,7 @@ endif()
 
 if(HIOP_DEVELOPER_MODE)
   target_link_libraries(hiop_tpl INTERFACE hiop_options hiop_warnings)
+  install(TARGETS hiop_options hiop_warnings EXPORT hiop-targets)
 endif()
 
 if(NOT (HIOP_USE_GPU AND HIOP_USE_HIP))


### PR DESCRIPTION
Closes #401 

The new additions we have to the exported target `HiOpTargets.cmake` when `HIOP_DEVELOPER_MODE` is enabled is:

```CMake
# Create imported target HiOp::hiop_options
add_library(HiOp::hiop_options INTERFACE IMPORTED)

set_target_properties(HiOp::hiop_options PROPERTIES
  INTERFACE_COMPILE_FEATURES "cxx_std_11;cxx_alignas;cxx_alignof;cxx_attributes;cxx_auto_type;cxx_constexpr;cxx_defaulted_functions;cxx_deleted_functions;cxx_final;cxx_lambdas;cxx_noexcept;cxx_override;cxx_range_for;cxx_rvalue_references;cxx_static_assert;cxx_strong_enums;cxx_trailing_return_types;cxx_unicode_literals;cxx_user_literals;cxx_variadic_macros"
)

# Create imported target HiOp::hiop_warnings
add_library(HiOp::hiop_warnings INTERFACE IMPORTED)

set_target_properties(HiOp::hiop_warnings PROPERTIES
  INTERFACE_COMPILE_OPTIONS "-Wall;-Wextra;-Wshadow;-Wnull-dereference;-Wdouble-promotion;-Wmisleading-indentation;-Wduplicated-cond;-Wduplicated-branches;-Wuseless-cast"
)
```

@ashermancinelli discussed potentially making this a private include, but `INTERFACE library can only be used with the INTERFACE keyword of
   target_link_libraries` as stated by CMake.

I think this is fine as is, since I don't expect many users to install using developer mode. I can add this to the relevant documentation if needed.