### PR TITLE
Inertia free fix for condensed system

### DIFF
--- a/src/Optimization/hiopAlgFilterIPM.cpp
+++ b/src/Optimization/hiopAlgFilterIPM.cpp
@@ -1521,6 +1521,14 @@ decideAndCreateFactAcceptor(hiopPDPerturbation* p, hiopNlpFormulation* nlp, hiop
   std::string strKKT = nlp->options->GetString("fact_acceptor");
   if(strKKT == "inertia_free")
   {
+#ifdef HIOP_SPARSE    
+    if(nullptr != dynamic_cast<hiopKKTLinSysCondensedSparse*>(kkt)) {
+      // for LinSysCondensedSparse correct inertia is different
+      assert(nullptr != dynamic_cast<hiopNlpSparseIneq*>(nlp) &&
+             "wrong combination of optimization objects was created");
+      return new hiopFactAcceptorInertiaFreeDWD(p, 0);      
+    }
+#endif
     return new hiopFactAcceptorInertiaFreeDWD(p, nlp->m_eq()+nlp->m_ineq());
   } else {
 #ifdef HIOP_SPARSE    

--- a/src/Optimization/hiopFactAcceptor.hpp
+++ b/src/Optimization/hiopFactAcceptor.hpp
@@ -133,7 +133,8 @@ public:
    * Check inertia condition to determine if a factorization is acceptable or not
    */
   hiopFactAcceptorInertiaFreeDWD(hiopPDPerturbation* p, const size_type n_required_neg_eig)
-    : hiopFactAcceptor(p)
+    : hiopFactAcceptor(p),
+      n_required_neg_eig_(n_required_neg_eig)
   {}
 
   virtual ~hiopFactAcceptorInertiaFreeDWD() 

--- a/src/Optimization/hiopKKTLinSys.cpp
+++ b/src/Optimization/hiopKKTLinSys.cpp
@@ -361,7 +361,8 @@ bool hiopKKTLinSysCurvCheck::factorize_inertia_free()
   size_t num_refactorization = 0;
 
   while(num_refactorization<=max_refactorization && solver_flag < 0) {
-                      
+    nlp_->log->printf(hovWarning, "linsys: matrix becomes singular after adding primal regularization!\n");
+
     continue_re_fact = fact_acceptor_->requireReFactorization(*nlp_, solver_flag, delta_wx, delta_wd, delta_cc, delta_cd);
     
     if(-1==continue_re_fact) {

--- a/src/Optimization/hiopKKTLinSys.cpp
+++ b/src/Optimization/hiopKKTLinSys.cpp
@@ -282,8 +282,8 @@ bool hiopKKTLinSysCurvCheck::factorize()
   assert(nlp_);
 
   // factorization + inertia correction if needed
-  const size_t max_refactorizaion = 10;
-  size_t num_refactorizaion = 0;
+  const size_t max_refactorization = 10;
+  size_t num_refactorization = 0;
   int continue_re_fact;
 
   double delta_wx, delta_wd, delta_cc, delta_cd;
@@ -292,11 +292,11 @@ bool hiopKKTLinSysCurvCheck::factorize()
     return false;
   }
 
-  while(num_refactorizaion<=max_refactorizaion) {
+  while(num_refactorization <= max_refactorization) {
     assert(delta_wx == delta_wd && "something went wrong with IC");
     assert(delta_cc == delta_cd && "something went wrong with IC");
     nlp_->log->printf(hovScalars, "linsys: delta_w=%12.5e delta_c=%12.5e (ic %d)\n",
-            delta_wx, delta_cc, num_refactorizaion);
+            delta_wx, delta_cc, num_refactorization);
 
     // the update of the linear system, including IC perturbations
     this->build_kkt_matrix(delta_wx, delta_wd, delta_cc, delta_cd);
@@ -317,14 +317,14 @@ bool hiopKKTLinSysCurvCheck::factorize()
     }
 
     // will do an inertia correction
-    num_refactorizaion++;
+    num_refactorization++;
     nlp_->runStats.kkt.nUpdateICCorr++;
   } // end of IC loop
 
-  if(num_refactorizaion>max_refactorizaion) {
+  if(num_refactorization>max_refactorization) {
     nlp_->log->printf(hovError,
         "Reached max number (%d) of refactorization within an outer iteration.\n",
-              max_refactorizaion);
+              max_refactorization);
     return false;
   }
   return true;
@@ -340,11 +340,6 @@ bool hiopKKTLinSysCurvCheck::factorize_inertia_free()
   double delta_wx, delta_wd, delta_cc, delta_cd;
   perturb_calc_->get_curr_perturbations(delta_wx, delta_wd, delta_cc, delta_cd);
 
-#ifdef HIOP_DEEPCHECKS
-    this->build_kkt_matrix(delta_wx, delta_wd, delta_cc, delta_cd);
-    non_singular_mat = factorizeWithCurvCheck();
-    assert(non_singular_mat>=0);
-#endif
   continue_re_fact = fact_acceptor_->requireReFactorization(*nlp_, non_singular_mat, delta_wx, delta_wd, delta_cc, delta_cd, true);
 
   assert(delta_wx == delta_wd && "something went wrong with IC");
@@ -362,10 +357,10 @@ bool hiopKKTLinSysCurvCheck::factorize_inertia_free()
   // if solver_flag<0, matrix becomes singular, or not pd (in condensed system) after adding regularization
   // this should not happen, but some linear solver may have numerical difficulty.
   // adding more regularization till it succeeds
-  const size_t max_refactorizaion = 10;
-  size_t num_refactorizaion = 0;
+  const size_t max_refactorization = 10;
+  size_t num_refactorization = 0;
 
-  while(num_refactorizaion<=max_refactorizaion && solver_flag < 0) {
+  while(num_refactorization<=max_refactorization && solver_flag < 0) {
                       
     continue_re_fact = fact_acceptor_->requireReFactorization(*nlp_, solver_flag, delta_wx, delta_wd, delta_cc, delta_cd);
     
@@ -389,7 +384,7 @@ bool hiopKKTLinSysCurvCheck::factorize_inertia_free()
     nlp_->runStats.kkt.tmUpdateInnerFact.stop();
 
     // will do an inertia correction
-    num_refactorizaion++;
+    num_refactorization++;
     nlp_->runStats.kkt.nUpdateICCorr++;
   } // end of IC loop
 


### PR DESCRIPTION
With condensed linear system, current implementation add dual regularization if a Cholesky solver fails, e.g. matrix is not p.d. This PR adds primal regularizations in stead of the dual ones.

In some test cases, the un-regularized matrix can be Cholesky factorized successfully, while adding a small primal regularization fails the Cholesky solver. This PR also addressed this issue, by increasing the primal regularization till the Cholesky solver succeeds.