### PR TITLE
A temporary solution to the magma-hip bug

### DIFF
--- a/src/LinAlg/hiopLinSolverIndefDenseMagma.cpp
+++ b/src/LinAlg/hiopLinSolverIndefDenseMagma.cpp
@@ -80,6 +80,13 @@ namespace hiop
 
     magma_uplo_t uplo=MagmaLower; // M is upper in C++ so it's lower in fortran
 
+#ifdef HIOP_USE_HIP
+    uplo = MagmaUpper; // M is upper in C++ so it's lower in fortran
+
+    M_
+#endif
+
+
     std::string mem_space = nlp_->options->GetString("mem_space");
     if(mem_space == "default" || mem_space == "host") {
       nlp_->runStats.linsolv.tmDeviceTransfer.start();

--- a/src/LinAlg/hiopLinSolverIndefDenseMagma.cpp
+++ b/src/LinAlg/hiopLinSolverIndefDenseMagma.cpp
@@ -82,10 +82,8 @@ namespace hiop
 
 #ifdef HIOP_USE_HIP
     uplo = MagmaUpper; // M is upper in C++ so it's lower in fortran
-
-    M_
+    M_->symmetrize();
 #endif
-
 
     std::string mem_space = nlp_->options->GetString("mem_space");
     if(mem_space == "default" || mem_space == "host") {
@@ -199,6 +197,9 @@ namespace hiop
     nlp_->runStats.linsolv.tmTriuSolves.start();
     
     magma_uplo_t uplo=MagmaLower; // M is upper in C++ so it's lower in fortran
+ #ifdef HIOP_USE_HIP
+    uplo = MagmaUpper; // M is upper in C++ so it's lower in fortran
+#endif
     int info;
     magma_dsytrs_gpu(uplo, N, NRHS, device_M_, ldda_, ipiv_, device_rhs_, lddb_, &info, magma_device_queue_);
 

--- a/src/LinAlg/hiopLinSolverIndefSparseMA57.cpp
+++ b/src/LinAlg/hiopLinSolverIndefSparseMA57.cpp
@@ -35,7 +35,7 @@ namespace hiop
     icntl_[2-1] = 0;       // no Warning messages
     icntl_[4-1] = 1;       // no statistics messages
     icntl_[5-1] = 0;       // no Print messages.
-    icntl_[6-1] = 5;       // 2 use MC47;
+    icntl_[6-1] = 2;       // 2 use MC47;
                            // 3 min degree ordering as in MA27;
                            // 4 use Metis;
                            // 5 automatic choice(MA47 or Metis);

--- a/src/LinAlg/hiopMatrixDense.hpp
+++ b/src/LinAlg/hiopMatrixDense.hpp
@@ -241,6 +241,8 @@ public:
     return true;
   }
 #endif
+  virtual bool symmetrize() = 0;
+
 protected:
   size_type m_local_;
   size_type n_global_; //total / global number of columns

--- a/src/LinAlg/hiopMatrixDenseRowMajor.cpp
+++ b/src/LinAlg/hiopMatrixDenseRowMajor.cpp
@@ -871,5 +871,27 @@ bool hiopMatrixDenseRowMajor::assertSymmetry(double tol) const
   return true;
 }
 #endif
+
+bool hiopMatrixDenseRowMajor::symmetrize() 
+{
+  if(n_local_!=n_global_) {
+    assert(false && "should be used only for local matrices");
+    return false;
+  }
+  //must be square
+  if(m_local_!=n_global_) {
+    assert(false);
+    return false;
+  }
+
+  //symmetrize --- copy the upper triangular part to lower tirangular part
+  for(index_type i=0; i<n_local_; i++) {
+    for(index_type j=i+1; j<n_local_; j++) {
+      M_[j][i] = M_[i][j];
+    }
+  }
+  return true;
+}
+
 };
 

--- a/src/LinAlg/hiopMatrixDenseRowMajor.hpp
+++ b/src/LinAlg/hiopMatrixDenseRowMajor.hpp
@@ -235,6 +235,8 @@ public:
 #ifdef HIOP_DEEPCHECKS
   virtual bool assertSymmetry(double tol=1e-16) const;
 #endif
+  virtual bool symmetrize();
+
 private:
   double** M_; //local storage
   int n_local_; //local number of rows and cols, respectively

--- a/src/LinAlg/hiopMatrixRajaDense.cpp
+++ b/src/LinAlg/hiopMatrixRajaDense.cpp
@@ -1496,10 +1496,8 @@ bool hiopMatrixRajaDense::symmetrize()
     {
       double ij = Mview(i, j);
       double ji = Mview(j, i);
-      double relerr= fabs(ij - ji) /  (1 + fabs(ij));
-      assert(relerr < tol);
       if(i < j) {
-        Mview(i, j) = ji;
+        Mview(j, i) = ij;
       }
     });
   return true;

--- a/src/LinAlg/hiopMatrixRajaDense.cpp
+++ b/src/LinAlg/hiopMatrixRajaDense.cpp
@@ -1495,7 +1495,6 @@ bool hiopMatrixRajaDense::symmetrize()
     RAJA_LAMBDA(int j, int i)
     {
       double ij = Mview(i, j);
-      double ji = Mview(j, i);
       if(i < j) {
         Mview(j, i) = ij;
       }

--- a/src/LinAlg/hiopMatrixRajaDense.cpp
+++ b/src/LinAlg/hiopMatrixRajaDense.cpp
@@ -1474,6 +1474,37 @@ bool hiopMatrixRajaDense::assertSymmetry(double tol) const
 }
 #endif
 
+bool hiopMatrixRajaDense::symmetrize() 
+{
+  if(n_local_!=n_global_) {
+    assert(false && "should be used only for local matrices");
+    return false;
+  }
+  //must be square
+  if(m_local_!=n_global_) {
+    assert(false);
+    return false;
+  }
+
+  double* data = data_dev_;
+  RAJA::View<double, RAJA::Layout<2>> Mview(data, n_local_, n_local_);
+  RAJA::RangeSegment range(0, n_local_);
+
+  //symmetrize --- copy the upper triangular part to lower tirangular part
+  RAJA::kernel<matrix_exec>(RAJA::make_tuple(range, range),
+    RAJA_LAMBDA(int j, int i)
+    {
+      double ij = Mview(i, j);
+      double ji = Mview(j, i);
+      double relerr= fabs(ij - ji) /  (1 + fabs(ij));
+      assert(relerr < tol);
+      if(i < j) {
+        Mview(i, j) = ji;
+      }
+    });
+  return true;
+}
+
 /// Copy local host mirror data to the memory space
 void hiopMatrixRajaDense::copyToDev()
 {

--- a/src/LinAlg/hiopMatrixRajaDense.hpp
+++ b/src/LinAlg/hiopMatrixRajaDense.hpp
@@ -76,6 +76,7 @@ namespace hiop
  * addToSymDenseMatrixUpperTriangle
  * addUpperTriangleToSymDenseMatrixUpperTriangle
  * assertSymmetry
+ * symmetrize
  * copyBlockFromMatrix
  * copyFromMatrixBlock
  */
@@ -256,6 +257,7 @@ public:
 #ifdef HIOP_DEEPCHECKS
   virtual bool assertSymmetry(double tol=1e-16) const;
 #endif
+  virtual bool symmetrize();
 
   void copyToDev();
   void copyFromDev();

--- a/tests/LinAlg/matrixTestsDense.hpp
+++ b/tests/LinAlg/matrixTestsDense.hpp
@@ -1101,6 +1101,42 @@ public:
     return reduceReturn(fail, &A);
   }
 
+  int matrix_symmetrize(
+      hiop::hiopMatrixDense& A,
+      const int rank=0)
+  {
+    const local_ordinal_type M = getNumLocRows(&A);
+    const local_ordinal_type N = getNumLocCols(&A);
+    int fail = 0;
+    const real_type upper_val = one;
+    const real_type diag_val = zero;
+
+    assert(A.m() == A.n());
+    A.setToZero();
+
+    // Set the upper triangular part to one
+    for(int i=0; i<N; i++) {
+      for(int j=i+1; j<M; j++) {
+        if(rank == 0) {
+          setLocalElement(&A, i, j, upper_val);
+        }
+      }
+    }
+
+    // copy the upper triangular part to the lower triangylar part
+    A.symmetrize();
+
+    fail += verifyAnswer(&A,
+      [=] (local_ordinal_type i, local_ordinal_type j) -> real_type
+      {
+        bool is_diagonal = ( j==i );
+        return is_diagonal ? diag_val : upper_val;
+      });
+
+    printMessage(fail, __func__, rank);
+    return reduceReturn(fail, &A);
+  }
+
 #ifdef HIOP_DEEPCHECKS
   int matrixAssertSymmetry(
       hiop::hiopMatrixDense& A,

--- a/tests/testMatrixDense.cpp
+++ b/tests/testMatrixDense.cpp
@@ -241,6 +241,7 @@ static int runTests(const char* mem_space, MPI_Comm comm)
     fail += test.matrixAddSubDiagonal(*A_nxn_nodist, *x_m_nodist);
     fail += test.matrixTransAddToSymDenseMatrixUpperTriangle(*A_nxn_nodist, *A_kxm_nodist);
     fail += test.matrixAddUpperTriangleToSymDenseMatrixUpperTriangle(*A_nxn_nodist, *A_mxm_nodist);
+    fail += test.matrix_symmetrize(*A_nxn_nodist);
 #ifdef HIOP_DEEPCHECKS
     fail += test.matrixAssertSymmetry(*A_nxn_nodist);
     fail += test.matrixOverwriteUpperTriangleWithLower(*A_nxn_nodist);


### PR DESCRIPTION
There is a strange bug which prevent magma returning the correct solution from `magma_dsytrs_gpu`, when HIP is used.
See https://bitbucket.org/icl/magma/issues/57/magma_dsytrs_gpu-returns-wrong-solution-on for more details about this issue. A temporary solution suggested by Dr. Stanimire Tomov is to use `MagmaUpper` when calling the corresponding magma routines.

This PR addresses this issue, and uses MC47 as the default ordering for MA57.

@pelesh @ashermancinelli @cnpetra 