### PR TITLE
Sparse Linear Solver Interface update

### DIFF
--- a/src/LinAlg/hiopLinSolver.cpp
+++ b/src/LinAlg/hiopLinSolver.cpp
@@ -1,6 +1,5 @@
 // Copyright (c) 2017, Lawrence Livermore National Security, LLC.
 // Produced at the Lawrence Livermore National Laboratory (LLNL).
-// Written by Cosmin G. Petra, petra1@llnl.gov.
 // LLNL-CODE-742473. All rights reserved.
 //
 // This file is part of HiOp. For details, see https://github.com/LLNL/hiop. HiOp
@@ -101,6 +100,8 @@ namespace hiop {
     //this constructor (will call the 1-parameter constructor below) so they avoid creating
     //the triplet matrix
     M_ = new hiopMatrixSparseTriplet(n, n, nnz);
+    //this class will own `M_`
+    sys_mat_owned_ = true;
     nlp_ = nlp;
     perf_report_ = "on"==hiop::tolower(nlp->options->GetString("time_kkt"));
   }
@@ -108,6 +109,15 @@ namespace hiop {
   hiopLinSolverSymSparse::hiopLinSolverSymSparse(hiopNlpFormulation* nlp)
   {
     M_ = nullptr;
+    sys_mat_owned_ = false;
+    nlp_ = nlp;
+    perf_report_ = "on"==hiop::tolower(nlp->options->GetString("time_kkt"));
+  }
+
+  hiopLinSolverSymSparse::hiopLinSolverSymSparse(hiopMatrixSparse* M, hiopNlpFormulation* nlp)
+  {
+    M_ = M;
+    sys_mat_owned_ = false;
     nlp_ = nlp;
     perf_report_ = "on"==hiop::tolower(nlp->options->GetString("time_kkt"));
   }
@@ -115,6 +125,7 @@ namespace hiop {
   hiopLinSolverNonSymSparse::hiopLinSolverNonSymSparse(int n, int nnz, hiopNlpFormulation* nlp)
   {
     M_ = new hiopMatrixSparseTriplet(n, n, nnz);
+    sys_mat_owned_ = false;
     nlp_ = nlp;
     perf_report_ = "on"==hiop::tolower(nlp->options->GetString("time_kkt"));
   }

--- a/src/LinAlg/hiopLinSolverCholCuSparse.cpp
+++ b/src/LinAlg/hiopLinSolverCholCuSparse.cpp
@@ -62,7 +62,7 @@
 #include <cusolverSp_LOWLEVEL_PREVIEW.h>
 
 //this is for testing purposes only - will be removed once we have a better solution for ordering
-#define HIOP_USE_EIGEN
+//#define HIOP_USE_EIGEN
 
 #ifdef HIOP_USE_EIGEN
 #include "/home/petra1/work/installs/eigen-3.3.9/_install/include/eigen3/Eigen/Core"

--- a/src/LinAlg/hiopLinSolverCholCuSparse.cpp
+++ b/src/LinAlg/hiopLinSolverCholCuSparse.cpp
@@ -62,7 +62,7 @@
 #include <cusolverSp_LOWLEVEL_PREVIEW.h>
 
 //this is for testing purposes only - will be removed once we have a better solution for ordering
-//#define HIOP_USE_EIGEN
+#define HIOP_USE_EIGEN
 
 #ifdef HIOP_USE_EIGEN
 #include "/home/petra1/work/installs/eigen-3.3.9/_install/include/eigen3/Eigen/Core"
@@ -78,12 +78,9 @@ using PermutationMatrix = Ordering::PermutationType;
 
 namespace hiop
 {
-  
-hiopLinSolverCholCuSparse::hiopLinSolverCholCuSparse(const size_type& n, 
-                                                     const size_type& nnz, 
-                                                     hiopNlpFormulation* nlp)
-  : hiopLinSolverSymSparse(nlp),
-    nnz_(nnz),
+
+hiopLinSolverCholCuSparse::hiopLinSolverCholCuSparse(hiopMatrixSparseCSR* M, hiopNlpFormulation* nlp)
+  : hiopLinSolverSymSparse(M, nlp),
     buf_fact_(nullptr),
     rowptr_(nullptr),
     colind_(nullptr),
@@ -95,6 +92,8 @@ hiopLinSolverCholCuSparse::hiopLinSolverCholCuSparse(const size_type& n,
     rhs_buf1_(nullptr),
     rhs_buf2_(nullptr)
 {
+  nnz_ = M->numberOfNonzeros();
+  
   cusolverStatus_t ret;
   cusparseStatus_t ret_sp;
   
@@ -176,11 +175,12 @@ bool hiopLinSolverCholCuSparse::do_symb_analysis(const size_type n,
 
 bool hiopLinSolverCholCuSparse::initial_setup()
 {
+  auto* mat_csr = this->sys_mat_csr();
   cusolverStatus_t ret;
   assert(nullptr == buf_fact_);
-  size_type m = mat_csr_->m();
-  assert(m == mat_csr_->n());
-  assert(nnz_ == mat_csr_->numberOfNonzeros());
+  size_type m = mat_csr->m();
+  assert(m == mat_csr->n());
+  assert(nnz_ == mat_csr->numberOfNonzeros());
 
   //
   // allocate device CSR arrays; then 
@@ -215,22 +215,22 @@ bool hiopLinSolverCholCuSparse::initial_setup()
 
     auto* P_h = new index_type[m];
 #ifndef HIOP_USE_EIGEN
-    do_symb_analysis(mat_csr_->m(),
-                     mat_csr_->numberOfNonzeros(),
-                     mat_csr_->i_row(),
-                     mat_csr_->j_col(),
-                     mat_csr_->M(),
+    do_symb_analysis(mat_csr->m(),
+                     mat_csr->numberOfNonzeros(),
+                     mat_csr->i_row(),
+                     mat_csr->j_col(),
+                     mat_csr->M(),
                      P_h);
     ss_log << "\tOrdering: CUDA '" << nlp_->options->GetString("linear_solver_sparse_ordering") << "': ";
     
 #else
     // old code that uses Eigen to compute AMD
-    Eigen::Map<SparseMatrixCSR> M(mat_csr_->m(),
-                                  mat_csr_->m(),
-                                  mat_csr_->numberOfNonzeros(),
-                                  mat_csr_->i_row(),
-                                  mat_csr_->j_col(),
-                                  mat_csr_->M());
+    Eigen::Map<SparseMatrixCSR> M(mat_csr->m(),
+                                  mat_csr->m(),
+                                  mat_csr->numberOfNonzeros(),
+                                  mat_csr->i_row(),
+                                  mat_csr->j_col(),
+                                  mat_csr->M());
     
     PermutationMatrix P;
     Ordering ordering;
@@ -264,8 +264,8 @@ bool hiopLinSolverCholCuSparse::initial_setup()
                                             m,
                                             nnz_,
                                             mat_descr_,
-                                            mat_csr_->i_row(),
-                                            mat_csr_->j_col(),
+                                            mat_csr->i_row(),
+                                            mat_csr->j_col(),
                                             P_h,
                                             P_h,
                                             &buf_size);
@@ -279,8 +279,8 @@ bool hiopLinSolverCholCuSparse::initial_setup()
     int* colind_perm_h = new int[nnz_];
     assert(rowptr_perm_h);
     assert(colind_perm_h);
-    memcpy(rowptr_perm_h, mat_csr_->i_row(), (m+1)*sizeof(int));
-    memcpy(colind_perm_h, mat_csr_->j_col(), nnz_*sizeof(int));
+    memcpy(rowptr_perm_h, mat_csr->i_row(), (m+1)*sizeof(int));
+    memcpy(colind_perm_h, mat_csr->j_col(), nnz_*sizeof(int));
     
     //mapping (on host)
     int* map_h = new int[nnz_];
@@ -322,8 +322,8 @@ bool hiopLinSolverCholCuSparse::initial_setup()
     delete[] rowptr_perm_h;
 
   } else {
-    cudaMemcpy(rowptr_, mat_csr_->i_row(), (m+1)*sizeof(int), cudaMemcpyHostToDevice);
-    cudaMemcpy(colind_, mat_csr_->j_col(), nnz_*sizeof(int), cudaMemcpyHostToDevice);
+    cudaMemcpy(rowptr_, mat_csr->i_row(), (m+1)*sizeof(int), cudaMemcpyHostToDevice);
+    cudaMemcpy(colind_, mat_csr->j_col(), nnz_*sizeof(int), cudaMemcpyHostToDevice);
     
     int map_h[nnz_];
     for(int i=0; i<nnz_; i++) {
@@ -362,7 +362,7 @@ bool hiopLinSolverCholCuSparse::initial_setup()
 
   // TODO: this call as well as values_buf_ storage will be removed when the matrix is
   //going to reside on the device
-  cudaMemcpy(values_buf_, mat_csr_->M(), nnz_*sizeof(double), cudaMemcpyHostToDevice);
+  cudaMemcpy(values_buf_, mat_csr->M(), nnz_*sizeof(double), cudaMemcpyHostToDevice);
 
   // buffer size
   size_t internalData; // in BYTEs
@@ -391,9 +391,10 @@ bool hiopLinSolverCholCuSparse::initial_setup()
 /* returns -1 if zero or negative pivots are encountered */
 int hiopLinSolverCholCuSparse::matrixChanged()
 {
-  size_type m = mat_csr_->m();
-  assert(m == mat_csr_->n());
-  assert(nnz_ == mat_csr_->numberOfNonzeros());
+  auto* mat_csr = this->sys_mat_csr();
+  size_type m = mat_csr->m();
+  assert(m == mat_csr->n());
+  assert(nnz_ == mat_csr->numberOfNonzeros());
   cusolverStatus_t ret;
 
   hiopTimer t;
@@ -422,7 +423,7 @@ int hiopLinSolverCholCuSparse::matrixChanged()
   // TODO: this call as well as values_buf_ storage will be removed when the matrix is
   //going to reside on the device
   nlp_->runStats.linsolv.tmDeviceTransfer.start();
-  cudaMemcpy(values_buf_, mat_csr_->M(), nnz_*sizeof(double), cudaMemcpyHostToDevice);
+  cudaMemcpy(values_buf_, mat_csr->M(), nnz_*sizeof(double), cudaMemcpyHostToDevice);
   nlp_->runStats.linsolv.tmDeviceTransfer.stop();
  
   nlp_->runStats.linsolv.tmFactTime.start();
@@ -475,8 +476,8 @@ bool hiopLinSolverCholCuSparse::solve(hiopVector& x_in)
 {
   hiopTimer t;
   cusolverStatus_t ret;
-
-  int m = mat_csr_->m();
+  
+  int m = M_->m();
   assert(m == x_in.get_size());
 
   if(!rhs_buf1_) {

--- a/src/LinAlg/hiopLinSolverCholCuSparse.hpp
+++ b/src/LinAlg/hiopLinSolverCholCuSparse.hpp
@@ -76,7 +76,7 @@ namespace hiop
 class hiopLinSolverCholCuSparse: public hiopLinSolverSymSparse
 {
 public:
-  hiopLinSolverCholCuSparse(const size_type& n, const size_type& nnz, hiopNlpFormulation* nlp);
+  hiopLinSolverCholCuSparse(hiopMatrixSparseCSR* M, hiopNlpFormulation* nlp);
   virtual ~hiopLinSolverCholCuSparse();
 
   /**
@@ -91,10 +91,6 @@ public:
    */
   bool solve(hiopVector& x_in);
 
-  inline void set_linsys_mat(hiopMatrixSparseCSRSeq* mat)
-  {
-    mat_csr_ = mat;
-  }
 protected:
   /// performs initial analysis, sparsity permutation, and rescaling
   bool initial_setup();
@@ -150,11 +146,15 @@ protected:
   int* PT_;
   /// Permutation map for nonzeros (on device)
   int* map_nnz_perm_;
-  //TODO: temporary -> use the member matrix obj from the parent class
-  hiopMatrixSparseCSRSeq* mat_csr_;
   /// internal buffers in the size of the linear system (on device)
   double* rhs_buf1_;
   double* rhs_buf2_;
+  
+protected:
+  inline hiopMatrixSparseCSR* sys_mat_csr()
+  {
+    return dynamic_cast<hiopMatrixSparseCSR*>(M_);
+  }
 private:
   hiopLinSolverCholCuSparse() = delete; 
 };

--- a/src/Optimization/hiopDualsUpdater.cpp
+++ b/src/Optimization/hiopDualsUpdater.cpp
@@ -525,7 +525,7 @@ bool hiopDualsLsqUpdateLinsysAugSparse::do_lsq_update(hiopIterate& iter,
 
   t.reset();
   t.start();
-  hiopMatrixSparse& Msys = *(linSys->sysMatrix());
+  hiopMatrixSparse& Msys = *(linSys->sys_matrix());
   // update linSys system matrix
   {
     Msys.setToZero();

--- a/src/Optimization/hiopKKTLinSysSparse.cpp
+++ b/src/Optimization/hiopKKTLinSysSparse.cpp
@@ -107,7 +107,7 @@ namespace hiop
     auto* linSys = dynamic_cast<hiopLinSolverSymSparse*> (linSys_);
     assert(linSys);
 
-    auto* Msys = dynamic_cast<hiopMatrixSparseTriplet*>(linSys->sysMatrix());
+    auto* Msys = dynamic_cast<hiopMatrixSparseTriplet*>(linSys->sys_matrix());
     assert(Msys);
     
     if(perf_report_) {
@@ -404,7 +404,7 @@ namespace hiop
     auto* linSys = dynamic_cast<hiopLinSolverSymSparse*> (linSys_);
     assert(linSys);
 
-    auto* Msys = dynamic_cast<hiopMatrixSparseTriplet*>(linSys->sysMatrix());
+    auto* Msys = dynamic_cast<hiopMatrixSparseTriplet*>(linSys->sys_matrix());
     assert(Msys);
     if(perf_report_) {
       nlp_->log->printf(hovSummary,
@@ -821,7 +821,7 @@ namespace hiop
     auto* linSys = dynamic_cast<hiopLinSolverNonSymSparse*> (linSys_);
     assert(linSys);   
 
-    auto* Msys = dynamic_cast<hiopMatrixSparseTriplet*>(linSys->sysMatrix());
+    auto* Msys = dynamic_cast<hiopMatrixSparseTriplet*>(linSys->sys_matrix());
     assert(Msys);
     if(perf_report_) {
       nlp_->log->printf(hovSummary,

--- a/src/Optimization/hiopKKTLinSysSparseCondensed.cpp
+++ b/src/Optimization/hiopKKTLinSysSparseCondensed.cpp
@@ -217,7 +217,7 @@ bool hiopKKTLinSysCondensedSparse::build_kkt_matrix(const double& delta_wx_in,
     Diag.form_diag_from_symbolic(*Dx_);
 
     assert(nullptr == M_condensed_);
-    M_condensed_= M_condensed_tmp->add_matrix_alloc(Diag);
+    M_condensed_ = M_condensed_tmp->add_matrix_alloc(Diag);
     M_condensed_tmp->add_matrix_symbolic(*M_condensed_, Diag);
     delete M_condensed_tmp;
 

--- a/src/Optimization/hiopKKTLinSysSparseCondensed.cpp
+++ b/src/Optimization/hiopKKTLinSysSparseCondensed.cpp
@@ -140,9 +140,6 @@ bool hiopKKTLinSysCondensedSparse::build_kkt_matrix(const double& delta_wx_in,
   nlp_->runStats.kkt.tmUpdateInit.stop();
   nlp_->runStats.kkt.tmUpdateLinsys.start();
   
-#define USE_OLD_CODE 0
-#define USE_NEW_CODE 1  
-  
   //
   // compute condensed linear system J'*D*J + H + Dx + delta_wx*I
   //
@@ -192,8 +189,9 @@ bool hiopKKTLinSysCondensedSparse::build_kkt_matrix(const double& delta_wx_in,
 #ifdef HIOP_DEEPCHECKS
   JtDiagJ_->check_csr_is_ordered();
 #endif
-  
-  if(nullptr == M_condensed_) {
+
+  if(nullptr == linSys_) {
+    //first time this is called
     assert(nullptr == Hess_upper_csr_);
     Hess_upper_csr_ = new hiopMatrixSparseCSRSeq();
     Hess_upper_csr_->form_from_symbolic(*Hess_triplet);
@@ -218,13 +216,18 @@ bool hiopKKTLinSysCondensedSparse::build_kkt_matrix(const double& delta_wx_in,
     hiopMatrixSparseCSRSeq Diag;
     Diag.form_diag_from_symbolic(*Dx_);
 
-    M_condensed_ = M_condensed_tmp->add_matrix_alloc(Diag);
+    assert(nullptr == M_condensed_);
+    M_condensed_= M_condensed_tmp->add_matrix_alloc(Diag);
     M_condensed_tmp->add_matrix_symbolic(*M_condensed_, Diag);
     delete M_condensed_tmp;
 
     //t.stop(); printf("ADD-symb  took %.5f\n", t.getElapsedTime());
+  } else {
+    auto* lins_sys_sparse = dynamic_cast<hiopLinSolverSymSparse*>(linSys_);
+    assert(linSys_);
+    assert(M_condensed_);
+    //todo assert(M_condensed_ == linSys_->sys_matrix());
   }
-
 
   t.reset(); t.start();
   Hess_upper_csr_->form_from_numeric(*Hess_triplet);
@@ -238,17 +241,15 @@ bool hiopKKTLinSysCondensedSparse::build_kkt_matrix(const double& delta_wx_in,
   }
   M_condensed_->addDiagonal(1.0, *Dx_);
 
-  Hess_csr_->add_matrix_numeric(1.0, *M_condensed_, 1.0, *JtDiagJ_, 1.0);  
-  
+  Hess_csr_->add_matrix_numeric(1.0, *M_condensed_, 1.0, *JtDiagJ_, 1.0);
   //t.stop(); printf("ADD-nume  took %.5f\n", t.getElapsedTime());
+  
   int nnz_condensed = M_condensed_->numberOfNonzeros();
 
   //
   // linear system matrix update
   //
 
-  // TODO work directly with
-  // hiopMatrixSparseTriplet& Msys = linSys->sysMatrix();
   // TODO should have same code for different compute modes (remove is_cusolver_on)
   
   bool is_cusolver_on = nlp_->options->GetString("compute_mode") == "cpu" ? false : true;
@@ -262,13 +263,6 @@ bool hiopKKTLinSysCondensedSparse::build_kkt_matrix(const double& delta_wx_in,
 #endif  
   if(is_cusolver_on) {
     linSys_ = determine_and_create_linsys(nx, nineq, M_condensed_->numberOfNonzeros());
-
-#ifdef HIOP_USE_CUDA    
-    hiopLinSolverCholCuSparse* linSys_cusolver = dynamic_cast<hiopLinSolverCholCuSparse*>(linSys_);
-    assert(linSys_cusolver);
-    linSys_cusolver->set_linsys_mat(dynamic_cast<hiopMatrixSparseCSRSeq*>(M_condensed_));
-#endif    
-    
   } else {
     //compute mode cpu -> use update MA57 linear solver's matrix
     
@@ -289,7 +283,7 @@ bool hiopKKTLinSysCondensedSparse::build_kkt_matrix(const double& delta_wx_in,
 
     assert(linSys_);
     auto* linSys = dynamic_cast<hiopLinSolverSymSparse*> (linSys_);
-    auto* Msys = dynamic_cast<hiopMatrixSparseTriplet*>(linSys->sysMatrix());
+    auto* Msys = dynamic_cast<hiopMatrixSparseTriplet*>(linSys->sys_matrix());
     assert(Msys);
     assert(Msys->m() == M_condensed_->m());
 
@@ -472,8 +466,9 @@ hiopKKTLinSysCondensedSparse::determine_and_create_linsys(size_type nx, size_typ
 #ifdef HIOP_USE_CUDA
     nlp_->log->printf(hovWarning,
                       "KKT_SPARSE_Condensed linsys: alloc cuSOLVER-chol matrix size %d\n", n);
-    
-    linSys_ = new hiopLinSolverCholCuSparse(n, nnz, nlp_);
+    assert(M_condensed_);
+    linSys_ = new hiopLinSolverCholCuSparse(M_condensed_, nlp_);
+
 #endif    
     
     //Return NULL (and assert) if a GPU sparse linear solver is not present

--- a/src/Optimization/hiopKKTLinSysSparseCondensed.hpp
+++ b/src/Optimization/hiopKKTLinSysSparseCondensed.hpp
@@ -188,21 +188,6 @@ protected:
   /// Member for JacD'*Dd*JacD + H + Dx + delta_wx*I
   hiopMatrixSparseCSR* M_condensed_;
 
-  /**
-   * Maps indexes of the nonzeros in the union of the sparsity patterns of JacD'*Dd*JacD, H, and
-   * Dx + delta_wx*I, into the sorted CSR arrays of M_condensed_. Allows fast computation of
-   * the nonzeros of M_condensed_ from the nonzeros of JacD'*Dd*JacD, H, and
-   * Dx + delta_wx*I via add_matrices method. It is computed in add_matrices_init.
-   */
-  std::vector<index_type> map_idxs_in_sorted_;
-
-  /**
-   * Keeps the indexes of the nonzeros of the strictly lower triangle of H in the values array of H.
-   * It is built in add_matrices_init and reused in add_matrices to allow fast numerical computation
-   * of M_condensed_.
-   */
-  std::vector<index_type> map_H_lowtr_idxs_;
-
   /// Inertia correction perturbations used in the (last) factorization
   double delta_wx_;
 


### PR DESCRIPTION
Updates sparse linear solver interface to accommodate for cases  when it is more efficient to have the matrix class created by the KKT linear system. This occurs, for example, in condensed KKT with CSR storage, when the system matrix needs is created and computed prior to allocating the linear solver class.