### PR TITLE
Copy an empty vector from the end of another vector

### DIFF
--- a/src/LinAlg/hiopVectorPar.cpp
+++ b/src/LinAlg/hiopVectorPar.cpp
@@ -203,7 +203,7 @@ void hiopVectorPar::startingAtCopyFromStartingAt(int start_idx_dest,
 #endif
   assert((start_idx_dest>=0 && start_idx_dest<this->n_local_) || this->n_local_==0);
   const hiopVectorPar& v = dynamic_cast<const hiopVectorPar&>(v_in);
-  assert((start_idx_src>=0 && start_idx_src<v.n_local_) || v.n_local_==0);
+  assert((start_idx_src>=0 && start_idx_src<v.n_local_) || v.n_local_==0 || v.n_local_==start_idx_src);
 
   int howManyToCopy = this->n_local_ - start_idx_dest;
   const int howManyToCopySrc = v.n_local_-start_idx_src;

--- a/src/LinAlg/hiopVectorRajaPar.cpp
+++ b/src/LinAlg/hiopVectorRajaPar.cpp
@@ -452,9 +452,9 @@ void hiopVectorRajaPar::startingAtCopyFromStartingAt(
 #ifdef HIOP_DEEPCHECKS
   assert(n_local_ == n_ && "are you sure you want to call this?");
 #endif
-  assert(start_idx_dest >= 0 && start_idx_dest < this->n_local_);
+  assert(start_idx_dest >= 0 && start_idx_dest < this->n_local_ || this->n_local_==0);
   const hiopVectorRajaPar& v = dynamic_cast<const hiopVectorRajaPar&>(vec_src);
-  assert(start_idx_src >=0 && start_idx_src < v.n_local_);
+  assert(start_idx_src >=0 && start_idx_src < v.n_local_ || v.n_local_==0 || v.n_local_==start_idx_src);
 
   int howManyToCopyDest = this->n_local_ - start_idx_dest;
 

--- a/src/LinAlg/hiopVectorRajaPar.cpp
+++ b/src/LinAlg/hiopVectorRajaPar.cpp
@@ -452,9 +452,9 @@ void hiopVectorRajaPar::startingAtCopyFromStartingAt(
 #ifdef HIOP_DEEPCHECKS
   assert(n_local_ == n_ && "are you sure you want to call this?");
 #endif
-  assert(start_idx_dest >= 0 && start_idx_dest < this->n_local_ || this->n_local_==0);
+  assert((start_idx_dest >= 0 && start_idx_dest < this->n_local_) || this->n_local_==0);
   const hiopVectorRajaPar& v = dynamic_cast<const hiopVectorRajaPar&>(vec_src);
-  assert(start_idx_src >=0 && start_idx_src < v.n_local_ || v.n_local_==0 || v.n_local_==start_idx_src);
+  assert((start_idx_src >=0 && start_idx_src < v.n_local_) || v.n_local_==0 || v.n_local_==start_idx_src);
 
   int howManyToCopyDest = this->n_local_ - start_idx_dest;
 


### PR DESCRIPTION
Fix an incorrect assert conditions that occurs copying an empty vector from the end of another vector.
For example, the assert happens in the following sequence:
```
vec1.get_local_size()=0
vec2.get_local_size()=15

vec1.startingAtCopyFromStartingAt(0,vec2,15)
```
