### PR TITLE
Add support to sparse linear system in the formulation of normal equation

### DIFF
--- a/src/Drivers/Sparse/NlpSparseEx3.cpp
+++ b/src/Drivers/Sparse/NlpSparseEx3.cpp
@@ -53,6 +53,12 @@ SparseEx3::SparseEx3(int n, double scala_a, bool eq_feas, bool eq_infeas, bool i
 SparseEx3::~SparseEx3()
 {}
 
+bool SparseEx3::get_prob_info(NonlinearityType& type)
+{
+  type = hiopInterfaceBase::hiopLinear;
+  return true;
+}
+
 bool SparseEx3::get_prob_sizes(size_type& n, size_type& m)
 { 
   n = n_vars_;
@@ -66,7 +72,7 @@ bool SparseEx3::get_vars_info(const size_type& n, double *xlow, double* xupp, No
   for(index_type i=0; i<n; i++) {
     xlow[i] = 0.0;
     xupp[i] = 1e20;
-    type[i] = hiopNonlinear; 
+    type[i] = hiopInterfaceBase::hiopLinear; 
   }
   return true;
 }

--- a/src/Drivers/Sparse/NlpSparseEx3.hpp
+++ b/src/Drivers/Sparse/NlpSparseEx3.hpp
@@ -30,6 +30,7 @@ public:
   virtual ~SparseEx3();
 
   virtual bool get_prob_sizes(size_type& n, size_type& m);
+  virtual bool get_prob_info(NonlinearityType& type);
   virtual bool get_vars_info(const size_type& n, double *xlow, double* xupp, NonlinearityType* type);
   virtual bool get_cons_info(const size_type& m, double* clow, double* cupp, NonlinearityType* type);
   

--- a/src/Interface/hiopInterface.hpp
+++ b/src/Interface/hiopInterface.hpp
@@ -146,7 +146,15 @@ public:
    * @param m number of constraints
    */
   virtual bool get_prob_sizes(size_type& n, size_type& m)=0;
-  
+
+  /** Specifies the type of optimization problem
+   * @param[out] type indicating whether the optimization problem is
+   *                  linearily, quadratically, or general nonlinearily.
+   * TODO: need to `deepcheck` is this return value matches the returned type array from 
+   * `get_vars_info` and `get_cons_info`
+   */
+  virtual bool get_prob_info(NonlinearityType& type) { type = hiopInterfaceBase::hiopNonlinear; return true;}
+
   /** Specifies bounds on the variables.
    *    
    * @param[in] n global number of constraints

--- a/src/LinAlg/hiopMatrixRajaSparseTriplet.cpp
+++ b/src/LinAlg/hiopMatrixRajaSparseTriplet.cpp
@@ -1823,17 +1823,21 @@ bool hiopMatrixRajaSparseTriplet::is_diagonal() const
     return bret;
   }
 
+  // local copy of member variable/function, for RAJA access
+  index_type* iRow = iRow_;
+  index_type* jCol = jCol_;
+
   RAJA::ReduceSum<hiop_raja_reduce, int> sum_no_diag(0);
   RAJA::forall<hiop_raja_exec>(
     RAJA::RangeSegment(0, nnz_),
     RAJA_LAMBDA(RAJA::Index_type i)
     {
-      if (irow[i]!=jcol[i]) {
+      if (iRow[i]!=jCol[i]) {
         sum_no_diag += 1; 
       }
     }
   );
-  bret = ((sum.get())==0);
+  bret = ((sum_no_diag.get())==0);
   
   return bret;
 }

--- a/src/LinAlg/hiopMatrixRajaSparseTriplet.cpp
+++ b/src/LinAlg/hiopMatrixRajaSparseTriplet.cpp
@@ -1814,6 +1814,30 @@ void hiopMatrixRajaSparseTriplet::copyDiagMatrixToSubblock_w_pattern(const hiopV
   devalloc.deallocate(row_start_dev);
 }
 
+bool hiopMatrixRajaSparseTriplet::is_diagonal() const
+{
+  bool bret{false};
+  
+  if(ncols_ != nrows_) {
+    bret = false;
+    return bret;
+  }
+
+  RAJA::ReduceSum<hiop_raja_reduce, int> sum_no_diag(0);
+  RAJA::forall<hiop_raja_exec>(
+    RAJA::RangeSegment(0, nnz_),
+    RAJA_LAMBDA(RAJA::Index_type i)
+    {
+      if (irow[i]!=jcol[i]) {
+        sum_no_diag += 1; 
+      }
+    }
+  );
+  bret = ((sum.get())==0);
+  
+  return bret;
+}
+
 /**********************************************************************************
   * Sparse symmetric matrix in triplet format. Only the UPPER triangle is stored
   **********************************************************************************/

--- a/src/LinAlg/hiopMatrixRajaSparseTriplet.hpp
+++ b/src/LinAlg/hiopMatrixRajaSparseTriplet.hpp
@@ -440,18 +440,13 @@ public:
 #ifdef HIOP_DEEPCHECKS
   virtual bool assertSymmetry(double tol=1e-16) const { return true; }
 #endif
-  virtual bool isDiagonal() const 
+  virtual bool is_diagonal() const;
+
+  virtual void extract_diagonal(hiopVector& diag_out) const
   {
-    for(int itnnz = 0; itnnz < nnz_; itnnz++)
-    {
-      if(iRow_[itnnz] != jCol_[itnnz])
-      {
-        return false;
-      }
-    }
-    return true;
+    assert(false && "not yet implemented");
   }
-  
+
   virtual size_type numberOfOffDiagNonzeros() const;
 
   virtual void set_Jac_FR(const hiopMatrixSparse& Jac_c,

--- a/src/LinAlg/hiopMatrixRajaSparseTriplet.hpp
+++ b/src/LinAlg/hiopMatrixRajaSparseTriplet.hpp
@@ -304,6 +304,13 @@ public:
                             int **index_covert_CSR2Triplet,
                             int **index_covert_extra_Diag2CSR) {assert(0 && "not implemented");}
 
+  virtual bool is_diagonal() const;
+
+  virtual void extract_diagonal(hiopVector& diag_out) const
+  {
+    assert(false && "not yet implemented");
+  }
+
   virtual size_type numberOfOffDiagNonzeros() const {assert("not implemented"&&0);return 0;};
 
   virtual void set_Jac_FR(const hiopMatrixSparse& Jac_c,
@@ -440,7 +447,6 @@ public:
 #ifdef HIOP_DEEPCHECKS
   virtual bool assertSymmetry(double tol=1e-16) const { return true; }
 #endif
-  virtual bool is_diagonal() const;
 
   virtual void extract_diagonal(hiopVector& diag_out) const
   {

--- a/src/LinAlg/hiopMatrixSparse.hpp
+++ b/src/LinAlg/hiopMatrixSparse.hpp
@@ -369,6 +369,10 @@ public:
     return nnz_;
   }
 
+  virtual bool is_diagonal() const = 0;
+
+  virtual void extract_diagonal(hiopVector& diag_out) const = 0;
+
 #ifdef HIOP_DEEPCHECKS
   virtual bool assertSymmetry(double tol = 1e-16) const
   {

--- a/src/LinAlg/hiopMatrixSparseCSRCUDA.hpp
+++ b/src/LinAlg/hiopMatrixSparseCSRCUDA.hpp
@@ -305,6 +305,12 @@ public:
     return 0;
   }
 
+  virtual bool is_diagonal() const;
+  {
+    assert(false && "not yet implemented");
+    return false;
+  }
+
   /// @brief extend base problem Jac to the Jac in feasibility problem
   virtual void set_Jac_FR(const hiopMatrixSparse& Jac_c,
                           const hiopMatrixSparse& Jac_d,

--- a/src/LinAlg/hiopMatrixSparseCSRCUDA.hpp
+++ b/src/LinAlg/hiopMatrixSparseCSRCUDA.hpp
@@ -305,7 +305,7 @@ public:
     return 0;
   }
 
-  virtual bool is_diagonal() const;
+  virtual bool is_diagonal() const
   {
     assert(false && "not yet implemented");
     return false;

--- a/src/LinAlg/hiopMatrixSparseCSRSeq.cpp
+++ b/src/LinAlg/hiopMatrixSparseCSRSeq.cpp
@@ -248,8 +248,18 @@ void hiopMatrixSparseCSRSeq::addDiagonal(const double& alpha, const hiopVector& 
 
 void hiopMatrixSparseCSRSeq::addDiagonal(const double& value)
 {
-  assert(false && "not needed");
+  assert(irowptr_ && jcolind_ && values_);
+  
+  for(index_type i=0; i<nrows_; ++i) {
+    for(index_type pt=irowptr_[i]; pt<irowptr_[i+1]; ++pt) {
+      if(jcolind_[pt]==i) {
+        values_[pt] += value;
+        break;
+      }
+    }
+  }
 }
+
 void hiopMatrixSparseCSRSeq::addSubDiagonal(const double& alpha, index_type start, const hiopVector& d_)
 {
   assert(false && "not needed");
@@ -342,7 +352,12 @@ hiopMatrixSparse* hiopMatrixSparseCSRSeq::new_copy() const
 }
 void hiopMatrixSparseCSRSeq::copyFrom(const hiopMatrixSparse& dm)
 {
-  assert(false && "to be implemented - method def too vague for now");
+  assert(nnz_==dm.numberOfNonzeros() && nrows_==dm.m());
+  const hiopMatrixSparseCSRSeq& src = dynamic_cast<const hiopMatrixSparseCSRSeq&>(dm);
+  
+  memcpy(irowptr_, src.irowptr_, (nrows_+1)*sizeof(index_type));
+  memcpy(jcolind_, src.jcolind_, nnz_*sizeof(index_type));
+  memcpy(values_, src.values_, nnz_*sizeof(double));
 }
 
 /// @brief copy to 3 arrays.

--- a/src/LinAlg/hiopMatrixSparseCSRSeq.hpp
+++ b/src/LinAlg/hiopMatrixSparseCSRSeq.hpp
@@ -303,6 +303,12 @@ public:
     return 0;
   }
 
+  virtual bool is_diagonal() const
+  {
+    assert(false && "not yet implemented");
+    return false;
+  }
+
   /// @brief extend base problem Jac to the Jac in feasibility problem
   virtual void set_Jac_FR(const hiopMatrixSparse& Jac_c,
                           const hiopMatrixSparse& Jac_d,

--- a/src/LinAlg/hiopMatrixSparseTriplet.cpp
+++ b/src/LinAlg/hiopMatrixSparseTriplet.cpp
@@ -1369,6 +1369,7 @@ void hiopMatrixSparseTriplet::extract_diagonal(hiopVector& diag_out) const
   hiopVectorPar& vec = dynamic_cast<hiopVectorPar&>(diag_out);
   double* v_data = vec.local_data();
   
+  vec.setToZero();
   for(index_type itnnz=0; itnnz<nnz_; itnnz++) {
     if(iRow_[itnnz]==jCol_[itnnz]) {
       v_data[iRow_[itnnz]] = values_[itnnz];

--- a/src/LinAlg/hiopMatrixSparseTriplet.hpp
+++ b/src/LinAlg/hiopMatrixSparseTriplet.hpp
@@ -251,6 +251,21 @@ public:
                             int **index_covert_extra_Diag2CSR,
                             std::unordered_map<int,int> &extra_diag_nnz_map);
 
+  /* @brief sort the nonzeros from index `first` to `last`, by row and then by column.
+  *  @pre assuming there is no duplicate nonzero element
+  *  @remark member variables irow_, jcol_ and values_ will be recomputed 
+  */
+  virtual void sort();
+
+  /* @brief check if `this` matrix is a diagonal matrix
+  */
+  virtual bool is_diagonal() const;
+
+  /* @brief extract the diagonals to vector `diag_out`
+  *  @pre assuming `this` matrix is sorted by row and then by column
+  */
+  virtual void extract_diagonal(hiopVector& diag_out) const;
+
   virtual size_type numberOfOffDiagNonzeros() const {assert("not implemented"&&0);return 0;};
 
   /// @brief extend base problem Jac to the Jac in feasibility problem
@@ -277,7 +292,6 @@ public:
   inline const int* i_row() const { return iRow_; }
   inline const int* j_col() const { return jCol_; }
   inline const double* M() const { return values_; }
-
 
 #ifdef HIOP_DEEPCHECKS
   virtual bool assertSymmetry(double tol=1e-16) const { return false; }
@@ -364,11 +378,6 @@ public:
 #ifdef HIOP_DEEPCHECKS
   virtual bool assertSymmetry(double tol=1e-16) const { return true; }
 #endif
-  virtual bool isDiagonal() const
-  {
-    for(int itnnz=0; itnnz<nnz_; itnnz++) if(iRow_[itnnz]!=jCol_[itnnz]) return false;
-    return true;
-  }
 
   virtual size_type numberOfOffDiagNonzeros() const;
 

--- a/src/Optimization/CMakeLists.txt
+++ b/src/Optimization/CMakeLists.txt
@@ -17,6 +17,7 @@ set(hiopOptimization_SRC
 set(hiopOptimization_SPARSE_SRC
   hiopKKTLinSysSparse.cpp
   hiopKKTLinSysSparseCondensed.cpp
+  hiopKKTLinSysSparseNormalEqn.cpp
   )
 
 set(hiopOptimization_INTERFACE_HEADERS
@@ -32,6 +33,7 @@ set(hiopOptimization_INTERFACE_HEADERS
   hiopKKTLinSysMDS.hpp
   hiopKKTLinSysSparse.hpp
   hiopKKTLinSysSparseCondensed.hpp
+  hiopKKTLinSysSparseNormalEqn.hpp
   hiopLogBarProblem.hpp
   hiopNlpFormulation.hpp
   hiopNlpTransforms.hpp

--- a/src/Optimization/hiopAlgFilterIPM.cpp
+++ b/src/Optimization/hiopAlgFilterIPM.cpp
@@ -60,6 +60,8 @@
 #include "hiopKKTLinSysMDS.hpp"
 #include "hiopKKTLinSysSparse.hpp"
 #include "hiopKKTLinSysSparseCondensed.hpp"
+#include "hiopKKTLinSysSparseNormalEqn.hpp"
+
 #include "hiopFRProb.hpp"
 
 #include "hiopCppStdUtils.hpp"
@@ -1429,17 +1431,15 @@ hiopKKTLinSys* hiopAlgFilterIPMNewton::decideAndCreateLinearSystem(hiopNlpFormul
       std::string strKKT = nlp->options->GetString("KKTLinsys");
       if(strKKT == "full") {
         return new hiopKKTLinSysSparseFull(nlp);
+      } else if(strKKT == "xdycyd") {
+        return new hiopKKTLinSysCompressedSparseXDYcYd(nlp);
+      } else if(strKKT == "condensed") {
+        return new hiopKKTLinSysCondensedSparse(nlp);
+      } else if(strKKT == "normaleqn") {
+        return new hiopKKTLinSysSparseNormalEqn(nlp);
       } else {
-        if(strKKT == "xdycyd") {
-          return new hiopKKTLinSysCompressedSparseXDYcYd(nlp);
-        } else {
-          if(strKKT == "condensed") {
-            return new hiopKKTLinSysCondensedSparse(nlp);
-          } else {
-            //'auto' or 'XYcYd'
-            return new hiopKKTLinSysCompressedSparseXYcYd(nlp);
-          }
-        }
+        //'auto' or 'XYcYd'
+        return new hiopKKTLinSysCompressedSparseXYcYd(nlp);
       }
 #endif
     }

--- a/src/Optimization/hiopFRProb.cpp
+++ b/src/Optimization/hiopFRProb.cpp
@@ -171,6 +171,15 @@ bool hiopFRProbSparse::get_prob_sizes(size_type& n, size_type& m)
   return true;
 }
 
+bool hiopFRProbSparse::get_prob_info(NonlinearityType& type)
+{
+  // the objective of FR problem is quadratic. constraint c(x) depends on the origianl problem
+  if(nlp_base_->get_prob_type() != hiopNonlinear) {
+    type = hiopQuadratic;
+  }
+  return true;
+}
+
 bool hiopFRProbSparse::get_vars_info(const size_type& n, double *xlow, double* xupp, NonlinearityType* type)
 {
   assert(n == n_);
@@ -787,6 +796,15 @@ bool hiopFRProbMDS::get_prob_sizes(size_type& n, size_type& m)
 {
   n = n_;
   m = m_;
+  return true;
+}
+
+bool hiopFRProbMDS::get_prob_info(NonlinearityType& type)
+{
+  // the objective of FR problem is quadratic. constraint c(x) depends on the origianl problem
+  if(nlp_base_->get_prob_type() != hiopNonlinear) {
+    type = hiopQuadratic;
+  }
   return true;
 }
 

--- a/src/Optimization/hiopFRProb.hpp
+++ b/src/Optimization/hiopFRProb.hpp
@@ -85,6 +85,7 @@ public:
   virtual bool get_MPI_comm(MPI_Comm& comm_out);
 
   virtual bool get_prob_sizes(size_type& n, size_type& m);
+  virtual bool get_prob_info(NonlinearityType& type);
   virtual bool get_vars_info(const size_type& n, double *xlow, double* xupp, NonlinearityType* type);
   virtual bool get_cons_info(const size_type& m, double* clow, double* cupp, NonlinearityType* type);
   virtual bool get_sparse_blocks_info(int& nx,
@@ -287,6 +288,7 @@ public:
                               double* MHSD);
 
   virtual bool get_prob_sizes(size_type& n, size_type& m);
+  virtual bool get_prob_info(NonlinearityType& type);
   virtual bool get_vars_info(const size_type& n, double *xlow, double* xupp, NonlinearityType* type);
   virtual bool get_cons_info(const size_type& m, double* clow, double* cupp, NonlinearityType* type);
 

--- a/src/Optimization/hiopIterate.hpp
+++ b/src/Optimization/hiopIterate.hpp
@@ -173,6 +173,7 @@ public:
   friend class hiopKKTLinSysCompressedSparseXDYcYd;
   friend class hiopKKTLinSysFull;
   friend class hiopKKTLinSysSparseFull;
+  friend class hiopKKTLinSysNormalEquation;
 
 private:
   /** Primal variables */

--- a/src/Optimization/hiopKKTLinSys.cpp
+++ b/src/Optimization/hiopKKTLinSys.cpp
@@ -2200,8 +2200,8 @@ bool hiopKKTLinSysNormalEquation::computeDirections(const hiopResidual* resid, h
   *   [dd] = [ Dd+delta_wd ]^{-1}   ( [ rd_tilde ] - [dyd] ) 
   */
   dir->x->copyFrom(*rx_tilde_);
-  Jac_c_->transTimesVec(1.0, *rx_tilde_, -1.0, *dir->yc);
-  Jac_d_->transTimesVec(1.0, *rx_tilde_, -1.0, *dir->yd);
+  Jac_c_->transTimesVec(1.0, *dir->x, -1.0, *dir->yc);
+  Jac_d_->transTimesVec(1.0, *dir->x, -1.0, *dir->yd);
   dir->x->componentMult(*Hx_inv_);
 
   dir->d->copyFrom(*rd_tilde_);

--- a/src/Optimization/hiopKKTLinSys.hpp
+++ b/src/Optimization/hiopKKTLinSys.hpp
@@ -548,6 +548,72 @@ protected:
 
 };
 
+/** 
+ * @brief Provides the functionality for reducing the KKT linear system to the
+ * normal equation system below in dyc and dyd variables and then to perform
+ * the basic ops needed to compute the remaining directions
+ *
+ * Relies on the pure virtual 'solveCompressed' to form and solve the compressed
+ * linear system
+ * [ Jc  0 ] [ H + Dx   0 ]^{-1} [ Jc^T  Jd^T]  [dyc] = [   ryc_tilde    ]
+ * [ Jd -I ] [   0     Dd ]      [  0     -I ]  [dyd]   [   ryd_tilde    ]
+ *
+ * [ ryc_tilde ] = [ Jc  0 ] [ H+Dx+delta_wx     0       ]^{-1}  [ rx_tilde ] - [ ryc ] 
+ * [ ryd_tilde ]   [ Jd -I ] [   0           Dd+delta_wd ]       [ rd_tilde ]   [ ryd ]
+ * 
+ * and then to compute the rest of the search directions from
+ * [ H+Dx+delta_wx     0       ] [dx] = [ rx_tilde ] - [ Jc^T  Jd^T] [dyc]
+ * [   0           Dd+delta_wd ] [dd]   [ rd_tilde ]   [  0     -I ] [dyd]
+ * 
+ */
+class hiopKKTLinSysNormalEquation : public hiopKKTLinSysCompressed
+{
+public:
+  hiopKKTLinSysNormalEquation(hiopNlpFormulation* nlp);
+  virtual ~hiopKKTLinSysNormalEquation();
+
+  virtual bool update(const hiopIterate* iter, 
+                      const hiopVector* grad_f, 
+                      const hiopMatrix* Jac_c,
+                      const hiopMatrix* Jac_d,
+                      hiopMatrix* Hess);
+
+  virtual bool computeDirections(const hiopResidual* resid, hiopIterate* direction);
+
+  virtual bool build_kkt_matrix(const double& delta_wx,
+                                const double& delta_wd,
+                                const double& delta_cc,
+                                const double& delta_cd) = 0;
+
+  virtual bool solveCompressed(hiopVector& ryc_tilde,
+                               hiopVector& ryd_tilde,
+                               hiopVector& dyc,
+                               hiopVector& dyd) = 0;
+
+  /**
+   * @brief factorize the matrix and check curvature
+   */ 
+  virtual int factorizeWithCurvCheck() = 0;
+
+protected:
+  hiopVector* rd_tilde_;
+  hiopVector* ryc_tilde_;
+  hiopVector* ryd_tilde_;
+
+  // Keeps Hx = Dx (Dx=log-barrier diagonal for x) + regularization + diagOf(Hess)
+  // Keeps Hd = Dd (Dd=log-barrier diagonal for slack variable) + regularization
+  // Hx_inv_ = (Hx)^{-1}
+  // Hd_inv_ = (Hd)^{-1}
+  hiopVector *Hx_inv_;
+  hiopVector *Hd_inv_;
+  
+  // diagOf(Hess)
+  hiopVector *Hess_diag_;
+
+  hiopVector *x_wrk_;
+  hiopVector *d_wrk_;
+};
+
 
 /** 
  * operators for KKT mat-vec operations

--- a/src/Optimization/hiopKKTLinSys.hpp
+++ b/src/Optimization/hiopKKTLinSys.hpp
@@ -600,15 +600,8 @@ protected:
   hiopVector* ryc_tilde_;
   hiopVector* ryd_tilde_;
 
-  // Keeps Hx = Dx (Dx=log-barrier diagonal for x) + regularization + diagOf(Hess)
-  // Keeps Hd = Dd (Dd=log-barrier diagonal for slack variable) + regularization
-  // Hx_inv_ = (Hx)^{-1}
-  // Hd_inv_ = (Hd)^{-1}
-  hiopVector *Hx_inv_;
-  hiopVector *Hd_inv_;
-  
-  // diagOf(Hess)
-  hiopVector *Hess_diag_;
+  hiopVector* Hx_;  // [diag(H)+Dx+delta_wx]
+  hiopVector* Hd_;  // [Dd+delta_wd ]
 
   hiopVector *x_wrk_;
   hiopVector *d_wrk_;

--- a/src/Optimization/hiopKKTLinSysSparseCondensed.cpp
+++ b/src/Optimization/hiopKKTLinSysSparseCondensed.cpp
@@ -479,7 +479,7 @@ hiopKKTLinSysCondensedSparse::determine_and_create_linsys(size_type nx, size_typ
            "device as instructed by the 'compute_mode' option. Change the 'compute_mode' to 'cpu'");
   }
   
-  assert(linSys_&& "KKT_SPARSE_XYcYd linsys: cannot instantiate backend linear solver");
+  assert(linSys_&& "KKT_SPARSE_Condensed linsys: cannot instantiate backend linear solver");
   return dynamic_cast<hiopLinSolverSymSparse*> (linSys_);
 }
 

--- a/src/Optimization/hiopKKTLinSysSparseNormalEqn.cpp
+++ b/src/Optimization/hiopKKTLinSysSparseNormalEqn.cpp
@@ -54,7 +54,7 @@
 
 #include "hiopKKTLinSysSparseNormalEqn.hpp"
 #ifdef HIOP_USE_COINHSL
-#include "hiopLinSolverIndefSparseMA57.hpp"
+#include "hiopLinSolverSymSparseMA57.hpp"
 #endif
 
 #ifdef HIOP_USE_CUDA
@@ -275,7 +275,7 @@ bool hiopKKTLinSysSparseNormalEqn::build_kkt_matrix(const double& delta_wx_in,
   }
 
   {
-    hiopLinSolverIndefSparseMA57* linSolver_ma57 = dynamic_cast<hiopLinSolverIndefSparseMA57*>(linSys_);
+    hiopLinSolverSymSparseMA57* linSolver_ma57 = dynamic_cast<hiopLinSolverSymSparseMA57*>(linSys_);
     if(linSolver_ma57) {
       auto* linSys = dynamic_cast<hiopLinSolverSymSparse*> (linSys_);
       auto* Msys = dynamic_cast<hiopMatrixSparseTriplet*>(linSys->sys_matrix());
@@ -339,7 +339,7 @@ hiopLinSolverSymSparse* hiopKKTLinSysSparseNormalEqn::determine_and_create_linsy
         }
       }
     }
-    linSys_ = new hiopLinSolverIndefSparseMA57(n, itnz, nlp_);
+    linSys_ = new hiopLinSolverSymSparseMA57(n, itnz, nlp_);
 #else
     assert(false && "HiOp was built without a sparse linear solver needed by the condensed KKT approach");
 #endif // HIOP_USE_COINHSL

--- a/src/Optimization/hiopKKTLinSysSparseNormalEqn.cpp
+++ b/src/Optimization/hiopKKTLinSysSparseNormalEqn.cpp
@@ -73,9 +73,8 @@ hiopKKTLinSysSparseNormalEqn::hiopKKTLinSysSparseNormalEqn(hiopNlpFormulation* n
     Jac_cSp_{nullptr},
     Jac_dSp_{nullptr},
     rhs_{nullptr},
+    Hess_diag_{nullptr},
     Hxd_inv_{nullptr},
-    Hx_{nullptr},
-    Hd_{nullptr},
     JacD_{nullptr},
     JacDt_{nullptr},
     DiagJt_{nullptr},
@@ -92,9 +91,8 @@ hiopKKTLinSysSparseNormalEqn::hiopKKTLinSysSparseNormalEqn(hiopNlpFormulation* n
 hiopKKTLinSysSparseNormalEqn::~hiopKKTLinSysSparseNormalEqn()
 {
   delete rhs_;
+  delete Hess_diag_;
   delete Hxd_inv_;
-  delete Hx_;
-  delete Hd_;
   delete JacD_;
   delete JacDt_;
   delete DiagJt_;
@@ -158,16 +156,12 @@ bool hiopKKTLinSysSparseNormalEqn::build_kkt_matrix(const double& delta_wx_in,
   Hx_->copyFrom(*Dx_);
   Hx_->addConstant(delta_wx_in);
   Hx_->axpy(1.0,*Hess_diag_);
-  Hx_inv_->copyFrom(*Hx_);
-  Hx_inv_->invert();  
     
   if(nullptr == Hd_) {
     Hd_ = LinearAlgebraFactory::create_vector(nlp_->options->GetString("mem_space"), nineq);
   }
   Hd_->copyFrom(*Dd_);  
   Hd_->addConstant(delta_wd_in);
-  Hd_inv_->copyFrom(*Hd_);
-  Hd_inv_->invert();
 
   nlp_->runStats.kkt.tmUpdateInit.stop();
   nlp_->runStats.kkt.tmUpdateLinsys.start();

--- a/src/Optimization/hiopKKTLinSysSparseNormalEqn.cpp
+++ b/src/Optimization/hiopKKTLinSysSparseNormalEqn.cpp
@@ -1,0 +1,442 @@
+// Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory (LLNL).
+// LLNL-CODE-742473. All rights reserved.
+//
+// This file is part of HiOp. For details, see https://github.com/LLNL/hiop. HiOp
+// is released under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause).
+// Please also read "Additional BSD Notice" below.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+// i. Redistributions of source code must retain the above copyright notice, this list
+// of conditions and the disclaimer below.
+// ii. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the disclaimer (as noted below) in the documentation and/or
+// other materials provided with the distribution.
+// iii. Neither the name of the LLNS/LLNL nor the names of its contributors may be used to
+// endorse or promote products derived from this software without specific prior written
+// permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+// OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+// SHALL LAWRENCE LIVERMORE NATIONAL SECURITY, LLC, THE U.S. DEPARTMENT OF ENERGY OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+// OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+// AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+// EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Additional BSD Notice
+// 1. This notice is required to be provided under our contract with the U.S. Department
+// of Energy (DOE). This work was produced at Lawrence Livermore National Laboratory under
+// Contract No. DE-AC52-07NA27344 with the DOE.
+// 2. Neither the United States Government nor Lawrence Livermore National Security, LLC
+// nor any of their employees, makes any warranty, express or implied, or assumes any
+// liability or responsibility for the accuracy, completeness, or usefulness of any
+// information, apparatus, product, or process disclosed, or represents that its use would
+// not infringe privately-owned rights.
+// 3. Also, reference herein to any specific commercial products, process, or services by
+// trade name, trademark, manufacturer or otherwise does not necessarily constitute or
+// imply its endorsement, recommendation, or favoring by the United States Government or
+// Lawrence Livermore National Security, LLC. The views and opinions of authors expressed
+// herein do not necessarily state or reflect those of the United States Government or
+// Lawrence Livermore National Security, LLC, and shall not be used for advertising or
+// product endorsement purposes.
+
+/**
+ * @file hiopKKTLinSysSparseNormalEqn.cpp
+ *
+ * @author Cosmin G. Petra <petra1@llnl.gov>, LLNL
+ * @author Nai-Yuan Chiang <chiang7@llnl.gov>, LLNL
+ */
+
+#include "hiopKKTLinSysSparseNormalEqn.hpp"
+#ifdef HIOP_USE_COINHSL
+#include "hiopLinSolverIndefSparseMA57.hpp"
+#endif
+
+#ifdef HIOP_USE_CUDA
+#include "hiopLinSolverCholCuSparse.hpp"
+#endif
+
+#include "hiopMatrixSparseCSRSeq.hpp"
+
+namespace hiop
+{
+ 
+hiopKKTLinSysSparseNormalEqn::hiopKKTLinSysSparseNormalEqn(hiopNlpFormulation* nlp)
+  : hiopKKTLinSysNormalEquation(nlp),
+    nlpSp_{nullptr},
+    HessSp_{nullptr},
+    Jac_cSp_{nullptr},
+    Jac_dSp_{nullptr},
+    rhs_{nullptr},
+    Hxd_inv_{nullptr},
+    Hx_{nullptr},
+    Hd_{nullptr},
+    JacD_{nullptr},
+    JacDt_{nullptr},
+    DiagJt_{nullptr},
+    JDiagJt_{nullptr},
+    Diag_reg_{nullptr},
+    M_normaleqn_{nullptr},
+    write_linsys_counter_(-1),
+    csr_writer_(nlp)
+{
+  nlpSp_ = dynamic_cast<hiopNlpSparse*>(nlp_);
+  assert(nlpSp_);
+}
+
+hiopKKTLinSysSparseNormalEqn::~hiopKKTLinSysSparseNormalEqn()
+{
+  delete rhs_;
+  delete Hxd_inv_;
+  delete Hx_;
+  delete Hd_;
+  delete JacD_;
+  delete JacDt_;
+  delete DiagJt_;
+  delete JDiagJt_;
+  delete Diag_reg_;
+  delete M_normaleqn_;
+}
+
+bool hiopKKTLinSysSparseNormalEqn::build_kkt_matrix(const double& delta_wx_in,
+                                                    const double& delta_wd_in,
+                                                    const double& delta_cc_in,
+                                                    const double& delta_cd_in)
+{
+  assert(delta_cc_in == delta_cd_in);
+  auto delta_cc = delta_cc_in;
+   
+  HessSp_ = dynamic_cast<hiopMatrixSparse*>(Hess_);
+  if(!HessSp_) { assert(false); return false; }
+
+  Jac_cSp_ = dynamic_cast<const hiopMatrixSparse*>(Jac_c_);
+  if(!Jac_cSp_) { assert(false); return false; }
+
+  Jac_dSp_ = dynamic_cast<const hiopMatrixSparse*>(Jac_d_);
+  if(!Jac_dSp_) { assert(false); return false; }
+
+  nlp_->runStats.kkt.tmUpdateInit.start();
+
+  /* TODO: here we assume Hess is diagonal!*/
+  assert(HessSp_->is_diagonal());
+  
+  hiopMatrixSymSparseTriplet* Hess_triplet = dynamic_cast<hiopMatrixSymSparseTriplet*>(Hess_);
+  const hiopMatrixSparseTriplet* Jac_c_triplet = dynamic_cast<const hiopMatrixSparseTriplet*>(Jac_c_);
+  const hiopMatrixSparseTriplet* Jac_d_triplet = dynamic_cast<const hiopMatrixSparseTriplet*>(Jac_d_);
+  
+  assert(HessSp_ && Jac_cSp_ && Jac_dSp_);
+  if(nullptr==Jac_dSp_ || nullptr==HessSp_) {
+    nlp_->runStats.kkt.tmUpdateInit.stop();
+    //incorrect linear algebra objects were provided to this class
+    return false;
+  }
+  
+  size_type nx = HessSp_->n();
+  size_type neq = Jac_cSp_->m();
+  size_type nineq = Jac_dSp_->m();
+  assert(nineq == Dd_->get_size());
+  assert(nx == Dx_->get_size());
+
+  /* TODO: here we assume Hess is diagonal!*/
+  if(nullptr == Hess_diag_) {
+    Hess_diag_ = LinearAlgebraFactory::create_vector(nlp_->options->GetString("mem_space"), nx);
+    assert(Hess_diag_);
+    Hess_triplet->extract_diagonal(*Hess_diag_);
+  }
+  
+  //build the diagonal Hx = Dx + delta_wx + diag(Hess)
+  if(nullptr == Hx_) {
+    Hx_ = LinearAlgebraFactory::create_vector(nlp_->options->GetString("mem_space"), nx);
+    assert(Hx_);
+  }
+  Hx_->copyFrom(*Dx_);
+  Hx_->addConstant(delta_wx_in);
+  Hx_->axpy(1.0,*Hess_diag_);
+      
+  if(nullptr == Hd_) {
+    Hd_ = LinearAlgebraFactory::create_vector(nlp_->options->GetString("mem_space"), nineq);
+  }
+  Hd_->copyFrom(*Dd_);  
+  Hd_->addConstant(delta_wd_in);
+
+  nlp_->runStats.kkt.tmUpdateInit.stop();
+  nlp_->runStats.kkt.tmUpdateLinsys.start();
+  
+  /*
+  *  compute condensed linear system
+  * ( [ Jc  0 ] [ H+Dx+delta_wx     0       ]^{-1} [ Jc^T  Jd^T ] + [ -delta_cc     0     ] ) 
+  * ( [ Jd -I ] [   0           Dd+delta_wd ]      [  0     -I  ]   [    0      -delta_cd ] ) 
+  */
+
+  hiopTimer t;
+
+  if(nullptr == JDiagJt_) {
+    //first time this is called
+    // form sparse matrix in triplet form
+    size_type nnz_jac_con = Jac_cSp_->numberOfNonzeros()+Jac_dSp_->numberOfNonzeros()+nineq;
+    auto* Jac_triplet_tmp = new hiopMatrixSparseTriplet(neq+nineq, nx+nineq, nnz_jac_con);
+    Jac_triplet_tmp->setToZero();
+
+    // build  [ Jc  0 ]
+    //        [ Jd -I ]
+    // copy Jac to the full iterate matrix
+    size_type dest_nnz_st{0};
+    Jac_triplet_tmp->copyRowsBlockFrom(*Jac_cSp_, 0,   neq,   0, dest_nnz_st);
+    dest_nnz_st += Jac_cSp_->numberOfNonzeros();
+    Jac_triplet_tmp->copyRowsBlockFrom(*Jac_dSp_, 0, nineq, neq, dest_nnz_st);
+    dest_nnz_st += Jac_dSp_->numberOfNonzeros();
+
+    // minus identity matrix for slack variables
+    Jac_triplet_tmp->copyDiagMatrixToSubblock(-1., neq, nx, dest_nnz_st, nineq);
+    dest_nnz_st += nineq;
+
+    /// TODO: now we assume Jc and Jd won't change, i.e., LP or QP. hence we build JacD_ and JacDt_ once and save them
+    Jac_triplet_tmp->sort();
+
+    assert(nullptr == JacD_ && nullptr == JacDt_ && nullptr == DiagJt_);
+
+    // symbolic conversion from triplet to CSR
+    JacD_ = new hiopMatrixSparseCSRSeq();
+    JacD_->form_from_symbolic(*Jac_triplet_tmp);
+    JacD_->form_from_numeric(*Jac_triplet_tmp);
+
+    JacDt_ = new hiopMatrixSparseCSRSeq();
+    JacDt_->form_transpose_from_symbolic(*Jac_triplet_tmp);
+    JacDt_->form_transpose_from_numeric(*Jac_triplet_tmp);
+
+    DiagJt_ = new hiopMatrixSparseCSRSeq();
+    DiagJt_->form_transpose_from_symbolic(*Jac_triplet_tmp);
+    
+    // build the diagonal Hxd_inv_ = [H+Dx+delta_wx, Dd+delta_wd ]^{-1}
+    assert(nullptr == Hxd_inv_);
+    Hxd_inv_ = LinearAlgebraFactory::create_vector(nlp_->options->GetString("mem_space"), nx + nineq);
+
+    //symbolic multiplication for JacD*Diag*JacDt
+    assert(nullptr == JDiagJt_);
+    // J * (D*Jt)  (D is not used since it does not change the sparsity pattern)
+    JDiagJt_ = JacD_->times_mat_alloc(*JacDt_);
+    JacD_->times_mat_symbolic(*JDiagJt_, *JacDt_);
+    
+    delete Jac_triplet_tmp;
+  }
+
+  t.reset(); t.start();
+
+  Hx_->copyToStarting(*Hxd_inv_, 0);
+  Hd_->copyToStarting(*Hxd_inv_, nx);
+  Hxd_inv_->invert();
+
+  // J * D * Jt
+  DiagJt_->copyFrom(*JacDt_);
+  DiagJt_->scale_rows(*Hxd_inv_);
+  JacD_->times_mat_numeric(0.0, *JDiagJt_, 1.0, *DiagJt_);
+
+#ifdef HIOP_DEEPCHECKS
+  JDiagJt_->check_csr_is_ordered();
+#endif
+
+  if(nullptr == M_normaleqn_) {
+    //ensure storage for nonzeros diagonal is allocated by adding (symbolically)
+    //a diagonal matrix
+    Diag_reg_ = new hiopMatrixSparseCSRSeq();
+    hiopVector* diag_cons = LinearAlgebraFactory::create_vector(nlp_->options->GetString("mem_space"), neq + nineq);
+    Diag_reg_->form_diag_from_symbolic(*diag_cons);
+
+    //form sparsity pattern of M_condensed_ = JacD*Diag*JacDt - delta_cc*I
+    M_normaleqn_ = Diag_reg_->add_matrix_alloc(*JDiagJt_);
+    Diag_reg_->add_matrix_symbolic(*M_normaleqn_, *JDiagJt_);
+    delete diag_cons;
+  }
+
+  t.reset(); t.start();
+  if(delta_cc>0) {
+    Diag_reg_->set_diagonal(delta_cc);
+  } else {
+    Diag_reg_->set_diagonal(0.0);
+  }
+
+  M_normaleqn_->setToZero();
+  Diag_reg_->add_matrix_numeric(1.0, *M_normaleqn_, -1.0, *JDiagJt_, 1.0);
+
+  // TODO should have same code for different compute modes (remove is_cusolver_on), i.e., remove if(linSolver_ma57)
+  // right now we use this if statement to transfer CSR form back to triplet form for ma57
+  if(nullptr == linSys_) {
+    linSys_ = determine_and_create_linsys(neq+nineq, M_normaleqn_->numberOfNonzeros());
+  }
+
+  {
+    hiopLinSolverIndefSparseMA57* linSolver_ma57 = dynamic_cast<hiopLinSolverIndefSparseMA57*>(linSys_);
+    if(linSolver_ma57) {
+      auto* linSys = dynamic_cast<hiopLinSolverSymSparse*> (linSys_);
+      auto* Msys = dynamic_cast<hiopMatrixSparseTriplet*>(linSys->sys_matrix());
+      assert(Msys);
+      assert(Msys->m() == M_normaleqn_->m());
+
+      index_type itnz = 0;
+      for(index_type i = 0; i < Msys->m(); ++i) {
+        for(index_type p = M_normaleqn_->i_row()[i]; p < M_normaleqn_->i_row()[i+1]; ++p) {
+          const index_type j = M_normaleqn_->j_col()[p];
+          if(i<=j) {
+            Msys->i_row()[itnz] = i;
+            Msys->j_col()[itnz] = j;
+            Msys->M()[itnz] = M_normaleqn_->M()[p];
+            itnz++; 
+          }
+        }
+      }
+      assert(itnz == Msys->numberOfNonzeros());
+    }
+  }
+
+  t.stop();
+
+  //write matrix to file if requested
+  if(nlp_->options->GetString("write_kkt") == "yes") {
+    write_linsys_counter_++;
+  }
+  if(write_linsys_counter_>=0) {
+    // TODO csr_writer_.writeMatToFile(Msys, write_linsys_counter_, nx, 0, nineq);
+  }
+
+  return true; 
+}
+
+hiopLinSolverSymSparse* hiopKKTLinSysSparseNormalEqn::determine_and_create_linsys(size_type n, size_type nnz)
+{
+  if(linSys_) {
+    return dynamic_cast<hiopLinSolverSymSparse*> (linSys_);
+  }
+
+  if(nlp_->options->GetString("compute_mode") == "cpu") {
+    //auto linear_solver = nlp_->options->GetString("linear_solver_sparse");
+
+    //TODO:
+    //add support for linear_solver == "cholmod"
+    // maybe add pardiso as an option in the future
+    //
+    
+#ifdef HIOP_USE_COINHSL
+    nlp_->log->printf(hovWarning,
+                      "KKT_SPARSE_NormalEqn linsys: alloc MA57 for matrix of size %d (0 cons)\n", n);
+
+    // only a triangular part is needed for ma57. reset nnz
+    index_type itnz = 0;
+    for(index_type i=0; i<JDiagJt_->m(); ++i) {
+      for(index_type p=JDiagJt_->i_row()[i]; p<JDiagJt_->i_row()[i+1]; ++p) {
+        const index_type j = JDiagJt_->j_col()[p];
+        if(i<=j) {
+          itnz++; 
+        }
+      }
+    }
+    linSys_ = new hiopLinSolverIndefSparseMA57(n, itnz, nlp_);
+#else
+    assert(false && "HiOp was built without a sparse linear solver needed by the condensed KKT approach");
+#endif // HIOP_USE_COINHSL
+  } else {
+    //
+    // on device: compute_mode is hybrid, auto, or gpu
+    //
+    assert(nullptr==linSys_);
+#ifdef HIOP_USE_CUDA
+    nlp_->log->printf(hovWarning,
+                      "KKT_SPARSE_NormalEqn linsys: alloc cuSOLVER-chol matrix size %d\n", n);
+    assert(JDiagJt_);
+    linSys_ = new hiopLinSolverCholCuSparse(JDiagJt_, nlp_);
+#endif
+    //Return NULL (and assert) if a GPU sparse linear solver is not present
+    assert(linSys_!=nullptr &&
+           "HiOp was built without a sparse linear solver for GPU/device and cannot run on the "
+           "device as instructed by the 'compute_mode' option. Change the 'compute_mode' to 'cpu'");
+  }
+  assert(linSys_&& "KKT_SPARSE_NormalEqn linsys: cannot instantiate backend linear solver");
+  return dynamic_cast<hiopLinSolverSymSparse*> (linSys_);
+}
+
+bool hiopKKTLinSysSparseNormalEqn::solveCompressed(hiopVector& ryc,
+                                                   hiopVector& ryd,
+                                                   hiopVector& dyc,
+                                                   hiopVector& dyd)
+{
+  bool bret{false};
+
+  nlp_->runStats.kkt.tmSolveRhsManip.start();
+
+  size_type nyc = ryc.get_size();
+  size_type nyd = ryd.get_size();
+
+  // this is rhs used by the direct "condensed" solve
+  if(rhs_ == NULL) {
+    rhs_ = LinearAlgebraFactory::create_vector(nlp_->options->GetString("mem_space"), nyc+nyd);
+  }
+
+  nlp_->log->write("RHS KKT_SPARSE_NormalEqn ryc:", ryc, hovIteration);
+  nlp_->log->write("RHS KKT_SPARSE_NormalEqn ryd:", ryd, hovIteration);
+
+  //
+  // form the rhs for the sparse linSys
+  //
+  ryc.copyToStarting(*rhs_, 0);
+  ryd.copyToStarting(*rhs_, nyc);
+
+  if(write_linsys_counter_>=0) {
+    csr_writer_.writeRhsToFile(*rhs_, write_linsys_counter_);
+  }
+  nlp_->runStats.kkt.tmSolveRhsManip.stop();
+
+  //
+  // solve
+  //
+  nlp_->runStats.kkt.tmSolveInner.start();
+  bret = linSys_->solve(*rhs_);
+  nlp_->runStats.kkt.tmSolveInner.stop();
+
+  nlp_->runStats.linsolv.end_linsolve();
+ 
+  if(perf_report_) {
+    nlp_->log->printf(hovSummary,
+                      "(summary for linear solver from KKT_SPARSE_NormalEqn(direct))\n%s",
+                      nlp_->runStats.linsolv.get_summary_last_solve().c_str());
+  }
+  if(write_linsys_counter_>=0) {
+    csr_writer_.writeSolToFile(*rhs_, write_linsys_counter_);
+  }
+
+  nlp_->runStats.kkt.tmSolveRhsManip.start();
+
+  //
+  // unpack
+  //
+  rhs_->startingAtCopyToStartingAt(0,   dyc, 0);
+  rhs_->startingAtCopyToStartingAt(nyc, dyd, 0);
+  nlp_->log->write("SOL KKT_SPARSE_NormalEqn dyc:", dyc, hovMatrices);
+  nlp_->log->write("SOL KKT_SPARSE_NormalEqn dyd:", dyd, hovMatrices);
+
+  nlp_->runStats.kkt.tmSolveRhsManip.stop();
+    
+  return bret;
+}
+
+int hiopKKTLinSysSparseNormalEqn::factorizeWithCurvCheck()
+{
+  //factorization
+  size_type n_neg_eig = hiopKKTLinSysCurvCheck::factorizeWithCurvCheck();
+
+  size_type n_neg_eig_11 = 0;
+  if(n_neg_eig == -1) {
+    nlp_->log->printf(hovWarning,
+                "KKT_SPARSE_NormalEqn linsys: Detected null eigenvalues.\n");
+    n_neg_eig = -1;
+  } else {
+    n_neg_eig = Jac_c_->m() + Jac_d_->m();;    
+  }
+
+  return n_neg_eig;
+}
+
+} // end of namespace

--- a/src/Optimization/hiopKKTLinSysSparseNormalEqn.cpp
+++ b/src/Optimization/hiopKKTLinSysSparseNormalEqn.cpp
@@ -146,9 +146,10 @@ bool hiopKKTLinSysSparseNormalEqn::build_kkt_matrix(const double& delta_wx_in,
   if(nullptr == Hess_diag_) {
     Hess_diag_ = LinearAlgebraFactory::create_vector(nlp_->options->GetString("mem_space"), nx);
     assert(Hess_diag_);
-    Hess_triplet->extract_diagonal(*Hess_diag_);
+    Hess_diag_->setToZero();
   }
-  
+  Hess_triplet->extract_diagonal(*Hess_diag_); 
+ 
   //build the diagonal Hx = Dx + delta_wx + diag(Hess)
   if(nullptr == Hx_) {
     Hx_ = LinearAlgebraFactory::create_vector(nlp_->options->GetString("mem_space"), nx);
@@ -157,12 +158,16 @@ bool hiopKKTLinSysSparseNormalEqn::build_kkt_matrix(const double& delta_wx_in,
   Hx_->copyFrom(*Dx_);
   Hx_->addConstant(delta_wx_in);
   Hx_->axpy(1.0,*Hess_diag_);
-      
+  Hx_inv_->copyFrom(*Hx_);
+  Hx_inv_->invert();  
+    
   if(nullptr == Hd_) {
     Hd_ = LinearAlgebraFactory::create_vector(nlp_->options->GetString("mem_space"), nineq);
   }
   Hd_->copyFrom(*Dd_);  
   Hd_->addConstant(delta_wd_in);
+  Hd_inv_->copyFrom(*Hd_);
+  Hd_inv_->invert();
 
   nlp_->runStats.kkt.tmUpdateInit.stop();
   nlp_->runStats.kkt.tmUpdateLinsys.start();

--- a/src/Optimization/hiopKKTLinSysSparseNormalEqn.hpp
+++ b/src/Optimization/hiopKKTLinSysSparseNormalEqn.hpp
@@ -111,8 +111,9 @@ public:
 protected:
   hiopVector *rhs_;  // [ryc_tilde, ryd_tilde]
   hiopVector *Hxd_inv_;  // [H+Dx+delta_wx, Dd+delta_wd ]^-1
-  hiopVector *Hx_;  // [H+Dx+delta_wx]
-  hiopVector *Hd_;  // [Dd+delta_wd ]
+
+  // diagOf(Hess)
+  hiopVector *Hess_diag_;
 
   // -1 when disabled; otherwise acts like a counter, 0,1,... incremented each time
   // 'solveCompressed' is called; activated by the 'write_kkt' option

--- a/src/Optimization/hiopKKTLinSysSparseNormalEqn.hpp
+++ b/src/Optimization/hiopKKTLinSysSparseNormalEqn.hpp
@@ -1,0 +1,158 @@
+// Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory (LLNL).
+// LLNL-CODE-742473. All rights reserved.
+//
+// This file is part of HiOp. For details, see https://github.com/LLNL/hiop. HiOp
+// is released under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause).
+// Please also read “Additional BSD Notice” below.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+// i. Redistributions of source code must retain the above copyright notice, this list
+// of conditions and the disclaimer below.
+// ii. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the disclaimer (as noted below) in the documentation and/or
+// other materials provided with the distribution.
+// iii. Neither the name of the LLNS/LLNL nor the names of its contributors may be used to
+// endorse or promote products derived from this software without specific prior written
+// permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+// OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+// SHALL LAWRENCE LIVERMORE NATIONAL SECURITY, LLC, THE U.S. DEPARTMENT OF ENERGY OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+// OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+// AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+// EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Additional BSD Notice
+// 1. This notice is required to be provided under our contract with the U.S. Department
+// of Energy (DOE). This work was produced at Lawrence Livermore National Laboratory under
+// Contract No. DE-AC52-07NA27344 with the DOE.
+// 2. Neither the United States Government nor Lawrence Livermore National Security, LLC
+// nor any of their employees, makes any warranty, express or implied, or assumes any
+// liability or responsibility for the accuracy, completeness, or usefulness of any
+// information, apparatus, product, or process disclosed, or represents that its use would
+// not infringe privately-owned rights.
+// 3. Also, reference herein to any specific commercial products, process, or services by
+// trade name, trademark, manufacturer or otherwise does not necessarily constitute or
+// imply its endorsement, recommendation, or favoring by the United States Government or
+// Lawrence Livermore National Security, LLC. The views and opinions of authors expressed
+// herein do not necessarily state or reflect those of the United States Government or
+// Lawrence Livermore National Security, LLC, and shall not be used for advertising or
+// product endorsement purposes.
+
+/**
+ * @file hiopKKTLinSysSparseNormalEqn.hpp
+ *
+ * @author Cosmin G. Petra <petra1@llnl.gov>, LLNL
+ * @author Nai-Yuan Chiang <chiang7@llnl.gov>, LLNL
+ */
+
+#ifndef HIOP_KKTLINSYSSPARSE_NORMALEQ
+#define HIOP_KKTLINSYSSPARSE_NORMALEQ
+
+#include "hiopKKTLinSysSparse.hpp"
+#include "hiopMatrixSparseTriplet.hpp"
+#include "hiopMatrixSparseCSR.hpp"
+#include "hiopKrylovSolver.hpp"
+
+namespace hiop
+{
+
+/** 
+ * @brief Provides the functionality for reducing the KKT linear system to the
+ * normal equation system below in dyc and dyd variables and then to perform
+ * the basic ops needed to compute the remaining directions
+ *
+ * Relies on the pure virtual 'solveCompressed' to form and solve the compressed
+ * linear system
+ * ( [ Jc  0 ] [ H+Dx+delta_wx     0       ]^{-1} [ Jc^T  Jd^T ] + [ -delta_cc     0     ] ) [dyc] = [ ryc_tilde ]
+ * ( [ Jd -I ] [   0           Dd+delta_wd ]      [  0     -I  ]   [    0      -delta_cd ] ) [dyd]   [ ryd_tilde ]
+ *
+ * [ ryc_tilde ] = [ Jc  0 ] [ H+Dx+delta_wx     0       ]^{-1}  [ rx_tilde ] - [ ryc ] 
+ * [ ryd_tilde ]   [ Jd -I ] [   0           Dd+delta_wd ]       [ rd_tilde ]   [ ryd ]
+ * 
+ * where
+ *  - Jc and Jd present the sparse Jacobians for equalities and inequalities
+ *  - H is a sparse Hessian matrix
+ *  - Dx is diagonal corresponding to x variable in the log-barrier diagonal Dx, respectively
+ *
+ * REMARK: This linear system fits LP/QP best, where H is empty and hence only diagonal matrices are inversed.
+ * If H is diagonal, the normal equation matrix becomes:
+ *   [ Jc(H+Dx+delta_wx)^{-1}Jc^T    Jc(H+Dx+delta_wx)^{-1}Jd^T ]                        + [ -delta_cc     0     ] 
+ *   [ Jd(H+Dx+delta_wx)^{-1}Jc^T    Jd(H+Dx+delta_wx)^{-1}Jd^T + ( Dd+delta_wd)^{-1} ]    [    0      -delta_cd ]
+ *
+ */
+class hiopKKTLinSysSparseNormalEqn : public hiopKKTLinSysNormalEquation
+{
+public:
+  hiopKKTLinSysSparseNormalEqn(hiopNlpFormulation* nlp);
+  virtual ~hiopKKTLinSysSparseNormalEqn();
+
+  virtual bool build_kkt_matrix(const double& delta_wx,
+                                const double& delta_wd,
+                                const double& delta_cc,
+                                const double& delta_cd);
+
+  virtual bool solveCompressed(hiopVector& ryc_tilde,
+                               hiopVector& ryd_tilde,
+                               hiopVector& dyc,
+                               hiopVector& dyd);
+
+  /**
+   * @brief factorize the matrix and check curvature
+   */ 
+  virtual int factorizeWithCurvCheck();
+
+protected:
+  hiopVector *rhs_;  // [ryc_tilde, ryd_tilde]
+  hiopVector *Hxd_inv_;  // [H+Dx+delta_wx, Dd+delta_wd ]^-1
+  hiopVector *Hx_;  // [H+Dx+delta_wx]
+  hiopVector *Hd_;  // [Dd+delta_wd ]
+
+  // -1 when disabled; otherwise acts like a counter, 0,1,... incremented each time
+  // 'solveCompressed' is called; activated by the 'write_kkt' option
+  int write_linsys_counter_;
+  hiopCSR_IO csr_writer_;
+
+  //just dynamic_cast-ed pointers
+  hiopNlpSparse* nlpSp_;
+  hiopMatrixSparse* HessSp_;
+  const hiopMatrixSparse* Jac_cSp_;
+  const hiopMatrixSparse* Jac_dSp_;
+
+  /// Member for ( [ Jc  0 ] [ H+Dx+delta_wx     0       ]^{-1} [ Jc^T  Jd^T ] + [ -delta_cc     0     ] )
+  ///            ( [ Jd -I ] [   0           Dd+delta_wd ]      [  0     -I  ]   [    0      -delta_cd ] )
+  /// let JacD_ = [Jc 0; Jd -I]
+  /// TODO: now we assume Jc and Jd won't change, i.e., LP or QP. hence we build JacD_ and JacDt_ once and save them
+
+  /// Member for JacD in CSR format
+  hiopMatrixSparseCSR* JacD_;
+  
+  /// Member for JacD' in CSR format
+  hiopMatrixSparseCSR* JacDt_;
+
+  /// Hxd_ * JacDt_
+  hiopMatrixSparseCSR* DiagJt_;
+
+  /// Member for JacD*Dd*JacD'
+  hiopMatrixSparseCSR* JDiagJt_;
+
+  /// Member for delta_cc*I
+  hiopMatrixSparseCSR* Diag_reg_;
+
+  /// Member forJacD*Dd*JacD' - delta_cc*I
+  hiopMatrixSparseCSR* M_normaleqn_;
+
+private:
+  //placeholder for the code that decides which linear solver to used based on safe_mode_
+  hiopLinSolverSymSparse* determine_and_create_linsys(size_type n, size_type nnz);
+};
+
+} // end of namespace
+
+#endif

--- a/src/Optimization/hiopKKTLinSysSparseNormalEqn.hpp
+++ b/src/Optimization/hiopKKTLinSysSparseNormalEqn.hpp
@@ -70,8 +70,8 @@ namespace hiop
  *
  * Relies on the pure virtual 'solveCompressed' to form and solve the compressed
  * linear system
- * ( [ Jc  0 ] [ H+Dx+delta_wx     0       ]^{-1} [ Jc^T  Jd^T ] + [ -delta_cc     0     ] ) [dyc] = [ ryc_tilde ]
- * ( [ Jd -I ] [   0           Dd+delta_wd ]      [  0     -I  ]   [    0      -delta_cd ] ) [dyd]   [ ryd_tilde ]
+ * ( [ Jc  0 ] [ H+Dx+delta_wx     0       ]^{-1} [ Jc^T  Jd^T ] + [ delta_cc     0     ] ) [dyc] = [ ryc_tilde ]
+ * ( [ Jd -I ] [   0           Dd+delta_wd ]      [  0     -I  ]   [    0      delta_cd ] ) [dyd]   [ ryd_tilde ]
  *
  * [ ryc_tilde ] = [ Jc  0 ] [ H+Dx+delta_wx     0       ]^{-1}  [ rx_tilde ] - [ ryc ] 
  * [ ryd_tilde ]   [ Jd -I ] [   0           Dd+delta_wd ]       [ rd_tilde ]   [ ryd ]
@@ -83,8 +83,8 @@ namespace hiop
  *
  * REMARK: This linear system fits LP/QP best, where H is empty and hence only diagonal matrices are inversed.
  * If H is diagonal, the normal equation matrix becomes:
- *   [ Jc(H+Dx+delta_wx)^{-1}Jc^T    Jc(H+Dx+delta_wx)^{-1}Jd^T ]                        + [ -delta_cc     0     ] 
- *   [ Jd(H+Dx+delta_wx)^{-1}Jc^T    Jd(H+Dx+delta_wx)^{-1}Jd^T + ( Dd+delta_wd)^{-1} ]    [    0      -delta_cd ]
+ *   [ Jc(H+Dx+delta_wx)^{-1}Jc^T    Jc(H+Dx+delta_wx)^{-1}Jd^T ]                        + [ delta_cc     0     ] 
+ *   [ Jd(H+Dx+delta_wx)^{-1}Jc^T    Jd(H+Dx+delta_wx)^{-1}Jd^T + ( Dd+delta_wd)^{-1} ]    [    0      delta_cd ]
  *
  */
 class hiopKKTLinSysSparseNormalEqn : public hiopKKTLinSysNormalEquation
@@ -126,8 +126,8 @@ protected:
   const hiopMatrixSparse* Jac_cSp_;
   const hiopMatrixSparse* Jac_dSp_;
 
-  /// Member for ( [ Jc  0 ] [ H+Dx+delta_wx     0       ]^{-1} [ Jc^T  Jd^T ] + [ -delta_cc     0     ] )
-  ///            ( [ Jd -I ] [   0           Dd+delta_wd ]      [  0     -I  ]   [    0      -delta_cd ] )
+  /// Member for ( [ Jc  0 ] [ H+Dx+delta_wx     0       ]^{-1} [ Jc^T  Jd^T ] + [ delta_cc     0     ] )
+  ///            ( [ Jd -I ] [   0           Dd+delta_wd ]      [  0     -I  ]   [    0      delta_cd ] )
   /// let JacD_ = [Jc 0; Jd -I]
   /// TODO: now we assume Jc and Jd won't change, i.e., LP or QP. hence we build JacD_ and JacDt_ once and save them
 

--- a/src/Optimization/hiopNlpFormulation.hpp
+++ b/src/Optimization/hiopNlpFormulation.hpp
@@ -217,7 +217,8 @@ public:
   inline hiopInterfaceBase::NonlinearityType* get_var_type() const {return vars_type_;}
   inline hiopInterfaceBase::NonlinearityType* get_cons_eq_type() const {return cons_eq_type_;}
   inline hiopInterfaceBase::NonlinearityType* get_cons_ineq_type() const {return cons_ineq_type_;}
-  
+  inline hiopInterfaceBase::NonlinearityType  get_prob_type() const {return prob_type_;}
+
   /** const accessors */
   inline size_type n() const      {return n_vars_;}
   inline size_type m() const      {return n_cons_;}
@@ -324,7 +325,15 @@ protected:
 
   hiopVector *dl_, *du_,  *idl_, *idu_; //these will be local
   hiopInterfaceBase::NonlinearityType* cons_ineq_type_;
-  
+
+  /**
+   * Flag to indicate whether problem is LP, QP or NLP
+   */
+  hiopInterfaceBase::NonlinearityType prob_type_;
+
+  // flag to indicate whether f/grad/con/Jac/Hes has been evaluated once
+  bool nlp_evaluated_;
+
   // keep track of the constraints indexes in the original, user's formulation
   hiopVectorInt *cons_eq_mapping_, *cons_ineq_mapping_; 
 
@@ -379,6 +388,7 @@ protected:
    * ineq. into and to return it to the user via @user_callback_solution and @user_callback_iterate
    */
   hiopVector* cons_lambdas_;
+
 private:
   hiopNlpFormulation(const hiopNlpFormulation& s)
     : interface_base(s.interface_base),

--- a/src/Optimization/hiopResidual.hpp
+++ b/src/Optimization/hiopResidual.hpp
@@ -186,6 +186,7 @@ private:
   friend class hiopKKTLinSysCompressed;
   friend class hiopKKTLinSysCompressedXYcYd;
   friend class hiopKKTLinSysCompressedXDYcYd;
+  friend class hiopKKTLinSysNormalEquation;
   friend class hiopKKTLinSysLowRank;
   friend class hiopKKTLinSys;
 };

--- a/src/Utils/hiopOptions.cpp
+++ b/src/Utils/hiopOptions.cpp
@@ -804,14 +804,15 @@ void hiopOptionsNLP::register_options()
   }
   //linear algebra
   {
-    vector<string> range = {"auto", "xycyd", "xdycyd", "full", "condensed"};
+    vector<string> range = {"auto", "xycyd", "xdycyd", "full", "condensed", "normaleqn"};
     register_str_option("KKTLinsys",
                         "auto",
                         range,
                         "Type of KKT linear system used internally: decided by HiOp 'auto' (default), "
                         "the more compact 'XYcYd, the more stable 'XDYcYd', the full-size non-symmetric "
-                        "'full', or the condensed that uses Cholesky (available when no eq. constraints "
-                        "are present). The last four options are available only with "
+                        "'full', the symmetric normal equation 'normaleqn', or the condensed that "
+                        "uses Cholesky (available when no eq. constraints "
+                        "are present). The last five options are available only with "
                         "'Hessian=analyticalExact'.");
   }
 
@@ -1055,7 +1056,7 @@ void hiopOptionsNLP::ensure_consistence()
 
   if(GetString("Hessian")=="quasinewton_approx") {
     string strKKT = GetString("KKTLinsys");
-    if(strKKT=="xycyd" || strKKT=="xdycyd" || strKKT=="full") {
+    if(strKKT=="xycyd" || strKKT=="xdycyd" || strKKT=="full" || strKKT=="normaleqn") {
       if(is_user_defined("Hessian")) {
         log_printf(hovWarning,
                    "The option 'KKTLinsys=%s' is not valid with 'Hessian=quasiNewtonApprox'. "


### PR DESCRIPTION
Add support to normal equation.
Right now we assume the input Hessian is diagonal.

Follow-up PRs will 
1. add unit tests for matrix function `is_diagonal` and `extract_diagonal`
2. add CI tests
3. optimize numerical efficiency for LP and QP