### PR TITLE
Pridec run local

### DIFF
--- a/src/Drivers/PriDec/NlpPriDecEx2Driver.cpp
+++ b/src/Drivers/PriDec/NlpPriDecEx2Driver.cpp
@@ -141,6 +141,7 @@ int main(int argc, char **argv)
   hiop::hiopAlgPrimalDecomposition pridec_solver(&pridec_problem, MPI_COMM_WORLD);
   pridec_solver.set_initial_alpha_ratio(0.5);
   pridec_solver.set_alpha_min(0.3);
+  //pridec_solver.set_local_accum("true");
   //pridec_solver.set_tolerance(1e-6);
   //pridec_solver.set_max_iteration(5);
   auto status = pridec_solver.run();

--- a/src/Drivers/PriDec/NlpPriDecEx2SparseDriver.cpp
+++ b/src/Drivers/PriDec/NlpPriDecEx2SparseDriver.cpp
@@ -134,6 +134,7 @@ int main(int argc, char **argv)
   hiop::hiopAlgPrimalDecomposition pridec_solver(&pridec_problem, MPI_COMM_WORLD);
   pridec_solver.set_initial_alpha_ratio(0.5);
   pridec_solver.set_alpha_min(0.3);
+  //pridec_solver.set_local_accum("true");
   //pridec_solver.set_tolerance(1e-6);
   //pridec_solver.set_max_iteration(5);
   auto status = pridec_solver.run();

--- a/src/Optimization/hiopAlgPrimalDecomp.cpp
+++ b/src/Optimization/hiopAlgPrimalDecomp.cpp
@@ -796,6 +796,7 @@ void hiopAlgPrimalDecomposition::set_local_accum(const std::string local_accum)
     double* grad_r_vec=grad_r->local_data();
   
     hiopVector* hess_appx = grad_r->alloc_clone();
+    hess_appx->setToZero();
     double* hess_appx_vec = hess_appx->local_data();
    
     hiopVector* x0 = grad_r->alloc_clone();
@@ -1265,7 +1266,8 @@ void hiopAlgPrimalDecomposition::set_local_accum(const std::string local_accum)
 
     hiopVector* hess_appx = grad_r->alloc_clone();
     double* hess_appx_vec = hess_appx->local_data();
-   
+    hess_appx->setToZero();
+
     hiopVector* x0 = grad_r->alloc_clone();
     x0->setToZero(); 
     double* x0_vec=x0->local_data();

--- a/src/Optimization/hiopAlgPrimalDecomp.cpp
+++ b/src/Optimization/hiopAlgPrimalDecomp.cpp
@@ -90,6 +90,22 @@ namespace hiop
       assert(MPI_SUCCESS == ierr);
       return mpi_test_flag;
     }
+
+    // only receive signal (that computation is finished), no actual functional information
+    void post_recv_sign(int tag, int rank_from, MPI_Comm comm)
+    {
+      int recv_sign = 0;
+      int ierr = MPI_Irecv(&recv_sign, 1, MPI_INT, rank_from, tag, comm, &request_);
+      assert(MPI_SUCCESS == ierr);
+    }
+    // only sende signal (that computation is finished), no actual functional information
+    void post_send_sign(int tag, int rank_to, MPI_Comm comm)
+    {
+      int send_sign = 0;
+      int ierr = MPI_Isend(&send_sign, 1, MPI_INT, rank_to, tag, comm, &request_);
+      assert(MPI_SUCCESS == ierr);
+    }
+
     void post_recv(int tag, int rank_from, MPI_Comm comm)
     {
       double* buffer_arr = buffer->local_data();
@@ -562,7 +578,9 @@ hiopAlgPrimalDecomposition(hiopInterfacePriDecProblem* prob_in,
   set_alpha_max(options_->GetNumeric("alpha_max"));
   
   set_alpha_min(options_->GetNumeric("alpha_min"));
-
+ 
+  set_local_accum(options_->GetString("accum_local"));
+  
   assert(alpha_max_ > alpha_min_);
 
   set_verbosity(options_->GetInteger("verbosity_level"));
@@ -614,8 +632,9 @@ hiopAlgPrimalDecomposition(hiopInterfacePriDecProblem* prob_in,
   set_alpha_max(options_->GetNumeric("alpha_max"));
   
   set_alpha_min(options_->GetNumeric("alpha_min"));
-
   assert(alpha_max_ > alpha_min_);
+
+  set_local_accum(options_->GetString("accum_local"));
 
   set_verbosity(options_->GetInteger("verbosity_level"));
   log_ = new hiopLogger(options_, stdout, 0, comm_world);
@@ -740,6 +759,11 @@ void hiopAlgPrimalDecomposition::set_alpha_max(const double alp_max)
   alpha_max_ = alp_max;
 }
 
+void hiopAlgPrimalDecomposition::set_local_accum(const std::string local_accum)
+{
+  local_accum_ = local_accum;
+}
+
 /** MPI engine for pridec solver
  */
 
@@ -750,6 +774,11 @@ void hiopAlgPrimalDecomposition::set_alpha_max(const double alp_max)
     if(options_->GetString("print_options") == "yes") {
       log_->write(nullptr, *options_, hovSummary);
     }
+    
+    if(local_accum_ == "yes") { // if worker ranks accumulate solution locally before tranferring to master rank 
+      return run_local();
+    }
+    
     if(comm_size_==1) {
       return run_single();//call the serial solver
     }
@@ -1078,6 +1107,7 @@ void hiopAlgPrimalDecomposition::set_alpha_max(const double alp_max)
 
         log_->printf(hovSummary, "real rval %18.12e\n", rval);
         
+        std::cout<<"my rank "<<my_rank_<< " grad "<< grad_r_vec[0]<< " "<<grad_r_vec[1]<<std::endl;
         MPI_Status mpi_status; 
 
         for(int i=0; i<nc_; i++) {
@@ -1215,6 +1245,523 @@ hiopSolveStatus hiopAlgPrimalDecomposition::run()
 }
 #endif
 
+/**
+ * A different asynchronous communication scheme where evaluator ranks 
+ * transfer data only once with the master rank
+ *
+ */
+hiopSolveStatus hiopAlgPrimalDecomposition::run_local()
+  {
+    log_->printf(hovSummary, "===============\nHiop Primal Decomposition SOLVER\n===============\n");
+    log_->printf(hovSummary, "===============\nUsing local accumulation OPTION\n===============\n");
+    if(options_->GetString("print_options") == "yes") {
+      log_->write(nullptr, *options_, hovSummary);
+    }
+    if(comm_size_==1) {
+      return run_single();//call the serial solver
+    }
+    if(my_rank_==0) {
+      printf("total number of recourse problems  %lu\n", S_);
+      printf("total ranks %d\n",comm_size_);
+    }
+    // initial point set to all zero, for now
+    x_->setToConstant(0.0);
+      
+    bool bret;
+    int rank_master=0; // master rank is also the rank that solves the master problem
+    // Define the values and gradients as needed as well as a receving buffer on the master rank
+    double rval = 0.;
+    
+    double rval_main = 0.;
+
+    hiopVector* grad_r;
+    grad_r = LinearAlgebraFactory::create_vector(options_->GetString("mem_space"), nc_) ; 
+    grad_r->setToZero(); 
+    double* grad_r_vec=grad_r->local_data();
+
+    // grad_r_main is only needed on the master rank
+    hiopVector* grad_r_main;
+    grad_r_main = LinearAlgebraFactory::create_vector(options_->GetString("mem_space"), nc_) ; 
+    grad_r_main->setToZero(); 
+    double* grad_r_main_vec=grad_r_main->local_data();
+
+    hiopVector* hess_appx = grad_r->alloc_clone();
+    double* hess_appx_vec = hess_appx->local_data();
+   
+    hiopVector* x0 = grad_r->alloc_clone();
+    x0->setToZero(); 
+    double* x0_vec=x0->local_data();
+    
+    // local recourse terms for each evaluator, defined accross all processors
+    // it is only necessary if a batch of recourse indices are sent at the same time 
+    // therefore in run_local() no longer defined 
+    //double rec_val = 0.;
+    //hiopVector* grad_acc = grad_r->alloc_clone();
+    //grad_acc->setToZero(); 
+    //double* grad_acc_vec = grad_acc->local_data();
+
+    //hess_appx_2 is declared by all ranks while only rank 0 uses it
+    HessianApprox* hess_appx_2 = new HessianApprox(nc_, alpha_ratio_, master_prob_, options_);
+    hess_appx_2->set_alpha_min(alpha_min_);
+    hess_appx_2->set_alpha_max(alpha_max_);
+
+    if(ver_ >= hovSummary) {
+      hess_appx_2->set_verbosity(ver_);
+    }
+
+    double base_val = 0.; // basecase objective value
+    double base_valm1 = 0.; // basecase objective value from the previous step 
+    double recourse_val = 0.;  // recourse objective value
+    double dinf = 0.; // step size 
+
+    double convg = 1e20;  // convergence measure
+    double convg_g = 1e20;
+    double convg_f = 1e20;
+    int accp_count = 0;
+
+    int end_signal = 0;
+    double t1 = 0;
+    double t2 = 0; 
+    hiopInterfacePriDecProblem::RecourseApproxEvaluator* evaluator = new hiopInterfacePriDecProblem::
+      RecourseApproxEvaluator(nc_, S_, xc_idx_->local_data(), options_->GetString("mem_space"));
+    double* x_vec = x_->local_data();
+
+    std::string options_file_master_prob;
+    // Outer loop starts
+    for(int it=0; it<max_iter_;it++) {
+      
+      if(my_rank_==0) {
+        t1 = MPI_Wtime(); 
+      }
+      it_ = it;
+      // solve the basecase first
+      if(my_rank_ == 0 && it==0) {//initial solve 
+        // log_->printf(hovIteration, "my rank for solver  %d\n", my_rank_); 
+
+        options_file_master_prob = options_->GetString("options_file_master_prob");
+        solver_status_ = master_prob_->solve_master(*x_, false, 0, 0, 0, options_file_master_prob.c_str());
+
+        if(solver_status_){     
+          // to do, what if solve fails?
+        }
+       
+        log_->write(nullptr, *x_, hovFcnEval);
+        base_val = master_prob_->get_objective();
+        base_valm1 = master_prob_->get_objective();
+      }
+
+      // send basecase solutions to all ranks
+      int ierr = MPI_Bcast(x_vec, n_, MPI_DOUBLE, rank_master, comm_world_);
+      assert(ierr == MPI_SUCCESS);
+
+      // set up recourse problem send/recv interface
+      std::vector<ReqRecourseApprox* > rec_prob;
+      for(int r=0; r<comm_size_;r++) {
+        rec_prob.push_back(new ReqRecourseApprox(nc_));
+      }
+      
+      ReqContingencyIdx* req_cont_idx = new ReqContingencyIdx(0);
+
+
+      rval = 0.;
+      grad_r->setToZero();
+      
+      rval_main = 0.;
+      grad_r_main->setToZero();
+
+      // master rank communication
+      if(my_rank_ == 0) {
+        // array for number of indices, currently the indices are in [0,S_] 
+        
+        std::vector<int> cont_idx(S_);
+        for(int i=0; i<S_; i++) {
+          cont_idx[i] = i;
+        }
+        // The number of contigencies/recourse problems should be larger than the number of processors
+        assert(S_>=comm_size_-1);
+        // idx is the next contingency to be sent out from the master
+        int idx = 0;
+        // Initilize the recourse communication by sending indices to the evaluator 
+        // Using Blocking send here
+        for(int r=1; r< comm_size_;r++) {
+          int cur_idx = cont_idx[idx];
+          int ierr = MPI_Send(&cur_idx, 1, MPI_INT, r, 1,comm_world_);
+          assert(MPI_SUCCESS == ierr);  
+          // log_->printf(hovIteration, "rank %d to get contingency index  %d\n", r, cur_idx); //verbosity level 10
+          idx += 1;
+        }
+        int mpi_test_flag; // for testing if the send/recv is completed
+        // Posting initial receive of recourse solutions from evaluators
+        for(int r=1; r<comm_size_; r++) {
+          // rec_prob[r]->post_recv(2,r,comm_world_);// 2 is the tag, r is the rank source 
+          
+	  rec_prob[r]->post_recv_sign(2,r,comm_world_);// 2 is the tag, r is the rank source 
+          // log_->printf(hovIteration, "receive flag for contingency value %d\n", mpi_test_flag); 
+        }
+        // Both finish_flag and last_loop are used to deal with the final round remaining contingencies/recourse problems.
+        // Some ranks are finished while others are not. The loop needs to continue to fetch the results. 
+        // hiopVectorInt* finish_flag = LinearAlgebraFactory::createVectorInt(comm_size_);
+        // finish_flag->setToZero();
+        std::vector<int> finish_flag(comm_size_); // standard vector will be replaced by hiopVectorInt
+        for(int i=0;i<comm_size_;i++) {
+          finish_flag[i]=0;
+        }
+        int last_loop = 0;
+        // log_->printf(hovIteration, "total idx %d\n", S_); 
+        t2 = MPI_Wtime(); 
+        
+        log_->printf(hovFcnEval, "Elapsed time for entire iteration %d is %f\n",it, t2 - t1);
+        
+        while(idx<=S_ || last_loop) { 
+          for(int r=1; r< comm_size_;r++) {
+            int mpi_test_flag = rec_prob[r]->test();
+            if(mpi_test_flag && (finish_flag[r]==0)) {// receive completed
+              if(!last_loop && idx<S_) {
+                log_->printf(hovLinesearch, "idx %d sent to rank %d\n", idx,r);
+              } else {
+                log_->printf(hovLinesearch, "last loop for rank %d\n", r );
+              }
+              
+	      // no need to add to the master rank variables
+	      /*
+	      rval += rec_prob[r]->value();
+              for(int i=0;i<nc_;i++) {
+                grad_r_vec[i] += rec_prob[r]->grad(i);
+              }
+              */
+	      
+	      if(last_loop) {
+                finish_flag[r]=1;
+              }
+              // this is for dealing with the end of contingencies where some ranks have already finished
+              if(idx<S_) {
+                req_cont_idx->set_idx(cont_idx[idx]);
+                req_cont_idx->post_send(1,r,comm_world_);
+                
+	        rec_prob[r]->post_recv_sign(2,r,comm_world_);// 2 is the tag, r is the rank source 
+		// rec_prob[r]->post_recv(2,r,comm_world_);// 2 is the tag, r is the rank source 
+                // log_->printf(hovFcnEval, "recourse value: is %18.12e)\n", rec_prob[r]->value());
+              } else {
+                finish_flag[r] = 1;
+                last_loop = 1; 
+              }
+              idx += 1; 
+            } 
+          }
+
+          // Current way of ending the loop while accounting for all the last round of results
+          if(last_loop) {
+            last_loop=0;
+            for(int r=1; r< comm_size_;r++) {
+              if(finish_flag[r]==0){last_loop=1;}
+            }
+          }
+
+        }
+        //rval /= S_;
+        //grad_r->scale(1.0/S_);
+        // send end signal to all evaluators
+        int cur_idx = -1;
+        for(int r=1; r<comm_size_; r++) {
+          req_cont_idx->set_idx(-1);
+          req_cont_idx->post_send(1,r,comm_world_);
+        }
+        t2 = MPI_Wtime(); 
+        log_->printf(hovFcnEval, "Elapsed time for entire iteration %d is %f\n",it, t2 - t1);
+      }
+
+      //evaluators
+      if(my_rank_ != 0) {
+        /* old sychronous implementation of contingencies
+         * int cpr = S_/(comm_size_-1); //contingency per rank
+         * int cr = S_%(comm_size_-1); //contingency remained
+         * log_->printf(hovIteration, "my rank start evaluating work %d)\n", my_rank_); 
+         */
+        std::vector<int> cont_idx(1); // currently sending/receiving one contingency index at a time
+        int cont_i = 0;
+        cont_idx[0] = 0;
+        // Receive the index of the contingency to evaluate
+        int mpi_test_flag = 0;
+        int ierr = MPI_Recv(&cont_i, 1, MPI_INT, rank_master, 1, comm_world_, &status_);
+        assert(MPI_SUCCESS == ierr);  
+        cont_idx[0] = cont_i;
+        // log_->printf(hovIteration, "contingency index %d, rank %d)\n", cont_idx[0],my_rank_); 
+        // compute the recourse function values and gradients
+        
+	// accumulate locally so cannot set to zero
+	//rec_val = 0.;
+        //grad_acc->setToZero();
+        
+	double aux=0.;
+
+        if(nc_<n_) {
+          x0->copy_from_indexes(*x_, *xc_idx_);
+        } else {
+          assert(nc_==n_);
+          x0->copyFromStarting(0, *x_);
+        }
+        for(int ri=0; ri<cont_idx.size(); ri++) {
+          aux = 0.;
+          int idx_temp = cont_idx[ri];
+
+          bret = master_prob_->eval_f_rterm(idx_temp, nc_, x0_vec, aux); // solving the recourse problem
+          if(!bret) {
+              //TODO
+          }
+          //rec_val += aux;
+          rval += aux;
+        }
+
+        // log_->printf(hovFcnEval, "recourse value: is %18.12e)\n", rec_val);
+        hiopVector* grad_aux = x0->alloc_clone();
+        grad_aux->setToZero(); 
+
+        for(int ri=0; ri<cont_idx.size(); ri++) {
+          int idx_temp = cont_idx[ri];
+          bret = master_prob_->eval_grad_rterm(idx_temp, nc_, x0_vec, *grad_aux);
+          if(!bret) {
+            //TODO
+          }
+          //grad_acc->axpy(1.0, *grad_aux);
+          grad_r->axpy(1.0, *grad_aux);
+        }
+        delete grad_aux;
+
+        // no need to set values for rec_prob anymore
+        //rec_prob[my_rank_]->set_value(rec_val);
+        //rec_prob[my_rank_]->set_grad(grad_acc_vec);
+        
+	//rec_prob[my_rank_]->post_send(2, rank_master, comm_world_);
+	// send signal that subproblem has been solved
+        rec_prob[my_rank_]->post_send_sign(2, rank_master, comm_world_);
+
+	// request the next subproblem index 
+        req_cont_idx->post_recv(1, rank_master, comm_world_);
+        while(cont_idx[0]!=-1) {//loop until end signal received
+          mpi_test_flag = req_cont_idx->test();
+          /* contigency starts at 0 
+           * sychronous implmentation of contingencist
+          */
+          if(mpi_test_flag) {
+            // log_->printf(hovIteration, "contingency index %d, rank %d)\n", cont_idx[0],my_rank_); 
+            for(int ri=0; ri<cont_idx.size(); ri++) {
+              cont_idx[ri] = req_cont_idx->value();
+            }
+            if(cont_idx[0]==-1) {
+              break;
+            }
+            
+	    // accumulate locally so cannot set to zero
+	    //rec_val = 0.;
+            //grad_acc->setToZero();
+
+            double aux=0.;
+            if(nc_<n_) {
+              x0->copy_from_indexes(*x_, *xc_idx_);
+            } else {
+              assert(nc_==n_);
+              x0->copyFromStarting(0, *x_);
+            }
+            for(int ri=0; ri<cont_idx.size(); ri++) {
+              aux = 0.;
+              int idx_temp = cont_idx[ri];
+              
+              bret = master_prob_->eval_f_rterm(idx_temp, nc_, x0_vec, aux); //need to add extra time here
+              if(!bret) {
+              //TODO
+              }
+              //rec_val += aux;
+              rval += aux;
+            }
+            // log_->printf(hovFcnEval, "recourse value: is %18.12e)\n", rec_val);
+            hiopVector* grad_aux = x0->alloc_clone();
+            grad_aux->setToZero(); 
+
+            for(int ri=0; ri<cont_idx.size(); ri++) {
+              int idx_temp = cont_idx[ri];
+              bret = master_prob_->eval_grad_rterm(idx_temp, nc_, x0_vec, *grad_aux);
+              if(!bret) {
+                //TODO
+              }
+              //grad_acc->axpy(1.0, *grad_aux);
+              grad_r->axpy(1.0, *grad_aux);
+            }
+
+            //rec_prob[my_rank_]->set_value(rec_val);
+            //rec_prob[my_rank_]->set_grad(grad_acc_vec);
+           
+	    // send signal that the subproblem has been solved 
+            rec_prob[my_rank_]->post_send_sign(2, rank_master, comm_world_);
+	    //rec_prob[my_rank_]->post_send(2, rank_master, comm_world_);
+            // log_->printf(hovIteration, "send recourse value flag for test %d \n", mpi_test_flag); 
+        
+            // post recv for new index
+            req_cont_idx->post_recv(1, rank_master, comm_world_);
+            // ierr = MPI_Irecv(&cont_idx[0], 1, MPI_INT, rank_master, 1, comm_world_, &request_[0]);
+            delete grad_aux;
+          }
+        }
+	//rval = rec_val;
+	//grad_r->copyFrom(grad_acc_vec);
+      }
+
+      if(my_rank_==0) {
+        assert(rval == 0);
+	for (int i=0; i<nc_; i++ ) {
+          assert(grad_r_vec[i] == 0.);
+        }
+	int mpi_test_flag = 0;
+        for(int r=1; r<comm_size_;r++) {
+          MPI_Wait(&(rec_prob[r]->request_), &status_);
+          MPI_Wait(&req_cont_idx->request_, &status_);
+        }
+      }
+
+      //std::cout<<"my rank "<<my_rank_<< " grad "<< grad_r_vec[0]<< " "<<grad_r_vec[1]<<std::endl;
+      MPI_Reduce(&rval, &rval_main, 1, MPI_DOUBLE, MPI_SUM, 0, comm_world_); // collect recourse function value 
+      MPI_Reduce(grad_r_vec, grad_r_main_vec, nc_, MPI_DOUBLE, MPI_SUM, 0, comm_world_); // collect recourse function gradient 
+      
+      if(my_rank_==0) {
+        
+        //std::cout<<"real rval %18.12e\n "<< rval_main<<std::endl;
+        rval = rval_main;
+	grad_r->copyFrom(grad_r_main_vec);
+
+        rval /= S_;
+        grad_r->scale(1.0/S_);
+
+        log_->printf(hovSummary, "real rval %18.12e\n", rval);
+        
+        MPI_Status mpi_status; 
+
+        for(int i=0; i<nc_; i++) {
+          hess_appx_vec[i] = 1.0;
+        }
+
+        if(nc_<n_) {
+          x0->copy_from_indexes(*x_, *xc_idx_);
+        } else {
+          assert(nc_==n_);
+          x0->copyFromStarting(0, *x_);
+        }
+
+        if(it==0) {
+          hess_appx_2->initialize(rval, *x0, *grad_r);
+          double alp_temp = hess_appx_2->get_alpha_f(*grad_r);
+          // double alp_temp = hess_appx_2->get_alpha_tr(); // alternative update rule for alpha
+          log_->printf(hovSummary, "alpd %18.12e\n", alp_temp);
+          
+          for(int i=0; i<nc_; i++) {
+            hess_appx_vec[i] = alp_temp;
+          }
+        } else {
+          hess_appx_2->update_hess_coeff(*x0, *grad_r, rval);
+          //update basecase objective, this requires updated skm1 and ykm1
+          base_valm1 = base_val;
+          base_val = hess_appx_2->compute_base(master_prob_->get_objective());
+
+          //hess_appx_2->update_ratio();
+          hess_appx_2->update_ratio(base_val, base_valm1);
+          
+          double alp_temp = hess_appx_2->get_alpha_f(*grad_r);
+          //double alp_temp = hess_appx_2->get_alpha_tr();
+          
+          //double alp_temp2 = hess_appx_2->get_alpha_BB();
+          log_->printf(hovSummary, "alpd %18.12e\n", alp_temp);
+          // log_->printf(hovSummary, "alpd BB %18.12e\n", alp_temp2);
+          convg_g = hess_appx_2->check_convergence_grad(*grad_r);
+          log_->printf(hovSummary,"gradient convergence measure %18.12e\n", convg_g);
+          convg_f = hess_appx_2->check_convergence_fcn(base_val, base_valm1);
+          log_->printf(hovSummary,"function val convergence measure %18.12e\n", convg_f);
+          convg = std::min(convg_f,convg_g);
+          for(int i=0; i<nc_; i++) {
+            hess_appx_vec[i] = alp_temp;
+          }
+
+        }
+
+        // wait for the sending/receiving to finish
+        // for debugging purpose print out the recourse gradient
+        log_->write(nullptr, *grad_r, hovFcnEval);
+       
+        if(it>0) {
+          log_->printf(hovSummary, "iteration           objective                   residual                   "   
+             "step_size                   convg\n");
+          
+          log_->printf(hovSummary, "%d              %18.12e            %18.12e           %18.12e         " 
+             "%18.12e\n", it, base_val+recourse_val, convg_f, dinf, convg_g);
+          
+          fflush(stdout);
+        }
+
+        assert(evaluator->get_rgrad()!=NULL);// evaluator should be defined
+        evaluator->set_rval(rval);
+        evaluator->set_rgrad(nc_,*grad_r);
+        evaluator->set_rhess(nc_,*hess_appx);
+        evaluator->set_x0(nc_,*x0);
+
+        bret = master_prob_->set_recourse_approx_evaluator(nc_, evaluator);
+        if(!bret) {
+          //TODO
+        }
+        
+        options_file_master_prob = options_->GetString("options_file_master_prob");
+        
+        // log_->printf(hovIteration, "solving full problem starts, iteration %d \n", it); 
+        solver_status_ = master_prob_->solve_master(*x_, true, 0, 0, 0, options_file_master_prob.c_str());
+
+        log_->printf(hovSummary, "solved full problem with objective %18.12e\n", master_prob_->get_objective());
+
+        log_->write(nullptr, *x_, hovFcnEval);
+        
+        t2 = MPI_Wtime(); 
+        log_->printf(hovFcnEval, "Elapsed time for entire iteration %d is %f\n",it, t2 - t1);
+        
+        dinf = step_size_inf(nc_, *xc_idx_, *x_, *x0);
+        
+      } else {
+        // evaluator ranks do nothing     
+      }
+      if(convg <= accp_tol_) {
+        accp_count += 1;
+      } else {
+        accp_count = 0;
+      }
+
+      if(stopping_criteria(it, convg, accp_count)) {
+        end_signal = 1; 
+      }
+      ierr = MPI_Bcast(&end_signal, 1, MPI_INT, rank_master, comm_world_);
+      assert(ierr == MPI_SUCCESS);
+      
+      for(auto it : rec_prob) {
+        delete it;
+      }
+
+      delete req_cont_idx;
+      
+      if(end_signal) {
+        break;
+      }
+    }
+
+    delete grad_r;
+    delete grad_r_main;
+    delete hess_appx;
+    delete x0;
+    //delete grad_acc;
+    delete hess_appx_2;
+    delete evaluator;
+    
+    if(my_rank_==0) {
+      return solver_status_;
+    } else {
+      return Solve_Success;    
+    }
+  }
+
+
+
 
 /* Solve problem in serial with only one rank
  */
@@ -1231,7 +1778,7 @@ hiopSolveStatus hiopAlgPrimalDecomposition::run_single()
   // double grad_r[nc_];
   hiopVector* grad_r;
   grad_r = LinearAlgebraFactory::create_vector(options_->GetString("mem_space"), nc_) ; 
-  double* grad_r_vec = grad_r->local_data_host();
+  double* grad_r_vec = grad_r->local_data();
   
   hiopVector* hess_appx;
   hess_appx = grad_r->alloc_clone();

--- a/src/Optimization/hiopAlgPrimalDecomp.cpp
+++ b/src/Optimization/hiopAlgPrimalDecomp.cpp
@@ -1234,23 +1234,13 @@ void hiopAlgPrimalDecomposition::set_local_accum(const std::string local_accum)
       return Solve_Success;    
     }
   }
-#else
-hiopSolveStatus hiopAlgPrimalDecomposition::run()
-{
-  log_->printf(hovSummary, "===============\nHiop Primal Decomposition SOLVER\n===============\n");
-  if(options_->GetString("print_options") == "yes") {
-    log_->write(nullptr, *options_, hovSummary);
-  }
-  return run_single(); // call the serial solver
-}
-#endif
 
-/**
- * A different asynchronous communication scheme where evaluator ranks 
- * transfer data only once with the master rank
- *
- */
-hiopSolveStatus hiopAlgPrimalDecomposition::run_local()
+  /**
+   * A different asynchronous communication scheme where evaluator ranks 
+   * transfer data only once with the master rank
+   *
+   */
+  hiopSolveStatus hiopAlgPrimalDecomposition::run_local()
   {
     log_->printf(hovSummary, "===============\nHiop Primal Decomposition SOLVER\n===============\n");
     log_->printf(hovSummary, "===============\nUsing local accumulation OPTION\n===============\n");
@@ -1759,6 +1749,17 @@ hiopSolveStatus hiopAlgPrimalDecomposition::run_local()
       return Solve_Success;    
     }
   }
+
+#else
+hiopSolveStatus hiopAlgPrimalDecomposition::run()
+{
+  log_->printf(hovSummary, "===============\nHiop Primal Decomposition SOLVER\n===============\n");
+  if(options_->GetString("print_options") == "yes") {
+    log_->write(nullptr, *options_, hovSummary);
+  }
+  return run_single(); // call the serial solver
+}
+#endif
 
 
 

--- a/src/Optimization/hiopAlgPrimalDecomp.hpp
+++ b/src/Optimization/hiopAlgPrimalDecomp.hpp
@@ -124,6 +124,9 @@ public:
 
   /** Main function to run the optimization in parallel */
   hiopSolveStatus run();
+  /** Main function to run the optimization in parallel with local accumulation of recourse function (and subgradient) */
+  hiopSolveStatus run_local();
+  
   /** Main function to run the optimization in serial */
   hiopSolveStatus run_single();
 
@@ -178,9 +181,15 @@ public:
   /** set the number of iterations that consecutively reach acceptable tolerance before convergence is considered obtained */ 
   void set_acceptable_count(const int count);
  
-  /** compute the step size of the coupled variable, nc components of x */
+  /** compute the step size of the coupled variable, nc components of x 
+   * default is two-norm, not inf norm. Naming due to older version. 
+   */ 
   double step_size_inf(const int nc, const hiopVectorInt& idx, const hiopVector& x, const hiopVector& x0);
-  
+ 
+  /** set the variable local_accum_ */ 
+  void set_local_accum(const std::string local_accum);
+
+
   /** Contains information of a previous solution step including function value 
    * and gradient. Used for storing the solution for the previous iteration
    * This struct is intended for internal use of hiopAlgPrimalDecomposition class only.
@@ -385,6 +394,10 @@ private:
 
   MPI_Comm comm_world_;
   //master/solver(0), or worker(1:total rank)
+
+  // communication strategy; if true, worker ranks accumulate information locally
+  // no effect if only one rank
+  std::string local_accum_ = "no"; 
 
   /// maximum number of outer iterations, can be user specified
   int max_iter_ = 200;

--- a/src/Utils/hiopOptions.cpp
+++ b/src/Utils/hiopOptions.cpp
@@ -1305,6 +1305,14 @@ void hiopOptionsPriDec::register_options()
                         "the memory space in which the master solve is going to be done.");
   }
   
+  // option for local accumulation of function value and subgradient on evaluator ranks, then reduce
+  {
+    register_str_option("accum_local",
+                        "false", // default value for the option
+                        vector<string>({"yes", "no"}), // range
+                        "Accumulates recourse problem solutions locally on evaluator ranks (default 'false')");
+  }
+
   //
   // convergence and stopping criteria
   //


### PR DESCRIPTION
Add a different parallel implementation for pridec solver. Previously, the 2nd stage problem solutions and subgradeints are sent to rank 0 as soon as a problem is solved. The run_local function instead lets evaluator rank each collects the sum of the function value and subgradients locally on its own rank. MPI_Reduce is called after all the 2nd stage problems are solved to send the information to rank 0. This is an option that can be set in hiop_pridec.options.