### PR TITLE
Condensed KKT unified computations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,6 +254,10 @@ if(HIOP_USE_RAJA)
   target_link_libraries(hiop_tpl INTERFACE umpire RAJA)
   message(STATUS "Found RAJA pkg-config: ${RAJA_CONFIG}")
   message(STATUS "Found umpire pkg-config: ${umpire_CONFIG}")
+else()
+  if(HIOP_USE_CUDA)
+    message(FATAL_ERROR "Momentarily RAJA is needed for building with HIOP_USE_CUDA=ON.")
+  endif()
 endif()
 
 # KLU needed with cuSolver. TODO: make this an optional dependency

--- a/src/LinAlg/hiopLinAlgFactory.cpp
+++ b/src/LinAlg/hiopLinAlgFactory.cpp
@@ -66,13 +66,14 @@
 #include <hiopVectorRajaPar.hpp>
 #include <hiopMatrixRajaDense.hpp>
 #include <hiopMatrixRajaSparseTriplet.hpp>
+#include <hiopMatrixSparseCsrCuda.hpp>
 #endif // HIOP_USE_RAJA
 
 #include <hiopVectorIntSeq.hpp>
 #include <hiopVectorPar.hpp>
 #include <hiopMatrixDenseRowMajor.hpp>
 #include <hiopMatrixSparseTriplet.hpp>
-
+#include <hiopMatrixSparseCSRSeq.hpp>
 #include "hiopLinAlgFactory.hpp"
 
 #include "hiopCppStdUtils.hpp"
@@ -177,6 +178,47 @@ hiopMatrixSparse* LinearAlgebraFactory::create_matrix_sparse(const std::string& 
 #endif
   }
 }
+
+hiopMatrixSparseCSR* LinearAlgebraFactory::create_matrix_sparse_csr(const std::string& mem_space)
+{
+  const std::string mem_space_upper = toupper(mem_space);
+  if(mem_space_upper == "DEFAULT") {
+    return new hiopMatrixSparseCSRSeq();
+  } else {
+#ifdef HIOP_USE_GPU
+#ifndef HIOP_USE_RAJA
+#error "(HIOP_USE_)RAJA is needed by the sparse linear algebra (HIOP_SPARSE) under HIOP_USE_GPU"
+#endif
+    return new hiopMatrixSparseCSRCUDA();
+#else
+    assert(false && "requested memory space not available because Hiop was not built with RAJA support");
+    return new hiopMatrixSparseCSRSeq();
+#endif
+  }
+}
+  
+hiopMatrixSparseCSR*  LinearAlgebraFactory::create_matrix_sparse_csr(const std::string& mem_space,
+                                                                     size_type rows,
+                                                                     size_type cols,
+                                                                     size_type nnz)
+{
+  const std::string mem_space_upper = toupper(mem_space);
+  if(mem_space_upper == "DEFAULT") {
+    return new hiopMatrixSparseCSRSeq(rows, cols, nnz);
+  } else {
+#ifdef HIOP_USE_GPU
+#ifndef HIOP_USE_RAJA
+#error "(HIOP_USE_)RAJA is needed by the sparse linear algebra (HIOP_SPARSE) under HIOP_USE_GPU"
+#endif
+    return new hiopMatrixSparseCSRCUDA(rows, cols, nnz);
+#else
+    assert(false && "requested memory space not available because Hiop was not built with RAJA support");
+    return new hiopMatrixSparseCSRSeq(rows, cols, nnz);
+#endif
+  }
+
+}
+
 
 /**
  * @brief Creates an instance of a symmetric sparse matrix of the appropriate

--- a/src/LinAlg/hiopLinAlgFactory.hpp
+++ b/src/LinAlg/hiopLinAlgFactory.hpp
@@ -53,6 +53,7 @@
 #include <hiopVector.hpp>
 #include <hiopMatrixDense.hpp>
 #include <hiopMatrixSparse.hpp>
+#include <hiopMatrixSparseCSR.hpp>
 #include <hiopVectorInt.hpp>
 
 namespace hiop {
@@ -91,12 +92,27 @@ public:
                                               MPI_Comm comm = MPI_COMM_SELF,
                                               const size_type& m_max_alloc = -1);
   /**
-   * @brief Static method to create a sparse matrix
+   * @brief Static method to create the default, triplet sparse matrix
    */
   static hiopMatrixSparse* create_matrix_sparse(const std::string& mem_space,
                                                 size_type rows,
                                                 size_type cols,
                                                 size_type nnz);
+
+  /**
+   * @brief Static method to create an empty CSR sparse matrix of the type that supports the
+   * memory space passed as argument.
+   */
+  static hiopMatrixSparseCSR* create_matrix_sparse_csr(const std::string& mem_space);
+  
+  /**
+   * @brief Static method to create a CSR sparse matrix of the type that supports the
+   * memory space passed as argument.
+   */
+  static hiopMatrixSparseCSR* create_matrix_sparse_csr(const std::string& mem_space,
+                                                       size_type rows,
+                                                       size_type cols,
+                                                       size_type nnz);
 
   /**
    * @brief Static method to create a symmetric sparse matrix

--- a/src/LinAlg/hiopLinSolverCholCuSparse.cpp
+++ b/src/LinAlg/hiopLinSolverCholCuSparse.cpp
@@ -219,115 +219,119 @@ bool hiopLinSolverCholCuSparse::initial_setup()
   std::stringstream ss_log;
 
   //
-  // compute permutation to promote sparsity in the factors
+  // compute permutation to promote sparsity in the factors (on CPU/host)
   //
-  const bool dopermutation = true;
-  if(dopermutation) {
-    t.reset(); t.start();
-
-    auto* P_h = new index_type[m];
-
-    hiopMatrixSparseCSRSeq mat_csr_h(mat_csr->m(), mat_csr->m(), mat_csr->numberOfNonzeros());
-    mat_csr->copy_to(mat_csr_h);
+  t.reset(); t.start();
+  
+  auto* P_h = new index_type[m];
+  
+  hiopMatrixSparseCSRSeq mat_csr_h(mat_csr->m(), mat_csr->m(), mat_csr->numberOfNonzeros());
+  mat_csr->copy_to(mat_csr_h);
     
+  
+  do_symb_analysis(mat_csr_h.m(),
+                   mat_csr_h.numberOfNonzeros(),
+                   mat_csr_h.i_row(),
+                   mat_csr_h.j_col(),
+                   mat_csr_h.M(),
+                   P_h);
+  ss_log << "\tOrdering: '" << nlp_->options->GetString("linear_solver_sparse_ordering") << "': ";
     
-    do_symb_analysis(mat_csr_h.m(),
-                     mat_csr_h.numberOfNonzeros(),
-                     mat_csr_h.i_row(),
-                     mat_csr_h.j_col(),
-                     mat_csr_h.M(),
-                     P_h);
-    ss_log << "\tOrdering: '" << nlp_->options->GetString("linear_solver_sparse_ordering") << "': ";
+  t.stop();
+  ss_log << std::fixed << std::setprecision(4) << t.getElapsedTime() << " sec\n";
+  
+  //compute transpose/inverse permutation
+  index_type* PT_h = new index_type[m];
+  for(index_type i=0; i<m; i++) {
+    PT_h[P_h[i]] = i;
+  }
+  
+  //transfer permutation and its transpose to the device
+  assert(nullptr == P_);
+  cudaMalloc(&P_, m*sizeof(index_type));
+  cudaMemcpy(P_, P_h, m*sizeof(index_type), cudaMemcpyHostToDevice);
+  
+  assert(nullptr == PT_);
+  cudaMalloc(&PT_, m*sizeof(index_type));
+  cudaMemcpy(PT_, PT_h, m*sizeof(index_type), cudaMemcpyHostToDevice);
+  delete[] PT_h;
+  
+  // get permutation buffer size
+  size_t buf_size;
+  ret = cusolverSpXcsrperm_bufferSizeHost(h_cusolver_,
+                                          m,
+                                          m,
+                                          nnz_,
+                                          mat_descr_,
+                                          mat_csr_h.i_row(),
+                                          mat_csr_h.j_col(),
+                                          P_h,
+                                          P_h,
+                                          &buf_size);
+  assert(ret == CUSOLVER_STATUS_SUCCESS);
+  
+  // temporary buffer needed for permutation purposes (on host)
+  unsigned char* buf_perm_h = new unsigned char[buf_size];
+  
+  //compute permuted CSR arrays (on host)
+  int* rowptr_perm_h = new int[m+1];
+  int* colind_perm_h = new int[nnz_];
+  assert(rowptr_perm_h);
+  assert(colind_perm_h);
+  memcpy(rowptr_perm_h, mat_csr_h.i_row(), (m+1)*sizeof(int));
+  memcpy(colind_perm_h, mat_csr_h.j_col(), nnz_*sizeof(int));
     
-    t.stop();
-    ss_log << std::fixed << std::setprecision(4) << t.getElapsedTime() << " sec\n";
-
-    //compute transpose/inverse permutation
-    index_type* PT_h = new index_type[m];
-    for(int i=0; i<m; i++) {
-      PT_h[P_h[i]] = i;
-    }
-
-    //transfer permutation and its transpose to the device
-    assert(nullptr == P_);
-    cudaMalloc(&P_, m*sizeof(index_type));
-    cudaMemcpy(P_, P_h, m*sizeof(index_type), cudaMemcpyHostToDevice);
-    
-    assert(nullptr == PT_);
-    cudaMalloc(&PT_, m*sizeof(index_type));
-    cudaMemcpy(PT_, PT_h, m*sizeof(index_type), cudaMemcpyHostToDevice);
-    delete[] PT_h;
-
-    // get permutation buffer size
-    size_t buf_size;
-    ret = cusolverSpXcsrperm_bufferSizeHost(h_cusolver_,
-                                            m,
-                                            m,
-                                            nnz_,
-                                            mat_descr_,
-                                            mat_csr_h.i_row(),
-                                            mat_csr_h.j_col(),
-                                            P_h,
-                                            P_h,
-                                            &buf_size);
-    assert(ret == CUSOLVER_STATUS_SUCCESS);
-    
-    // temporary buffer needed for permutation purposes (on host)
-    unsigned char* buf_perm_h = new unsigned char[buf_size];
-    
-    //compute permuted CSR arrays (on host)
-    int* rowptr_perm_h = new int[m+1];
-    int* colind_perm_h = new int[nnz_];
-    assert(rowptr_perm_h);
-    assert(colind_perm_h);
-    memcpy(rowptr_perm_h, mat_csr_h.i_row(), (m+1)*sizeof(int));
-    memcpy(colind_perm_h, mat_csr_h.j_col(), nnz_*sizeof(int));
-    
-    //mapping (on host)
-    int* map_h = new int[nnz_];
-    for(int i=0; i<nnz_; i++) {
-      map_h[i] = i;
-    }
-
-    t.reset();
-    t.start();
-    ret = cusolverSpXcsrpermHost(h_cusolver_,
-                                 m,
-                                 m,
-                                 nnz_,
-                                 mat_descr_,
-                                 rowptr_perm_h,
-                                 colind_perm_h,
-                                 P_h,
-                                 P_h,
-                                 map_h,
-                                 buf_perm_h);
-    assert(ret == CUSOLVER_STATUS_SUCCESS);
-    t.stop();
-    ss_log << "\tcsrpermHost: " << t.getElapsedTime() << " sec" << std::endl;
-    delete[] P_h;
-    delete[] buf_perm_h;
-    
-    assert(nullptr == map_nnz_perm_);
-    cudaMalloc(&map_nnz_perm_, nnz_*sizeof(int));
-    //transfer the permutation map for nonzeros on device
-    cudaMemcpy(map_nnz_perm_, map_h, nnz_*sizeof(int), cudaMemcpyHostToDevice);
-    delete[] map_h;
-    // transfer the CSR index arrays on device
-    //
-    //values_ not needed here and will be updated in matrixChanged()
-    cudaMemcpy(rowptr_, rowptr_perm_h, (m+1)*sizeof(int), cudaMemcpyHostToDevice);
-    cudaMemcpy(colind_, colind_perm_h, nnz_*sizeof(int), cudaMemcpyHostToDevice);
-
-    delete[] colind_perm_h;
-    delete[] rowptr_perm_h;
-
-  } else {
+  //mapping (on host)
+  int* map_h = new int[nnz_];
+  for(index_type i=0; i<nnz_; i++) {
+    map_h[i] = i;
+  }
+  
+  t.reset();
+  t.start();
+  ret = cusolverSpXcsrpermHost(h_cusolver_,
+                               m,
+                               m,
+                               nnz_,
+                               mat_descr_,
+                               rowptr_perm_h,
+                               colind_perm_h,
+                               P_h,
+                               P_h,
+                               map_h,
+                               buf_perm_h);
+  assert(ret == CUSOLVER_STATUS_SUCCESS);
+  t.stop();
+  ss_log << "\tcsrpermHost: " << t.getElapsedTime() << " sec" << std::endl;
+  delete[] P_h;
+  delete[] buf_perm_h;
+  
+  assert(nullptr == map_nnz_perm_);
+  cudaMalloc(&map_nnz_perm_, nnz_*sizeof(int));
+  //transfer the permutation map for nonzeros on device
+  cudaMemcpy(map_nnz_perm_, map_h, nnz_*sizeof(int), cudaMemcpyHostToDevice);
+  delete[] map_h;
+  // transfer the CSR index arrays on device
+  //
+  //values_ not needed here and will be updated in matrixChanged()
+  cudaMemcpy(rowptr_, rowptr_perm_h, (m+1)*sizeof(int), cudaMemcpyHostToDevice);
+  cudaMemcpy(colind_, colind_perm_h, nnz_*sizeof(int), cudaMemcpyHostToDevice);
+  
+  delete[] colind_perm_h;
+  delete[] rowptr_perm_h;
+  //end of ordering permutation to promote sparsity in the factors
+   
+#if 0
+  // the code below skips ordering permutation computation that is computed above. It uses
+  // the trivial permuation/no factor sparsity promoting permutation. It results in poor
+  // sparsity pattern and hence, in very long factorization times. It is intended for debugging
+  // purposes only
+  {
     cudaMemcpy(rowptr_, mat_csr->i_row(), (m+1)*sizeof(int), cudaMemcpyDeviceToDevice);
     cudaMemcpy(colind_, mat_csr->j_col(), nnz_*sizeof(int), cudaMemcpyDeviceToDevice);
     
-    int map_h[nnz_];
-    for(int i=0; i<nnz_; i++) {
+    index_type map_h[nnz_];
+    for(index_type i=0; i<nnz_; i++) {
       map_h[i] = i;
     }
     assert(nullptr == map_nnz_perm_);
@@ -335,9 +339,9 @@ bool hiopLinSolverCholCuSparse::initial_setup()
     cudaMemcpy(map_nnz_perm_, map_h, nnz_*sizeof(int), cudaMemcpyHostToDevice);
 
 
-    int PT_h[m];
-    int P_h[m];
-    for(int i=0; i<m; i++) {
+    index_type PT_h[m];
+    index_type P_h[m];
+    for(index_type i=0; i<m; i++) {
       PT_h[i] = i;
       P_h[i] = i;
     }
@@ -349,7 +353,7 @@ bool hiopLinSolverCholCuSparse::initial_setup()
     assert(nullptr == PT_);
     cudaMalloc(&PT_, m*sizeof(index_type));
     cudaMemcpy(PT_, PT_h, m*sizeof(index_type), cudaMemcpyHostToDevice);
-  }
+#endif //end of trivial permutation 
 
   t.reset();
   t.start();
@@ -466,7 +470,7 @@ bool hiopLinSolverCholCuSparse::solve(hiopVector& x_in)
   hiopTimer t;
   cusolverStatus_t ret;
   
-  int m = M_->m();
+  size_type m = M_->m();
   assert(m == x_in.get_size());
 
   if(!rhs_buf1_) {
@@ -511,7 +515,7 @@ bool hiopLinSolverCholCuSparse::solve(hiopVector& x_in)
 bool hiopLinSolverCholCuSparse::permute_vec(int n, double* vec_in, index_type* perm, double* vec_out)
 {
   cusparseStatus_t ret;
-#if CUSPARSE_VERSION >= 11700
+#if CUSPARSE_VERSION >= 11400
   //the descr of the array going to be permuted
   cusparseSpVecDescr_t v_out;
   //original nonzeros
@@ -538,7 +542,7 @@ bool hiopLinSolverCholCuSparse::permute_vec(int n, double* vec_in, index_type* p
   cusparseDestroySpVec(v_out);
   cusparseDestroyDnVec(v_in);
   
-#else //CUSPARSE_VERSION < 11700
+#else //CUSPARSE_VERSION < 11400
   
   ret = cusparseDgthr(h_cusparse_, n, vec_in, vec_out, perm, CUSPARSE_INDEX_BASE_ZERO);
   assert(CUSPARSE_STATUS_SUCCESS == ret);

--- a/src/LinAlg/hiopLinSolverCholCuSparse.hpp
+++ b/src/LinAlg/hiopLinSolverCholCuSparse.hpp
@@ -64,7 +64,7 @@
 #include <cusolverSp.h>
 #include <cusolverSp_LOWLEVEL_PREVIEW.h> 
 
-#include "hiopMatrixSparseCSRSeq.hpp"
+#include "hiopMatrixSparseCsrCuda.hpp"
 #include "hiopKKTLinSysSparseCondensed.hpp"
 namespace hiop
 {
@@ -153,9 +153,9 @@ protected:
   double* rhs_buf2_;
   
 protected:
-  inline hiopMatrixSparseCSR* sys_mat_csr()
+  inline hiopMatrixSparseCSRCUDA* sys_mat_csr()
   {
-    return dynamic_cast<hiopMatrixSparseCSR*>(M_);
+    return dynamic_cast<hiopMatrixSparseCSRCUDA*>(M_);
   }
 private:
   hiopLinSolverCholCuSparse() = delete; 

--- a/src/LinAlg/hiopLinSolverCholCuSparse.hpp
+++ b/src/LinAlg/hiopLinSolverCholCuSparse.hpp
@@ -126,13 +126,11 @@ protected:
   /// Number of nonzeros in the matrix sent to cuSOLVER
   size_type nnz_;
 
-  /// Array with row pointers of the matrix to be factorized (on device)
+  /// Array with row pointers of the matrix (permuted based on ordering) to be factorized (on device)
   int* rowptr_;
-  /// Array with column indexes of the matrix to be factorized (on device)
+  /// Array with column indexes of the matrix (permuted based on ordering) to be factorized (on device)
   int* colind_;
-  /// Array with matrix original values (on device)
-  double* values_buf_;
-  /// Array with values of the matrix to be factorized (on device)
+  /// Array with values of the matrix (permuted based on ordering) to be factorized (on device)
   double* values_;
   /// cuSPARSE matrix descriptor
   cusparseMatDescr_t mat_descr_;

--- a/src/LinAlg/hiopMatrixSparseCSR.hpp
+++ b/src/LinAlg/hiopMatrixSparseCSR.hpp
@@ -284,7 +284,12 @@ public:
                                   const hiopMatrixSparseCSR& Y,
                                   double beta) const = 0;
 
-  /// @brief Performs a quick check and returns false if the CSR indexes are not ordered
+  /** Performs a quick check and returns false if the CSR indexes are not ordered. 
+   * 
+   * Should be used with caution, for example only under HIOP_DEEPCHECKS or for debugging purposes
+   * because it is a computationally intensive method for GPU implementations as transfers the 
+   * matrix data from device to host. 
+   */
   virtual bool check_csr_is_ordered() = 0;
   /////////////////////////////////////////////////////////////////////
   // end of new CSR-specific methods

--- a/src/LinAlg/hiopMatrixSparseCsrCuda.cpp
+++ b/src/LinAlg/hiopMatrixSparseCsrCuda.cpp
@@ -421,6 +421,16 @@ void hiopMatrixSparseCSRCUDA::copy_to(hiopMatrixDense& W)
   assert(W.n() == ncols_);
 }
 
+void hiopMatrixSparseCSRCUDA::copy_to(hiopMatrixSparseCSRSeq& W)
+{
+  assert(W.m() == nrows_);
+  assert(W.n() == ncols_);
+  assert(W.numberOfNonzeros() == nnz_);
+  cudaMemcpy(W.i_row(), this->i_row(), sizeof(index_type)*(1+nrows_), cudaMemcpyDeviceToHost);
+  cudaMemcpy(W.j_col(), this->j_col(), sizeof(index_type)*nnz_, cudaMemcpyDeviceToHost);
+  cudaMemcpy(W.M(), this->M(), sizeof(double)*nnz_, cudaMemcpyDeviceToHost);
+}
+
 void hiopMatrixSparseCSRCUDA::
 addMDinvMtransToDiagBlockOfSymDeMatUTri(index_type rowAndCol_dest_start,
                                         const double& alpha,

--- a/src/LinAlg/hiopMatrixSparseCsrCuda.cpp
+++ b/src/LinAlg/hiopMatrixSparseCsrCuda.cpp
@@ -1235,8 +1235,9 @@ void hiopMatrixSparseCSRCUDA::extract_diagonal(hiopVector& diag_out) const
 
 bool hiopMatrixSparseCSRCUDA::check_csr_is_ordered()
 {
-  assert(false && "work in progress");
-  return true;
+  hiopMatrixSparseCSRSeq mat_h(nrows_, ncols_, nnz_);
+  this->copy_to(mat_h);
+  return mat_h.check_csr_is_ordered();
 }
 
 } //end of namespace

--- a/src/LinAlg/hiopMatrixSparseCsrCuda.hpp
+++ b/src/LinAlg/hiopMatrixSparseCsrCuda.hpp
@@ -64,6 +64,7 @@
 #include "hiopVector.hpp"
 #include "hiopMatrixDense.hpp"
 #include "hiopMatrixSparseCSR.hpp"
+#include "hiopMatrixSparseCSRSeq.hpp"
 #include "hiopMatrixSparseTriplet.hpp"
 
 #include <cassert>
@@ -92,6 +93,13 @@ public:
   virtual void setToConstant(double c);
   virtual void copyFrom(const hiopMatrixSparse& dm);
   virtual void copy_to(index_type* irow, index_type* jcol, double* val);
+
+  /**
+   * Copy to a CSR matrix allocated on host. Device to host transfer occurs. This is temporary
+   * code that will be removed in the future.
+   */
+  void copy_to(hiopMatrixSparseCSRSeq& src);
+  
   virtual void copy_to(hiopMatrixDense& W);
 
   virtual void copyRowsFrom(const hiopMatrix& src, const index_type* rows_idxs, size_type n_rows);

--- a/src/LinAlg/hiopMatrixSparseCsrCuda.hpp
+++ b/src/LinAlg/hiopMatrixSparseCsrCuda.hpp
@@ -579,7 +579,12 @@ public:
                           const hiopMatrixSparseCSR& Y,
                           double beta) const;
 
-  /// @brief Performs a quick check and returns false if the CSR indexes are not ordered
+  /** Performs a quick check and returns false if the CSR indexes are not ordered. 
+   * 
+   * Should be used with caution, for example only under HIOP_DEEPCHECKS or for debugging purposes
+   * because it is a computationally intensive method for GPU implementations as transfers the 
+   * matrix data from device to host. 
+   */
   bool check_csr_is_ordered();
   
   /////////////////////////////////////////////////////////////////////

--- a/src/Optimization/hiopKKTLinSysSparse.cpp
+++ b/src/Optimization/hiopKKTLinSysSparse.cpp
@@ -624,7 +624,7 @@ namespace hiop
         /////////////////////////////////////////////////////////////////////////////////////////////
         // CPU compute mode
         /////////////////////////////////////////////////////////////////////////////////////////////
-        
+        printf("aaaaaaaaaaaaaaa %s \n", linear_solver.c_str()); fflush(stdout);
         if(linear_solver == "ma57" || linear_solver == "auto") {
 #ifdef HIOP_USE_COINHSL
           linSys_ = new hiopLinSolverSymSparseMA57(n, nnz, nlp_);

--- a/src/Optimization/hiopKKTLinSysSparse.cpp
+++ b/src/Optimization/hiopKKTLinSysSparse.cpp
@@ -624,7 +624,6 @@ namespace hiop
         /////////////////////////////////////////////////////////////////////////////////////////////
         // CPU compute mode
         /////////////////////////////////////////////////////////////////////////////////////////////
-        printf("aaaaaaaaaaaaaaa %s \n", linear_solver.c_str()); fflush(stdout);
         if(linear_solver == "ma57" || linear_solver == "auto") {
 #ifdef HIOP_USE_COINHSL
           linSys_ = new hiopLinSolverSymSparseMA57(n, nnz, nlp_);

--- a/src/Optimization/hiopKKTLinSysSparseCondensed.cpp
+++ b/src/Optimization/hiopKKTLinSysSparseCondensed.cpp
@@ -275,7 +275,8 @@ bool hiopKKTLinSysCondensedSparse::build_kkt_matrix(const double& delta_wx_in,
   // (Jt*D) * J
   JacDt_->times_mat_numeric(0.0, *JtDiagJ_, 1.0, *JacD_);
   //t.stop(); printf("J*D*J'-nume  took %.5f\n", t.getElapsedTime());
-  
+
+  JtDiagJ_->print(stdout, "----\nJtDiagJ_\n");
 #ifdef HIOP_DEEPCHECKS
   JtDiagJ_->check_csr_is_ordered();
 #endif

--- a/src/Optimization/hiopKKTLinSysSparseCondensed.cpp
+++ b/src/Optimization/hiopKKTLinSysSparseCondensed.cpp
@@ -291,12 +291,14 @@ bool hiopKKTLinSysCondensedSparse::build_kkt_matrix(const double& delta_wx_in,
     Hess_upper_csr_ = LinearAlgebraFactory::create_matrix_sparse_csr(mem_space_internal);
     Hess_upper_csr_->form_from_symbolic(*Hess_triplet);
     Hess_upper_csr_->form_from_numeric(*Hess_triplet);
-    Hess_upper_csr_->set_diagonal(0.0);
     
     assert(nullptr == Hess_lower_csr_);
     Hess_lower_csr_ = LinearAlgebraFactory::create_matrix_sparse_csr(mem_space_internal);
     Hess_lower_csr_->form_transpose_from_symbolic(*Hess_upper_csr_);
     Hess_lower_csr_->form_transpose_from_numeric(*Hess_upper_csr_);
+
+    //zero out diagonal of the upper triangle to avoid adding it twice
+    Hess_upper_csr_->set_diagonal(0.0);
     
     assert(Hess_lower_csr_->numberOfNonzeros() == Hess_upper_csr_->numberOfNonzeros());
 
@@ -332,8 +334,9 @@ bool hiopKKTLinSysCondensedSparse::build_kkt_matrix(const double& delta_wx_in,
     t.reset(); t.start();
     //form lower and upper
     Hess_upper_csr_->form_from_numeric(*Hess_triplet);
-    Hess_upper_csr_->set_diagonal(0.0);
     Hess_lower_csr_->form_transpose_from_numeric(*Hess_upper_csr_);
+    //zero out diagonal of the upper triangle to avoid adding it twice
+    Hess_upper_csr_->set_diagonal(0.0);
     Diag_Dx_deltawx_->form_diag_from_numeric(*Dx_plus_deltawx_);
     Hess_upper_csr_->add_matrix_numeric(*Hess_upper_plus_diag_, 1.0, *Diag_Dx_deltawx_, 1.0);
     Hess_lower_csr_->add_matrix_numeric(*Hess_csr_, 1.0, *Hess_upper_plus_diag_, 1.0);
@@ -347,8 +350,9 @@ bool hiopKKTLinSysCondensedSparse::build_kkt_matrix(const double& delta_wx_in,
   //}
   //M_condensed_->addDiagonal(1.0, *Dx_);
 
-  Hess_csr_->print();
-  M_condensed_->print();
+  Dx_->print(stdout, "\n----  Dx\n");
+  Hess_csr_->print(stdout, "\nHess_csr_\n");
+  M_condensed_->print(stdout, "\n-----M_condensed_\n");
 
   fflush(stdout);
 

--- a/src/Optimization/hiopKKTLinSysSparseCondensed.cpp
+++ b/src/Optimization/hiopKKTLinSysSparseCondensed.cpp
@@ -80,13 +80,19 @@ hiopKKTLinSysCondensedSparse::hiopKKTLinSysCondensedSparse(hiopNlpFormulation* n
     Hess_upper_csr_(nullptr),
     Hess_csr_(nullptr),
     M_condensed_(nullptr),
-    Dx_plus_deltawx_(nullptr)
+    Hess_upper_plus_diag_(nullptr),
+    Dx_plus_deltawx_(nullptr),
+    Diag_Dx_deltawx_(nullptr),
+    Hd_copy_(nullptr)
 {
 }
 
 hiopKKTLinSysCondensedSparse::~hiopKKTLinSysCondensedSparse()
 {
+  delete Hd_copy_;
+  delete Diag_Dx_deltawx_;  
   delete Dx_plus_deltawx_;
+  delete Hess_upper_plus_diag_;
   delete M_condensed_;
   delete JtDiagJ_;
   delete JacDt_;
@@ -135,29 +141,44 @@ bool hiopKKTLinSysCondensedSparse::build_kkt_matrix(const double& delta_wx_in,
   assert(nineq == Dd_->get_size());
   assert(nx == Dx_->get_size());
 
+  // NOTE:
+  // hybrid compute mode -> linear algebra objects used internally by the class will be allocated on the device. Most of the inputs
+  // to this class will be however on HOST under hybrid mode, so some objects are copied/replicated/transfered to device
+  // gpu copute mode -> not yet supported
+  // cpu compute mode -> all objects on HOST, however, some objects will still be copied (e.g., Hd_) to ensure code homogeinity
+  //
+  // REMARK: The objects that are copied/replicated are temporary and will be removed later on as the remaining sparse KKT computations
+  // will be ported to device
 
+  //determine the "internal" memory space, see above note
+  std::string mem_space_internal = determine_memory_space_internal(nlp_->options->GetString("compute_mode"));
+  
   //allocate on the first call
-  auto mem_space_internal = determine_memory_space_internal(); 
   if(nullptr == Hd_) {
+    //HOST
     Hd_ = LinearAlgebraFactory::create_vector(nlp_->options->GetString("mem_space"), nineq);
+
+    assert(nullptr == Hd_copy_);
+    //temporary: make a copy of Hd on the "internal" mem_space
+    Hd_copy_ = LinearAlgebraFactory::create_vector(mem_space_internal, nineq);
+
     assert(nullptr == Dx_plus_deltawx_); //should be also not allocated
     //allocate this internal vector on the device if hybrid compute mode
     Dx_plus_deltawx_ = LinearAlgebraFactory::create_vector(mem_space_internal, Dx_->get_size());
   }
 
-//#define CSRCUDA_TESTING
-#ifdef CSRCUDA_TESTING
-  //temporary: put copy of Hd on device, unless compute mode is cpu
-  hiopVector* Hd_cuda = LinearAlgebraFactory::create_vector(mem_space_internal, nineq);
-#endif
+  //
+  // compute diagonals
+  //
+
+  //Hd_
   Hd_->copyFrom(*Dd_);
   Hd_->addConstant(delta_wd);
 
-#ifdef CSRCUDA_TESTING
-  //temporary code that will not be needed when all the objects will be allocated in the correct memory space
+  //temporary code, see above note
   {
     if(mem_space_internal == "DEVICE") {
-      auto Hd_raja = dynamic_cast<hiopVectorRajaPar*>(Hd_cuda);
+      auto Hd_raja = dynamic_cast<hiopVectorRajaPar*>(Hd_copy_);
       auto Hd_par =  dynamic_cast<hiopVectorPar*>(Hd_);
       assert(Hd_raja && "incorrect type for vector class");
       assert(Hd_par && "incorrect type for vector class");      
@@ -169,12 +190,12 @@ bool hiopKKTLinSysCondensedSparse::build_kkt_matrix(const double& delta_wx_in,
       Dx_raja->copy_from_host_vec(*Dx_par);
     } else {
       assert(dynamic_cast<hiopVectorPar*>(Hd_) && "incorrect type for vector class");
-      Hd_cuda->copyFrom(*Hd_);
+      Hd_copy_->copyFrom(*Hd_);
       Dx_plus_deltawx_->copyFrom(*Dx_);
     }
   }
-#endif
 
+  // Dd_ + delta_wx*I
   Dx_plus_deltawx_->addConstant(delta_wx);
   
   nlp_->runStats.kkt.tmUpdateInit.stop();
@@ -183,17 +204,20 @@ bool hiopKKTLinSysCondensedSparse::build_kkt_matrix(const double& delta_wx_in,
   //
   // compute condensed linear system J'*D*J + H + Dx + delta_wx*I
   //
+
+  printf("internal mem space: %s\n", mem_space_internal.c_str());fflush(stdout);
+  printf("compute mode: %s\n", nlp_->options->GetString("compute_mode").c_str());fflush(stdout);
   
   hiopTimer t;
   
   // symbolic conversion from triplet to CSR
   if(nullptr == JacD_) {
     t.reset(); t.start();
-    JacD_ = new hiopMatrixSparseCSRSeq();
+    JacD_ = LinearAlgebraFactory::create_matrix_sparse_csr(mem_space_internal);
     JacD_->form_from_symbolic(*Jac_triplet);
 
     assert(nullptr == JacDt_);
-    JacDt_ = new hiopMatrixSparseCSRSeq();
+    JacDt_ = LinearAlgebraFactory::create_matrix_sparse_csr(mem_space_internal);
     JacDt_->form_transpose_from_symbolic(*JacD_);
     //t.stop(); printf("JacD JacDt-symb from csr    took %.5f\n", t.getElapsedTime());
   }
@@ -233,7 +257,7 @@ bool hiopKKTLinSysCondensedSparse::build_kkt_matrix(const double& delta_wx_in,
   }
 
 #ifdef CSRCUDA_TESTING
-  JacD_cuda.scale_rows(*Hd_cuda);
+  JacD_cuda.scale_rows(*Hd_copy_);
 
   JtDiagJ_cuda = JacDt_cuda.times_mat_alloc(JacD_cuda);
   JacDt_cuda.times_mat_symbolic(*JtDiagJ_cuda, JacD_cuda);
@@ -247,66 +271,86 @@ bool hiopKKTLinSysCondensedSparse::build_kkt_matrix(const double& delta_wx_in,
   //numeric multiplication for JacD'*D*J
   t.reset(); t.start();
   // Jt * D
-  JacD_->scale_rows(*Hd_);
+  JacD_->scale_rows(*Hd_copy_);
   // (Jt*D) * J
   JacDt_->times_mat_numeric(0.0, *JtDiagJ_, 1.0, *JacD_);
   //t.stop(); printf("J*D*J'-nume  took %.5f\n", t.getElapsedTime());
-
+  
 #ifdef HIOP_DEEPCHECKS
   JtDiagJ_->check_csr_is_ordered();
 #endif
+  //
+  // Hess_csr_ = Hess_lower_csr_ + Hess_upper_csr_ + Dx + delta_wx*I
+  //
 
   if(nullptr == linSys_) {
-    //first time this is called
+    //
+    // allocate and perform symbolic phase first time this is called.
     assert(nullptr == Hess_upper_csr_);
-    Hess_upper_csr_ = new hiopMatrixSparseCSRSeq();
+    Hess_upper_csr_ = LinearAlgebraFactory::create_matrix_sparse_csr(mem_space_internal);
     Hess_upper_csr_->form_from_symbolic(*Hess_triplet);
-
+    Hess_upper_csr_->form_from_numeric(*Hess_triplet);
+    Hess_upper_csr_->set_diagonal(0.0);
+    
     assert(nullptr == Hess_lower_csr_);
-    Hess_lower_csr_ = new hiopMatrixSparseCSRSeq();
-    Hess_lower_csr_->form_transpose_from_symbolic(*Hess_triplet);
-
+    Hess_lower_csr_ = LinearAlgebraFactory::create_matrix_sparse_csr(mem_space_internal);
+    Hess_lower_csr_->form_transpose_from_symbolic(*Hess_upper_csr_);
+    Hess_lower_csr_->form_transpose_from_numeric(*Hess_upper_csr_);
+    
     assert(Hess_lower_csr_->numberOfNonzeros() == Hess_upper_csr_->numberOfNonzeros());
 
+    assert(nullptr == Diag_Dx_deltawx_);
+    Diag_Dx_deltawx_ = LinearAlgebraFactory::create_matrix_sparse_csr(mem_space_internal);
+    Diag_Dx_deltawx_->form_diag_from_symbolic(*Dx_plus_deltawx_);
+    Diag_Dx_deltawx_->form_diag_from_numeric(*Dx_plus_deltawx_);
+    
+    // Hess_upper_plus_diag_ =  Hess_upper_csr_ + Dx + delta_wx*I
+    assert(nullptr == Hess_upper_plus_diag_);
+    Hess_upper_plus_diag_ = Hess_upper_csr_->add_matrix_alloc(*Diag_Dx_deltawx_);
+    Hess_upper_csr_->add_matrix_symbolic(*Hess_upper_plus_diag_, *Diag_Dx_deltawx_);
+    Hess_upper_csr_->add_matrix_numeric(*Hess_upper_plus_diag_, 1.0, *Diag_Dx_deltawx_, 1.0);
+    
+    // form full Hess_csr_ = Hess_lower_csr_ + ( Hess_upper_csr_ + Dx + delta_wx*I )
     assert(nullptr == Hess_csr_);
-    Hess_csr_ = Hess_lower_csr_->add_matrix_alloc(*Hess_upper_csr_);
-    Hess_lower_csr_->add_matrix_symbolic(*Hess_csr_, *Hess_upper_csr_);
-
-    
-    //a temporary matrix needed to form sparsity pattern of M_condensed_
-    auto* M_condensed_tmp = Hess_csr_->add_matrix_alloc(*JtDiagJ_);
-    Hess_csr_->add_matrix_symbolic(*M_condensed_tmp, *JtDiagJ_);
-    
-    //ensure storage for nonzeros diagonal is allocated by adding (symbolically)
-    //a diagonal matrix
-    hiopMatrixSparseCSRSeq Diag;
-    Diag.form_diag_from_symbolic(*Dx_);
+    Hess_csr_ = Hess_lower_csr_->add_matrix_alloc(*Hess_upper_plus_diag_);
+    Hess_lower_csr_->add_matrix_symbolic(*Hess_csr_, *Hess_upper_plus_diag_);
+    Hess_lower_csr_->add_matrix_numeric(*Hess_csr_, 1.0, *Hess_upper_plus_diag_, 1.0);
 
     assert(nullptr == M_condensed_);
-    M_condensed_ = M_condensed_tmp->add_matrix_alloc(Diag);
-    M_condensed_tmp->add_matrix_symbolic(*M_condensed_, Diag);
-    delete M_condensed_tmp;
-
+    M_condensed_ = Hess_csr_->add_matrix_alloc(*JtDiagJ_);
+    Hess_csr_->add_matrix_symbolic(*M_condensed_, *JtDiagJ_);
+    Hess_csr_->add_matrix_numeric(*M_condensed_, 1.0, *JtDiagJ_, 1.0);
+    
     //t.stop(); printf("ADD-symb  took %.5f\n", t.getElapsedTime());
   } else {
     auto* lins_sys_sparse = dynamic_cast<hiopLinSolverSymSparse*>(linSys_);
     assert(linSys_);
     assert(M_condensed_);
     //todo assert(M_condensed_ == linSys_->sys_matrix());
+  
+    t.reset(); t.start();
+    //form lower and upper
+    Hess_upper_csr_->form_from_numeric(*Hess_triplet);
+    Hess_upper_csr_->set_diagonal(0.0);
+    Hess_lower_csr_->form_transpose_from_numeric(*Hess_upper_csr_);
+    Diag_Dx_deltawx_->form_diag_from_numeric(*Dx_plus_deltawx_);
+    Hess_upper_csr_->add_matrix_numeric(*Hess_upper_plus_diag_, 1.0, *Diag_Dx_deltawx_, 1.0);
+    Hess_lower_csr_->add_matrix_numeric(*Hess_csr_, 1.0, *Hess_upper_plus_diag_, 1.0);
+    Hess_csr_->add_matrix_numeric(*M_condensed_, 1.0, *JtDiagJ_, 1.0);
+    //t.stop(); printf("ADD-nume  took %.5f\n", t.getElapsedTime());
   }
 
-  t.reset(); t.start();
-  Hess_upper_csr_->form_from_numeric(*Hess_triplet);
-  Hess_upper_csr_->set_diagonal(0.0);
-  Hess_lower_csr_->form_transpose_from_numeric(*Hess_triplet);
-  //
-  // Hess_csr_ = Hess_lower_csr_ + Hess_upper_csr_
-  //
-  Hess_lower_csr_->add_matrix_numeric(*Hess_csr_, 1.0, *Hess_upper_csr_, 1.0);
+  
+  //if(delta_wx>0) {
+   //  M_condensed_->addDiagonal(delta_wx);
+  //}
+  //M_condensed_->addDiagonal(1.0, *Dx_);
+
   Hess_csr_->print();
+  M_condensed_->print();
+
   fflush(stdout);
 
-  
 #ifdef CSRCUDA_TESTING
   hiopMatrixSparseCSRCUDA* Hess_upper_csr_cuda = new hiopMatrixSparseCSRCUDA();
   Hess_upper_csr_cuda->form_from_symbolic(*Hess_triplet);
@@ -315,6 +359,7 @@ bool hiopKKTLinSysCondensedSparse::build_kkt_matrix(const double& delta_wx_in,
   hiopMatrixSparseCSRCUDA* Hess_lower_csr_cuda  = new hiopMatrixSparseCSRCUDA();
   Hess_lower_csr_cuda->form_transpose_from_symbolic(*Hess_upper_csr_cuda);
   Hess_lower_csr_cuda->form_transpose_from_numeric(*Hess_upper_csr_cuda);
+
   //set diagonal entries to zero (if any present) to avoid adding it the sum twice
   Hess_upper_csr_cuda->set_diagonal(0.0);
 
@@ -346,27 +391,10 @@ bool hiopKKTLinSysCondensedSparse::build_kkt_matrix(const double& delta_wx_in,
   delete Hess_lower_csr_cuda;
   delete Hess_upper_csr_cuda;
   delete JtDiagJ_cuda;
-  delete Hd_cuda;
   delete M_condensed_cuda;
   delete Hess_upper_plus_diag_cuda;
 #endif
   
-  //
-  // M_condensed_ = M_condensed_ + Hess_csr_ + JtDiagJ_ + Dx_ + delta_wx*I
-  //
-  Hess_csr_->add_matrix_numeric(*M_condensed_, 1.0, *JtDiagJ_, 1.0);
-  
-  if(delta_wx>0) {
-    M_condensed_->addDiagonal(delta_wx);
-  }
-
-  //M_condensed_->addDiagonal(1.0, *Dx_plus_deltawx_);
-  M_condensed_->addDiagonal(1.0, *Dx_);
-  //t.stop(); printf("ADD-nume  took %.5f\n", t.getElapsedTime());
-
-
-  //printf("CPU-----------------------------------\n");
-  //M_condensed_->print();
   
   int nnz_condensed = M_condensed_->numberOfNonzeros();
 
@@ -389,7 +417,7 @@ bool hiopKKTLinSysCondensedSparse::build_kkt_matrix(const double& delta_wx_in,
     linSys_ = determine_and_create_linsys(nx, nineq, M_condensed_->numberOfNonzeros());
   } else {
     //compute mode cpu -> use update MA57 linear solver's matrix
-    
+
     if(nullptr == linSys_) {
       
       index_type itnz = 0;
@@ -562,7 +590,9 @@ hiopKKTLinSysCondensedSparse::determine_and_create_linsys(size_type nx, size_typ
   if(linSys_) {
     return dynamic_cast<hiopLinSolverSymSparse*> (linSys_);
   }
- 
+
+  printf("---------------- determine_and_create_linsys\n"); fflush(stdout);
+  
   int n = nx;
   auto linsolv = nlp_->options->GetString("linear_solver_sparse");
   if(nlp_->options->GetString("compute_mode") == "cpu") {
@@ -604,6 +634,8 @@ hiopKKTLinSysCondensedSparse::determine_and_create_linsys(size_type nx, size_typ
   }
   
   assert(linSys_&& "KKT_SPARSE_Condensed linsys: cannot instantiate backend linear solver");
+
+  printf("---------------- determine_and_create_linsys D O N E\n"); fflush(stdout);
   return dynamic_cast<hiopLinSolverSymSparse*> (linSys_);
 }
 

--- a/src/Optimization/hiopKKTLinSysSparseCondensed.hpp
+++ b/src/Optimization/hiopKKTLinSysSparseCondensed.hpp
@@ -188,22 +188,29 @@ protected:
   /// Member for JacD'*Dd*JacD + H + Dx + delta_wx*I
   hiopMatrixSparseCSR* M_condensed_;
 
+  /// Member for storing auxiliary sum of upper triangle of H + Dx + delta_wx*I
+  hiopMatrixSparseCSR* Hess_upper_plus_diag_;
+
+  /// Member for storing the auxiliary sum of Dx + delta_wx*I
+  hiopMatrixSparseCSR* Diag_Dx_deltawx_;
+  
   /// Stores Dx plus delta_wx for more efficient updates of the condensed system matrix
   hiopVector* Dx_plus_deltawx_;
 
+  /// Stores a copy of Hd_ on the device (to be later removed)
+  hiopVector* Hd_copy_;
 private:
   /// Placeholder for the code that decides which linear solver to used based on safe_mode_
   hiopLinSolverSymSparse* determine_and_create_linsys(size_type nxd, size_type nineq, size_type nnz);
 
   /// Determines memory space used internally based on the "mem_space" and "compute_mode" options. This is temporary
   /// functionality and will be removed later on when all the objects will be in the same memory space.
-  inline std::string determine_memory_space_internal()
+  inline std::string determine_memory_space_internal(const std::string& opt_compute_mode)
   {
-    auto opt_compute_mode = nlp_->options->GetString("compute_mode");
-    if(opt_compute_mode == "cpu") {
+    if(opt_compute_mode == "cpu" || opt_compute_mode == "auto") {
       return "DEFAULT";
     } else {
-      //(opt_compute_mode == "auto" || opt_compute_mode == "hybrid" || opt_compute_mode == "gpu") {
+      //(opt_compute_mode == "hybrid" || opt_compute_mode == "gpu") {
       assert(opt_compute_mode != "gpu" && "When code is GPU-ready, remove this method");
       return "DEVICE";
     }

--- a/src/Optimization/hiopKKTLinSysSparseCondensed.hpp
+++ b/src/Optimization/hiopKKTLinSysSparseCondensed.hpp
@@ -211,8 +211,16 @@ private:
       return "DEFAULT";
     } else {
       //(opt_compute_mode == "hybrid" || opt_compute_mode == "gpu") {
+#ifdef HIOP_USE_CUDA
+#ifndef HIOP_USE_RAJA
+#error "RAJA build (HIOP_USE_RAJA) should be enabled when HIOP_USE_CUDA is")
+#endif      
       assert(opt_compute_mode != "gpu" && "When code is GPU-ready, remove this method");
       return "DEVICE";
+#else
+      assert(false && "compute mode not supported without HIOP_USE_CUDA build");
+      return "DEFAULT";
+#endif // HIOP_USE_CUDA
     }
   }
 };


### PR DESCRIPTION
The Condensed KKT class works both with CPU and GPU backends. 

The Cholesky  sparse linear solver (GPU) class was also updated to take advantage of system matrix being on the device and it now has no host-device transfers in the update/factorization methods.

Note that RAJA is now required by the `HIOP_USE_CUDA` build because linear algebra computations in condensed linear algebra reduction requires `hiopVector`s on the device for best performance.