### PR TITLE
Fix some compilation errors when AMD GPUs are used

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,6 +165,13 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     )
 endif()
 
+if(HIOP_USE_GPU AND HIOP_USE_HIP)
+  # Flang is required to link with ROCm bitcode library
+  if(NOT (CMAKE_Fortran_COMPILER_ID STREQUAL "Flang"))
+    message(SEND_ERROR "Flang is required to link with ROCm bitcode library.")
+  endif()
+endif()
+
 if(HIOP_DEVELOPER_MODE)
   target_link_libraries(hiop_tpl INTERFACE hiop_options hiop_warnings)
   install(TARGETS hiop_options hiop_warnings EXPORT hiop-targets)

--- a/src/LinAlg/hiopLinAlgFactory.cpp
+++ b/src/LinAlg/hiopLinAlgFactory.cpp
@@ -185,13 +185,10 @@ hiopMatrixSparseCSR* LinearAlgebraFactory::create_matrix_sparse_csr(const std::s
   if(mem_space_upper == "DEFAULT") {
     return new hiopMatrixSparseCSRSeq();
   } else {
-#ifdef HIOP_USE_GPU
-#ifndef HIOP_USE_RAJA
-#error "(HIOP_USE_)RAJA is needed by the sparse linear algebra (HIOP_SPARSE) under HIOP_USE_GPU"
-#endif
+#ifdef HIOP_USE_CUDA
     return new hiopMatrixSparseCSRCUDA();
 #else
-    assert(false && "requested memory space not available because Hiop was not built with RAJA support");
+    assert(false && "requested memory space not available because Hiop was not built with CUDA support");
     return new hiopMatrixSparseCSRSeq();
 #endif
   }
@@ -206,13 +203,10 @@ hiopMatrixSparseCSR*  LinearAlgebraFactory::create_matrix_sparse_csr(const std::
   if(mem_space_upper == "DEFAULT") {
     return new hiopMatrixSparseCSRSeq(rows, cols, nnz);
   } else {
-#ifdef HIOP_USE_GPU
-#ifndef HIOP_USE_RAJA
-#error "(HIOP_USE_)RAJA is needed by the sparse linear algebra (HIOP_SPARSE) under HIOP_USE_GPU"
-#endif
+#ifdef HIOP_USE_CUDA
     return new hiopMatrixSparseCSRCUDA(rows, cols, nnz);
 #else
-    assert(false && "requested memory space not available because Hiop was not built with RAJA support");
+    assert(false && "requested memory space not available because Hiop was not built with CUDA support");
     return new hiopMatrixSparseCSRSeq(rows, cols, nnz);
 #endif
   }


### PR DESCRIPTION
Flang is required when compiling HiOp with Hip toolkit, since ROCm bitcode library is only accessible by Clang or Flang.