### PR TITLE
update function hiopvector::print

### DIFF
--- a/src/LinAlg/hiopMatrixComplexDense.cpp
+++ b/src/LinAlg/hiopMatrixComplexDense.cpp
@@ -152,7 +152,7 @@ namespace hiop
 #ifdef HIOP_USE_MPI
     assert(n_local_ == n_global_ && "timesVec for distributed matrices not supported/not needed");
 #endif
-    
+
     if( MM != 0 && NN != 0 ) {
       // the arguments seem reversed but so is trans='T' 
       // required since we keep the matrix row-wise, while the Fortran/BLAS expects them column-wise
@@ -160,14 +160,13 @@ namespace hiop
 	     xa, &incx_y, &beta, ya, &incx_y );
     } else {
       if( MM != 0 ) {
-	int one=1; 
-	ZSCAL(&NN, &beta, ya, &one);
-	
+        int one=1; 
+        ZSCAL(&NN, &beta, ya, &one);
       } else {
-	assert(MM==0);
-	return;
+        assert(MM==0);
+        return;
       }
-    }    
+    } 
   }
   
   bool hiopMatrixComplexDense::isfinite() const
@@ -190,25 +189,27 @@ namespace hiop
       if(maxRows>m_local_) maxRows=m_local_;
       if(maxCols>n_local_) maxCols=n_local_;
       
-      if(f==NULL) f=stdout;
-      
       if(msg) {
-	fprintf(f, "%s (local_dims=[%d,%d])\n", msg, m_local_,n_local_);
+        fprintf(f, "%s (local_dims=[%d,%d])\n", msg, m_local_,n_local_);
       } else { 
-	fprintf(f, "hiopMatrixComplexDense::printing max=[%d,%d] (local_dims=[%d,%d], on rank=%d)\n", 
-		maxRows, maxCols, m_local_,n_local_,myrank_);
+        fprintf(f, "hiopMatrixComplexDense::printing max=[%d,%d] (local_dims=[%d,%d], on rank=%d)\n", 
+                maxRows, maxCols, m_local_,n_local_,myrank_);
       }
       maxRows = maxRows>=0?maxRows:m_local_;
       maxCols = maxCols>=0?maxCols:n_local_;
       fprintf(f, "[");
       for(int i=0; i<maxRows; i++) {
-	if(i>0) fprintf(f, " ");
-	for(int j=0; j<maxCols; j++) 
-	  fprintf(f, "%8.5e+%8.5ei; ", M[i][j].real(), M[i][j].imag());
-	if(i<maxRows-1)
-	  fprintf(f, "; ...\n");
-	else
-	  fprintf(f, "];\n");
+        if(i>0) {
+          fprintf(f, " ");
+        }
+        for(int j=0; j<maxCols; j++) {
+          fprintf(f, "%8.5e+%8.5ei; ", M[i][j].real(), M[i][j].imag());
+        }
+        if(i<maxRows-1) {
+      	  fprintf(f, "; ...\n");
+        } else {
+      	  fprintf(f, "];\n");          
+        }
       }
     }
   }

--- a/src/LinAlg/hiopVector.hpp
+++ b/src/LinAlg/hiopVector.hpp
@@ -292,8 +292,7 @@ public:
   virtual bool isfinite_local() const = 0;
   
   /// @brief prints up to max_elems (by default all), on rank 'rank' (by default on all)
-  virtual void print(FILE*, const char* message=NULL,int max_elems=-1, int rank=-1) const = 0;
-  virtual void print() const {assert(0);} 
+  virtual void print(FILE* file=nullptr, const char* message=nullptr,int max_elems=-1, int rank=-1) const = 0;
   /// @brief allocates a vector that mirrors this, but doesn't copy the values
   virtual hiopVector* alloc_clone() const = 0;
   /// @brief allocates a vector that mirrors this, and copies the values

--- a/src/LinAlg/hiopVectorPar.cpp
+++ b/src/LinAlg/hiopVectorPar.cpp
@@ -1117,9 +1117,14 @@ void hiopVectorPar::print() const
   printf("\n");
 }
 
-void hiopVectorPar::print(FILE* file, const char* msg/*=NULL*/, int max_elems/*=-1*/, int rank/*=-1*/) const 
+void hiopVectorPar::print(FILE* file/*=nullptr*/, const char* msg/*=nullptr*/, int max_elems/*=-1*/, int rank/*=-1*/) const 
 {
   int myrank_=0, numranks=1; 
+
+  if(nullptr == file) {
+    file = stdout;
+  }
+
 #ifdef HIOP_USE_MPI
   if(rank>=0) {
     int err = MPI_Comm_rank(comm_, &myrank_); assert(err==MPI_SUCCESS);
@@ -1129,17 +1134,21 @@ void hiopVectorPar::print(FILE* file, const char* msg/*=NULL*/, int max_elems/*=
   if(myrank_==rank || rank==-1) {
     if(max_elems>n_local_) max_elems=n_local_;
 
-    if(NULL==msg) {
-      if(numranks>1)
-	fprintf(file, "vector of size %d, printing %d elems (on rank=%d)\n", n_, max_elems, myrank_);
-      else
-	fprintf(file, "vector of size %d, printing %d elems (serial)\n", n_, max_elems);
+    if(nullptr==msg) {
+      if(numranks>1){
+        fprintf(file, "vector of size %d, printing %d elems (on rank=%d)\n", n_, max_elems, myrank_);
+      }
+      else{
+        fprintf(file, "vector of size %d, printing %d elems (serial)\n", n_, max_elems);
+      }
     } else {
       fprintf(file, "%s ", msg);
     }    
     fprintf(file, "=[");
     max_elems = max_elems>=0?max_elems:n_local_;
-    for(int it=0; it<max_elems; it++)  fprintf(file, "%24.18e ; ", data_[it]);
+    for(int it=0; it<max_elems; it++) {
+      fprintf(file, "%24.18e ; ", data_[it]);
+    }
     fprintf(file, "];\n");
   }
 }

--- a/src/LinAlg/hiopVectorPar.hpp
+++ b/src/LinAlg/hiopVectorPar.hpp
@@ -249,7 +249,7 @@ public:
   virtual bool isinf_local() const;
   virtual bool isfinite_local() const;
   
-  virtual void print(FILE*, const char* withMessage=NULL, int max_elems=-1, int rank=-1) const;
+  virtual void print(FILE* file=nullptr, const char* message=nullptr,int max_elems=-1, int rank=-1) const;
   virtual void print() const;
 
   /* more accessers */

--- a/src/LinAlg/hiopVectorRajaPar.cpp
+++ b/src/LinAlg/hiopVectorRajaPar.cpp
@@ -1970,7 +1970,12 @@ bool hiopVectorRajaPar::isfinite_local() const
  */
 void hiopVectorRajaPar::print(FILE* file, const char* msg/*=NULL*/, int max_elems/*=-1*/, int rank/*=-1*/) const
 {
-  int myrank=0, numranks=1; 
+  int myrank=0, numranks=1;
+
+  if(nullptr == file) {
+    file = stdout;
+  }
+
 #ifdef HIOP_USE_MPI
   if(rank >= 0) {
     int err = MPI_Comm_rank(comm_, &myrank); assert(err==MPI_SUCCESS);
@@ -1982,7 +1987,7 @@ void hiopVectorRajaPar::print(FILE* file, const char* msg/*=NULL*/, int max_elem
     if(max_elems>n_local_)
       max_elems=n_local_;
 
-    if(NULL==msg)
+    if(nullptr==msg)
     {
       std::stringstream ss;
       ss << "vector of size " << n_ << ", printing " << max_elems << " elems ";
@@ -2001,8 +2006,9 @@ void hiopVectorRajaPar::print(FILE* file, const char* msg/*=NULL*/, int max_elem
     }    
     fprintf(file, "=[");
     max_elems = max_elems >= 0 ? max_elems : n_local_;
-    for(int it=0; it<max_elems; it++)
+    for(int it=0; it<max_elems; it++) {
       fprintf(file, "%22.16e ; ", data_host_[it]);
+    }
     fprintf(file, "];\n");
   }
 }

--- a/src/LinAlg/hiopVectorRajaPar.hpp
+++ b/src/LinAlg/hiopVectorRajaPar.hpp
@@ -272,7 +272,7 @@ public:
   virtual bool isinf_local() const;
   virtual bool isfinite_local() const;
   
-  virtual void print(FILE*, const char* withMessage=NULL, int max_elems=-1, int rank=-1) const;
+  virtual void print(FILE* file=nullptr, const char* message=nullptr,int max_elems=-1, int rank=-1) const;
   virtual void print() const;
 
   /* more accessers */


### PR DESCRIPTION
Update function `hiopvector::print`.
Allow printing information to `stdout`.
Fix some minor indentation issues.