### PR TITLE
Refine the computation in normal equation system

### DIFF
--- a/doc/src/sections/solver_options.tex
+++ b/doc/src/sections/solver_options.tex
@@ -225,7 +225,7 @@ $(\mu-\mu_{target}) / (\mu_{init}-\mu_{target}) * ({bound\_relax\_perturb\_initi
 
 \noindent \textbf{regularization\_method}: whether randomized method is used to compute regularizations.
 \begin{itemize}
-\item ``standard'' (default) - no randomized method is used. Regularization is computed as a scala times an identiy matrix, i.e., $\delta I$.
+\item ``standard'' (default) - no randomized method is used. Regularization is computed as a scalar times an identiy matrix, i.e., $\delta I$.
 \item ``randomized'' - use randomized regularizations.
 \end{itemize}
 \medskip

--- a/src/Drivers/Sparse/NlpSparseEx3Driver.cpp
+++ b/src/Drivers/Sparse/NlpSparseEx3Driver.cpp
@@ -130,7 +130,7 @@ static void usage(const char* exeName)
 {
   printf("hiOp driver %s that solves a synthetic convex problem of variable size.\n", exeName);
   printf("Usage: \n");
-  printf("  '$ %s problem_size scala -selfcheck'\n", exeName);
+  printf("  '$ %s problem_size scalar -selfcheck'\n", exeName);
   printf("Arguments:\n");
   printf("  'problem_size': number of decision variables [optional, default is 50]\n");
   printf("  'scala_a': small pertubation added to the inequality bounds [optional, default is 1e-6]\n");

--- a/src/Optimization/CMakeLists.txt
+++ b/src/Optimization/CMakeLists.txt
@@ -42,12 +42,8 @@ set(hiopOptimization_INTERFACE_HEADERS
   hiopResidual.hpp
   )
 
-if(HIOP_USE_RAJA)
-  list(APPEND hiopOptimization_SPARSE_SRC hiopKKTLinSysSparseCondensed.cpp )
-endif()
-
 if(HIOP_SPARSE)
-  list(APPEND hiopOptimization_SRC ${hiopOptimization_SPARSE_SRC} hiopKKTLinSysSparseNormalEqn.cpp)
+  list(APPEND hiopOptimization_SRC ${hiopOptimization_SPARSE_SRC})
 endif()
 
 install(

--- a/src/Optimization/CMakeLists.txt
+++ b/src/Optimization/CMakeLists.txt
@@ -42,8 +42,12 @@ set(hiopOptimization_INTERFACE_HEADERS
   hiopResidual.hpp
   )
 
+if(HIOP_USE_RAJA)
+  list(APPEND hiopOptimization_SPARSE_SRC hiopKKTLinSysSparseCondensed.cpp )
+endif()
+
 if(HIOP_SPARSE)
-  list(APPEND hiopOptimization_SRC ${hiopOptimization_SPARSE_SRC})
+  list(APPEND hiopOptimization_SRC ${hiopOptimization_SPARSE_SRC} hiopKKTLinSysSparseNormalEqn.cpp)
 endif()
 
 install(

--- a/src/Optimization/hiopAlgFilterIPM.cpp
+++ b/src/Optimization/hiopAlgFilterIPM.cpp
@@ -974,8 +974,8 @@ hiopSolveStatus hiopAlgFilterIPMQuasiNewton::run()
 
   hiopKKTLinSysLowRank* kkt=new hiopKKTLinSysLowRank(nlp);
 
-  // assign an dummy pd_perturb, i.e., all the deltas = 0.0
-  pd_perturb_ = new hiopPDPerturbationDummy();
+  // assign an Null pd_perturb, i.e., all the deltas = 0.0
+  pd_perturb_ = new hiopPDPerturbationNull();
   if(!pd_perturb_->initialize(nlp)) {
     delete kkt;
     return SolveInitializationError;
@@ -1457,8 +1457,18 @@ hiopKKTLinSys* hiopAlgFilterIPMNewton::decideAndCreateLinearSystem(hiopNlpFormul
         return new hiopKKTLinSysCompressedSparseXDYcYd(nlp);
       } else if(strKKT == "condensed") {
         return new hiopKKTLinSysCondensedSparse(nlp);
-      } else if(strKKT == "normaleqn") {
-        return new hiopKKTLinSysSparseNormalEqn(nlp);
+      } else if(strKKT == "normaleqn" ) {
+        if(nlp->m()>0) {
+          return new hiopKKTLinSysSparseNormalEqn(nlp);
+        } else {
+          if(nlp->options->is_user_defined("KKTLinsys")) {
+            nlp->log->printf(hovWarning,
+                             "The option 'KKTLinsys = %s' is not valid for unconstrainted problem. "
+                             "Will use 'KKTLinsys = XYcYd'.[2]\n",
+                             strKKT.c_str());
+          }
+          return new hiopKKTLinSysCompressedSparseXYcYd(nlp);
+        }
       } else {
         //'auto' or 'XYcYd'
         return new hiopKKTLinSysCompressedSparseXYcYd(nlp);
@@ -1738,13 +1748,13 @@ hiopSolveStatus hiopAlgFilterIPMNewton::run()
     if(nlp->options->GetString("regularization_method")=="randomized") {
       pd_perturb_ = new hiopPDPerturbationDualFirstRand();
     } else {
-      pd_perturb_ = new hiopPDPerturbationDualFirstScala();
+      pd_perturb_ = new hiopPDPerturbationDualFirstScalar();
     }
   } else {
     if(nlp->options->GetString("regularization_method")=="randomized") {
       pd_perturb_ = new hiopPDPerturbationPrimalFirstRand();
     } else {
-      pd_perturb_ = new hiopPDPerturbationPrimalFirstScala();
+      pd_perturb_ = new hiopPDPerturbationPrimalFirstScalar();
     }
   }
 

--- a/src/Optimization/hiopAlgFilterIPM.hpp
+++ b/src/Optimization/hiopAlgFilterIPM.hpp
@@ -318,6 +318,7 @@ private:
   virtual void outputIteration(int lsStatus, int lsNum, int use_soc = 0, int use_fr = 0);
 private:
   hiopNlpDenseConstraints* nlpdc;
+  hiopPDPerturbation* pd_perturb_;
 private:
   hiopAlgFilterIPMQuasiNewton() : hiopAlgFilterIPMBase(NULL) {};
   hiopAlgFilterIPMQuasiNewton(const hiopAlgFilterIPMQuasiNewton& ) : hiopAlgFilterIPMBase(NULL){};

--- a/src/Optimization/hiopFactAcceptor.cpp
+++ b/src/Optimization/hiopFactAcceptor.cpp
@@ -63,10 +63,6 @@ namespace hiop
 
 int hiopFactAcceptorIC::requireReFactorization(const hiopNlpFormulation& nlp,
                                                const int& n_neg_eig,
-                                               hiopVector& delta_wx,
-                                               hiopVector& delta_wd,
-                                               hiopVector& delta_cc,
-                                               hiopVector& delta_cd,
                                                const bool force_reg)
 {
   int continue_re_fact{1};
@@ -104,16 +100,11 @@ int hiopFactAcceptorIC::requireReFactorization(const hiopNlpFormulation& nlp,
       //all is good
       continue_re_fact = 0;
   }
-  perturb_calc_->copy_from_curr_perturbations(delta_wx, delta_wd, delta_cc, delta_cd);
   return continue_re_fact;
 }
 
 int hiopFactAcceptorInertiaFreeDWD::requireReFactorization(const hiopNlpFormulation& nlp,
                                                            const int& n_neg_eig,
-                                                           hiopVector& delta_wx,
-                                                           hiopVector& delta_wd,
-                                                           hiopVector& delta_cc,
-                                                           hiopVector& delta_cd,
                                                            const bool force_reg)
 {
   int continue_re_fact{1};
@@ -161,7 +152,6 @@ int hiopFactAcceptorInertiaFreeDWD::requireReFactorization(const hiopNlpFormulat
     }
   }
 
-  perturb_calc_->copy_from_curr_perturbations(delta_wx, delta_wd, delta_cc, delta_cd);
   return continue_re_fact;
 }
   

--- a/src/Optimization/hiopFactAcceptor.cpp
+++ b/src/Optimization/hiopFactAcceptor.cpp
@@ -76,7 +76,7 @@ int hiopFactAcceptorIC::requireReFactorization(const hiopNlpFormulation& nlp,
       //matrix singular
       nlp.log->printf(hovScalars, "linsys is singular.\n");
 
-      if(!perturb_calc_->compute_perturb_singularity(delta_wx, delta_wd, delta_cc, delta_cd)) {\
+      if(!perturb_calc_->compute_perturb_singularity()) {\
         continue_re_fact = -1;
       }
     } else if(n_neg_eig != n_required_neg_eig_) {
@@ -84,7 +84,7 @@ int hiopFactAcceptorIC::requireReFactorization(const hiopNlpFormulation& nlp,
       nlp.log->printf(hovScalars, "linsys negative eigs mismatch: has %d expected %d.\n",
                       n_neg_eig,  n_required_neg_eig_);
 
-      if(!perturb_calc_->compute_perturb_wrong_inertia(delta_wx, delta_wd, delta_cc, delta_cd)) {
+      if(!perturb_calc_->compute_perturb_wrong_inertia()) {
         nlp.log->printf(hovWarning, "linsys: computing inertia perturbation failed.\n");
         continue_re_fact = -1;
       }
@@ -96,7 +96,7 @@ int hiopFactAcceptorIC::requireReFactorization(const hiopNlpFormulation& nlp,
       //correct for wrong intertia
       nlp.log->printf(hovScalars,  "linsys has wrong inertia (no constraints): factoriz "
                       "ret code %d\n.", n_neg_eig);
-      if(!perturb_calc_->compute_perturb_wrong_inertia(delta_wx, delta_wd, delta_cc, delta_cd)) {
+      if(!perturb_calc_->compute_perturb_wrong_inertia()) {
         nlp.log->printf(hovWarning, "linsys: computing inertia perturbation failed (2).\n");
         continue_re_fact = -1;
       }
@@ -104,6 +104,7 @@ int hiopFactAcceptorIC::requireReFactorization(const hiopNlpFormulation& nlp,
       //all is good
       continue_re_fact = 0;
   }
+  perturb_calc_->copy_from_curr_perturbations(delta_wx, delta_wd, delta_cc, delta_cd);
   return continue_re_fact;
 }
 
@@ -121,7 +122,7 @@ int hiopFactAcceptorInertiaFreeDWD::requireReFactorization(const hiopNlpFormulat
       //matrix singular
       nlp.log->printf(hovScalars, "linsys is singular.\n");
 
-      if(!perturb_calc_->compute_perturb_singularity(delta_wx, delta_wd, delta_cc, delta_cd)) {
+      if(!perturb_calc_->compute_perturb_singularity()) {
         continue_re_fact = -1;
       }
     } else {
@@ -131,7 +132,7 @@ int hiopFactAcceptorInertiaFreeDWD::requireReFactorization(const hiopNlpFormulat
       } else {
         // add regularization and accept current factorization (we do curvature test after backsolve)
         nlp.log->printf(hovScalars,  "linsys has wrong curvature. \n");
-        if(!perturb_calc_->compute_perturb_wrong_inertia(delta_wx, delta_wd, delta_cc, delta_cd)) {
+        if(!perturb_calc_->compute_perturb_wrong_inertia()) {
           nlp.log->printf(hovWarning, "linsys: computing inertia perturbation failed (2).\n");
           continue_re_fact = -1;
         }
@@ -141,7 +142,7 @@ int hiopFactAcceptorInertiaFreeDWD::requireReFactorization(const hiopNlpFormulat
     if(n_neg_eig < 0) {
       // Cholesky solver failes due to the lack of positive definiteness
       nlp.log->printf(hovScalars,  "Cholesky solver: factoriz ret code %d\n.", n_neg_eig);
-      if(!perturb_calc_->compute_perturb_wrong_inertia(delta_wx, delta_wd, delta_cc, delta_cd)) {
+      if(!perturb_calc_->compute_perturb_wrong_inertia()) {
         nlp.log->printf(hovWarning, "linsys: computing inertia perturbation failed (2).\n");
         continue_re_fact = -1;
       }
@@ -152,7 +153,7 @@ int hiopFactAcceptorInertiaFreeDWD::requireReFactorization(const hiopNlpFormulat
       } else {
         // add regularization and accept current factorization (we do curvature test after backsolve)
         nlp.log->printf(hovScalars,  "linsys has wrong curvature. \n");
-        if(!perturb_calc_->compute_perturb_wrong_inertia(delta_wx, delta_wd, delta_cc, delta_cd)) {
+        if(!perturb_calc_->compute_perturb_wrong_inertia()) {
           nlp.log->printf(hovWarning, "linsys: computing inertia perturbation failed (2).\n");
           continue_re_fact = -1;
         }
@@ -160,6 +161,7 @@ int hiopFactAcceptorInertiaFreeDWD::requireReFactorization(const hiopNlpFormulat
     }
   }
 
+  perturb_calc_->copy_from_curr_perturbations(delta_wx, delta_wd, delta_cc, delta_cd);
   return continue_re_fact;
 }
   

--- a/src/Optimization/hiopFactAcceptor.hpp
+++ b/src/Optimization/hiopFactAcceptor.hpp
@@ -87,10 +87,6 @@ public:
    */
   virtual int requireReFactorization(const hiopNlpFormulation& nlp,
                                      const int& n_neg_eig,
-                                     hiopVector& delta_wx,
-                                     hiopVector& delta_wd,
-                                     hiopVector& delta_cc,
-                                     hiopVector& delta_cd,
                                      const bool force_reg=false) = 0;
       
 protected:  
@@ -114,11 +110,7 @@ public:
   {}
    
   virtual int requireReFactorization(const hiopNlpFormulation& nlp,
-                                     const int& n_neg_eig, 
-                                     hiopVector& delta_wx,
-                                     hiopVector& delta_wd,
-                                     hiopVector& delta_cc,
-                                     hiopVector& delta_cd,
+                                     const int& n_neg_eig,
                                      const bool force_reg=false);
  
 protected:
@@ -141,11 +133,7 @@ public:
   {}
    
   virtual int requireReFactorization(const hiopNlpFormulation& nlp,
-                                     const int& n_neg_eig, 
-                                     hiopVector& delta_wx,
-                                     hiopVector& delta_wd,
-                                     hiopVector& delta_cc,
-                                     hiopVector& delta_cd,
+                                     const int& n_neg_eig,
                                      const bool force_reg=false);
  
 protected:

--- a/src/Optimization/hiopKKTLinSys.cpp
+++ b/src/Optimization/hiopKKTLinSys.cpp
@@ -49,6 +49,7 @@
 #include "hiopKKTLinSys.hpp"
 #include "hiopLinAlgFactory.hpp"
 #include "hiop_blasdefs.hpp"
+#include "hiopPDPerturbation.hpp"
 
 #include <cmath>
 
@@ -77,14 +78,6 @@ hiopKKTLinSys::hiopKKTLinSys(hiopNlpFormulation* nlp)
 {
   perf_report_ = "on"==hiop::tolower(nlp_->options->GetString("time_kkt"));
   mu_ = nlp_->options->GetNumeric("mu0");
-  delta_wx_ = nlp_->alloc_primal_vec();
-  delta_wd_ = nlp_->alloc_dual_ineq_vec();
-  delta_cc_ = nlp_->alloc_dual_eq_vec();
-  delta_cd_ = nlp_->alloc_dual_ineq_vec();
-  delta_wx_->setToZero();
-  delta_wd_->setToZero();
-  delta_cc_->setToZero();
-  delta_cd_->setToZero();
 }
 
 hiopKKTLinSys::~hiopKKTLinSys()
@@ -94,24 +87,21 @@ hiopKKTLinSys::~hiopKKTLinSys()
   delete ir_rhs_;
   delete ir_x0_;
   delete bicgIR_;
-  delete delta_wx_;
-  delete delta_wd_;
-  delete delta_cc_;
-  delete delta_cd_;
 }
 
 //computes the solve error for the KKT Linear system; used only for correctness checking
 double hiopKKTLinSys::errorKKT(const hiopResidual* resid, const hiopIterate* sol)
 {
   nlp_->log->printf(hovLinAlgScalars, "KKT LinSys::errorKKT KKT_large residuals norm:\n");
+  assert(perturb_calc_ && "perturb_calc_ is not assigned");
 
   if(perturb_calc_) {
-    perturb_calc_->get_curr_perturbations(*delta_wx_, *delta_wd_, *delta_cc_, *delta_cd_);  
+    delta_wx_ = perturb_calc_->get_curr_delta_wx();
+    delta_wd_ = perturb_calc_->get_curr_delta_wd();
+    delta_cc_ = perturb_calc_->get_curr_delta_cc();
+    delta_cd_ = perturb_calc_->get_curr_delta_cd();      
   } else {
-    delta_wx_->setToZero();
-    delta_wd_->setToZero();
-    delta_cc_->setToZero();
-    delta_cd_->setToZero();
+    
   }
 
   double derr=1e20, aux;
@@ -336,27 +326,30 @@ bool hiopKKTLinSysCurvCheck::factorize()
   size_t num_refactorization = 0;
   int continue_re_fact;
 
-  if(!perturb_calc_->compute_initial_deltas(*delta_wx_, *delta_wd_, *delta_cc_, *delta_cd_)) {
+  if(!perturb_calc_->compute_initial_deltas()) {
     nlp_->log->printf(hovWarning, "linsys: Regularization perturbation on new linsys failed.\n");
     return false;
   }
 
+  delta_wx_ = perturb_calc_->get_curr_delta_wx();
+  delta_wd_ = perturb_calc_->get_curr_delta_wd();
+  delta_cc_ = perturb_calc_->get_curr_delta_cc();
+  delta_cd_ = perturb_calc_->get_curr_delta_cd();
+  
   while(num_refactorization <= max_refactorization) {
 #ifdef HIOP_DEEPCHECKS
     assert(perturb_calc_->check_consistency() && "something went wrong with IC");
 #endif
       if(nlp_->options->GetString("regularization_method")=="scala") {
         nlp_->log->printf(hovScalars, "linsys: delta_w=%12.5e delta_c=%12.5e (ic %d)\n",
-                          delta_wx_->local_data_host()[0], delta_cc_->local_data_host()[0], num_refactorization);  
+                          delta_wx_->local_data_host_const()[0], delta_cc_->local_data_host_const()[0], num_refactorization);  
       } else {
-#ifndef NDEBUG
-        delta_wx_->print(nullptr, "delta_wx_");
-        delta_cc_->print(nullptr, "delta_cc_");
-#endif
+        nlp_->log->printf(hovScalars, "linsys: norm2(delta_w)=%12.5e norm2(delta_c)=%12.5e (ic %d)\n",
+                          delta_wx_->twonorm(), delta_cc_->twonorm(), num_refactorization); 
       }
 
     // the update of the linear system, including IC perturbations
-    this->build_kkt_matrix(*delta_wx_, *delta_wd_, *delta_cc_, *delta_cd_);
+    this->build_kkt_matrix(*perturb_calc_, *delta_wx_, *delta_wd_, *delta_cc_, *delta_cd_);
 
     nlp_->runStats.kkt.tmUpdateInnerFact.start();
 
@@ -394,7 +387,10 @@ bool hiopKKTLinSysCurvCheck::factorize_inertia_free()
   int non_singular_mat = 1;
   int continue_re_fact;
 
-  perturb_calc_->get_curr_perturbations(*delta_wx_, *delta_wd_, *delta_cc_, *delta_cd_);
+  delta_wx_ = perturb_calc_->get_curr_delta_wx();
+  delta_wd_ = perturb_calc_->get_curr_delta_wd();
+  delta_cc_ = perturb_calc_->get_curr_delta_cc();
+  delta_cd_ = perturb_calc_->get_curr_delta_cd();
 
   continue_re_fact = fact_acceptor_->requireReFactorization(*nlp_, non_singular_mat, *delta_wx_, *delta_wd_, *delta_cc_, *delta_cd_, true);
 
@@ -403,16 +399,14 @@ bool hiopKKTLinSysCurvCheck::factorize_inertia_free()
 #endif
   if(nlp_->options->GetString("regularization_method")=="scala") {
     nlp_->log->printf(hovScalars, "linsys: delta_w=%12.5e delta_c=%12.5e \n",
-                      delta_wx_->local_data_host()[0], delta_cc_->local_data_host()[0]);  
+                      delta_wx_->local_data_host_const()[0], delta_cc_->local_data_host_const()[0]);  
   } else {
-#ifndef NDEBUG
-    delta_wx_->print(nullptr, "delta_wx_");
-    delta_cc_->print(nullptr, "delta_cc_");
-#endif
+    nlp_->log->printf(hovScalars, "linsys: norm2(delta_w)=%12.5e norm2(delta_c)=%12.5e \n",
+                      delta_wx_->twonorm(), delta_cc_->twonorm());
   }
 
   // the update of the linear system, including IC perturbations
-  this->build_kkt_matrix(*delta_wx_, *delta_wd_, *delta_cc_, *delta_cd_);
+  this->build_kkt_matrix(*perturb_calc_, *delta_wx_, *delta_wd_, *delta_cc_, *delta_cd_);
 
   nlp_->runStats.kkt.tmUpdateInnerFact.start();
 
@@ -438,16 +432,14 @@ bool hiopKKTLinSysCurvCheck::factorize_inertia_free()
     }
 
     if(nlp_->options->GetString("regularization_method")=="scala") {
-      nlp_->log->printf(hovScalars, "linsys: delta_w=%12.5e delta_c=%12.5e \n", delta_wx_->local_data_host()[0], delta_cc_->local_data_host()[0]);  
+      nlp_->log->printf(hovScalars, "linsys: delta_w=%12.5e delta_c=%12.5e \n", delta_wx_->local_data_host_const()[0], delta_cc_->local_data_host_const()[0]);  
     }  else {
-#ifndef NDEBUG
-      delta_wx_->print(nullptr, "delta_wx_");
-      delta_cc_->print(nullptr, "delta_cc_");
-#endif
+        nlp_->log->printf(hovScalars, "linsys: norm2(delta_w)=%12.5e norm2(delta_c)=%12.5e \n",
+                          delta_wx_->twonorm(), delta_cc_->twonorm());
     }
 
     // the update of the linear system, including IC perturbations
-    this->build_kkt_matrix(*delta_wx_, *delta_wd_, *delta_cc_, *delta_cd_);
+    this->build_kkt_matrix(*perturb_calc_, *delta_wx_, *delta_wd_, *delta_cc_, *delta_cd_);
 
     nlp_->runStats.kkt.tmUpdateInnerFact.start();
 
@@ -491,8 +483,11 @@ bool hiopKKTLinSysCompressed::test_direction(const hiopIterate* dir, hiopMatrix*
   double dWd = 0;
   double xs_nrmsq = 0.0;
   double dbl_wrk;
-  perturb_calc_->get_curr_perturbations(*delta_wx_, *delta_wd_, *delta_cc_, *delta_cd_);
-
+  delta_wx_ = perturb_calc_->get_curr_delta_wx();
+  delta_wd_ = perturb_calc_->get_curr_delta_wd();
+  delta_cc_ = perturb_calc_->get_curr_delta_cc();
+  delta_cd_ = perturb_calc_->get_curr_delta_cd();
+  
   /* compute xWx = x(H+Dx_)x (for primal var [x,d] */
   Hess_->timesVec(0.0, *x_wrk_, 1.0, *sol_x);
   dWd += x_wrk_->dotProductWith(*sol_x);
@@ -715,15 +710,11 @@ errorCompressedLinsys(const hiopVector& rx, const hiopVector& ryc, const hiopVec
 		      const hiopVector& dx, const hiopVector& dyc, const hiopVector& dyd)
 {
   nlp_->log->printf(hovLinAlgScalars, "hiopKKTLinSysDenseXYcYd::errorCompressedLinsys residuals norm:\n");
-
-  if(perturb_calc_) {
-    perturb_calc_->get_curr_perturbations(*delta_wx_, *delta_wd_, *delta_cc_, *delta_cd_);  
-  } else {
-    delta_wx_->setToZero();
-    delta_wd_->setToZero();
-    delta_cc_->setToZero();
-    delta_cd_->setToZero();
-  }
+  assert(perturb_calc_);
+  delta_wx_ = perturb_calc_->get_curr_delta_wx();
+  delta_wd_ = perturb_calc_->get_curr_delta_wd();
+  delta_cc_ = perturb_calc_->get_curr_delta_cc();
+  delta_cd_ = perturb_calc_->get_curr_delta_cd();
 
   double derr=1e20, aux;
   hiopVector *RX=rx.new_copy();
@@ -1027,15 +1018,11 @@ errorCompressedLinsys(const hiopVector& rx, const hiopVector& rd,
 		      const hiopVector& dyc, const hiopVector& dyd)
 {
   nlp_->log->printf(hovLinAlgScalars, "hiopKKTLinSysDenseXDYcYd::errorCompressedLinsys residuals norm:\n");
-
-  if(perturb_calc_) {
-    perturb_calc_->get_curr_perturbations(*delta_wx_, *delta_wd_, *delta_cc_, *delta_cd_);  
-  } else {
-    delta_wx_->setToZero();
-    delta_wd_->setToZero();
-    delta_cc_->setToZero();
-    delta_cd_->setToZero();
-  }
+  assert(perturb_calc_);
+  delta_wx_ = perturb_calc_->get_curr_delta_wx();
+  delta_wd_ = perturb_calc_->get_curr_delta_wd();
+  delta_cc_ = perturb_calc_->get_curr_delta_cc();
+  delta_cd_ = perturb_calc_->get_curr_delta_cd();  
 
   double derr=-1., aux;
   hiopVector *RX=rx.new_copy();
@@ -1768,14 +1755,8 @@ bool hiopMatVecKKTFullOpr::times_vec(hiopVector& y, const hiopVector& x)
   hiopVector* delta_wd = kkt_->delta_wd_;
   hiopVector* delta_cc = kkt_->delta_cc_;
   hiopVector* delta_cd = kkt_->delta_cd_;
-  if(kkt_->get_perturb_calc()) {
-    kkt_->get_perturb_calc()->get_curr_perturbations(*delta_wx, *delta_wd, *delta_cc, *delta_cd);
-  } else {
-    delta_wx->setToZero();
-    delta_wd->setToZero();
-    delta_cc->setToZero();
-    delta_cd->setToZero();
-  }
+  assert(kkt_->get_perturb_calc());
+  kkt_->get_perturb_calc()->get_curr_perturbations_const(delta_wx, delta_wd, delta_cc, delta_cd);
 
   bool bret = split_vec_to_build_it(x);
 
@@ -1878,14 +1859,8 @@ bool hiopMatVecKKTFullOpr::trans_times_vec(hiopVector& y, const hiopVector& x)
   hiopVector* delta_wd = kkt_->delta_wd_;
   hiopVector* delta_cc = kkt_->delta_cc_;
   hiopVector* delta_cd = kkt_->delta_cd_;
-  if(kkt_->get_perturb_calc()) {
-    kkt_->get_perturb_calc()->get_curr_perturbations(*delta_wx, *delta_wd, *delta_cc, *delta_cd);
-  } else {
-    delta_wx->setToZero();
-    delta_wd->setToZero();
-    delta_cc->setToZero();
-    delta_cd->setToZero();
-  }
+  assert(kkt_->get_perturb_calc());
+  kkt_->get_perturb_calc()->get_curr_perturbations_const(delta_wx, delta_wd, delta_cc, delta_cd);
 
   bool bret = split_vec_to_build_it(x);
 
@@ -2294,7 +2269,11 @@ bool hiopKKTLinSysFull::test_direction(const hiopIterate* dir, hiopMatrix* Hess)
   double xs_nrmsq = 0.0;
   double dbl_wrk;
 
-  perturb_calc_->get_curr_perturbations(*delta_wx_, *delta_wd_, *delta_cc_, *delta_cd_);  
+  assert(perturb_calc_);
+  delta_wx_ = perturb_calc_->get_curr_delta_wx();
+  delta_wd_ = perturb_calc_->get_curr_delta_wd();
+  delta_cc_ = perturb_calc_->get_curr_delta_cc();
+  delta_cd_ = perturb_calc_->get_curr_delta_cd();
 
   /* compute xWx = x(H+Dx_)x (for primal var [x,d] */
   Hess_->timesVec(0.0, *x_wrk_, 1.0, *sol_x);

--- a/src/Optimization/hiopKKTLinSys.cpp
+++ b/src/Optimization/hiopKKTLinSys.cpp
@@ -349,7 +349,7 @@ bool hiopKKTLinSysCurvCheck::factorize()
       }
 
     // the update of the linear system, including IC perturbations
-    this->build_kkt_matrix(*perturb_calc_, *delta_wx_, *delta_wd_, *delta_cc_, *delta_cd_);
+    this->build_kkt_matrix(*perturb_calc_);
 
     nlp_->runStats.kkt.tmUpdateInnerFact.start();
 
@@ -358,7 +358,7 @@ bool hiopKKTLinSysCurvCheck::factorize()
 
     nlp_->runStats.kkt.tmUpdateInnerFact.stop();
 
-    continue_re_fact = fact_acceptor_->requireReFactorization(*nlp_, n_neg_eig, *delta_wx_, *delta_wd_, *delta_cc_, *delta_cd_);
+    continue_re_fact = fact_acceptor_->requireReFactorization(*nlp_, n_neg_eig);
     
     if(-1==continue_re_fact) {
       return false;
@@ -392,7 +392,7 @@ bool hiopKKTLinSysCurvCheck::factorize_inertia_free()
   delta_cc_ = perturb_calc_->get_curr_delta_cc();
   delta_cd_ = perturb_calc_->get_curr_delta_cd();
 
-  continue_re_fact = fact_acceptor_->requireReFactorization(*nlp_, non_singular_mat, *delta_wx_, *delta_wd_, *delta_cc_, *delta_cd_, true);
+  continue_re_fact = fact_acceptor_->requireReFactorization(*nlp_, non_singular_mat, true);
 
 #ifdef HIOP_DEEPCHECKS
     assert(perturb_calc_->check_consistency() && "something went wrong with IC");
@@ -406,7 +406,7 @@ bool hiopKKTLinSysCurvCheck::factorize_inertia_free()
   }
 
   // the update of the linear system, including IC perturbations
-  this->build_kkt_matrix(*perturb_calc_, *delta_wx_, *delta_wd_, *delta_cc_, *delta_cd_);
+  this->build_kkt_matrix(*perturb_calc_);
 
   nlp_->runStats.kkt.tmUpdateInnerFact.start();
 
@@ -422,7 +422,7 @@ bool hiopKKTLinSysCurvCheck::factorize_inertia_free()
   while(num_refactorization<=max_refactorization && solver_flag < 0) {
     nlp_->log->printf(hovWarning, "linsys: matrix becomes singular after adding primal regularization!\n");
 
-    continue_re_fact = fact_acceptor_->requireReFactorization(*nlp_, solver_flag, *delta_wx_, *delta_wd_, *delta_cc_, *delta_cd_);
+    continue_re_fact = fact_acceptor_->requireReFactorization(*nlp_, solver_flag);
     
     if(-1==continue_re_fact) {
       return false;
@@ -439,7 +439,7 @@ bool hiopKKTLinSysCurvCheck::factorize_inertia_free()
     }
 
     // the update of the linear system, including IC perturbations
-    this->build_kkt_matrix(*perturb_calc_, *delta_wx_, *delta_wd_, *delta_cc_, *delta_cd_);
+    this->build_kkt_matrix(*perturb_calc_);
 
     nlp_->runStats.kkt.tmUpdateInnerFact.start();
 
@@ -1756,8 +1756,12 @@ bool hiopMatVecKKTFullOpr::times_vec(hiopVector& y, const hiopVector& x)
   hiopVector* delta_cc = kkt_->delta_cc_;
   hiopVector* delta_cd = kkt_->delta_cd_;
   assert(kkt_->get_perturb_calc());
-  kkt_->get_perturb_calc()->get_curr_perturbations_const(delta_wx, delta_wd, delta_cc, delta_cd);
 
+  delta_wx = kkt_->perturb_calc_->get_curr_delta_wx();
+  delta_wd = kkt_->perturb_calc_->get_curr_delta_wd();
+  delta_cc = kkt_->perturb_calc_->get_curr_delta_cc();
+  delta_cd = kkt_->perturb_calc_->get_curr_delta_cd();
+  
   bool bret = split_vec_to_build_it(x);
 
   //rx = H*dx + delta_wx*I*dx + Jc'*dyc + Jd'*dyd - dzl + dzu
@@ -1860,7 +1864,11 @@ bool hiopMatVecKKTFullOpr::trans_times_vec(hiopVector& y, const hiopVector& x)
   hiopVector* delta_cc = kkt_->delta_cc_;
   hiopVector* delta_cd = kkt_->delta_cd_;
   assert(kkt_->get_perturb_calc());
-  kkt_->get_perturb_calc()->get_curr_perturbations_const(delta_wx, delta_wd, delta_cc, delta_cd);
+
+  delta_wx = kkt_->perturb_calc_->get_curr_delta_wx();
+  delta_wd = kkt_->perturb_calc_->get_curr_delta_wd();
+  delta_cc = kkt_->perturb_calc_->get_curr_delta_cc();
+  delta_cd = kkt_->perturb_calc_->get_curr_delta_cd();
 
   bool bret = split_vec_to_build_it(x);
 

--- a/src/Optimization/hiopKKTLinSys.cpp
+++ b/src/Optimization/hiopKKTLinSys.cpp
@@ -345,11 +345,15 @@ bool hiopKKTLinSysCurvCheck::factorize()
 #ifdef HIOP_DEEPCHECKS
     assert(perturb_calc_->check_consistency() && "something went wrong with IC");
 #endif
-      if(delta_wx_->get_size() == 1 && delta_cc_->get_size() == 1) {
+      if(nlp_->options->GetString("regularization_method")=="scala")) {
         nlp_->log->printf(hovScalars, "linsys: delta_w=%12.5e delta_c=%12.5e (ic %d)\n",
                           delta_wx_->local_data_host()[0], delta_cc_->local_data_host()[0], num_refactorization);  
+      } else {
+#ifndef NDEBUG
+        delta_wx_->print(nullptr, "delta_wx_");
+        delta_cc_->print(nullptr, "delta_cc_");
+#endif
       }
-
 
     // the update of the linear system, including IC perturbations
     this->build_kkt_matrix(*delta_wx_, *delta_wd_, *delta_cc_, *delta_cd_);
@@ -397,11 +401,16 @@ bool hiopKKTLinSysCurvCheck::factorize_inertia_free()
 #ifdef HIOP_DEEPCHECKS
     assert(perturb_calc_->check_consistency() && "something went wrong with IC");
 #endif
-  if(delta_wx_->get_size() == 1 && delta_cc_->get_size() == 1) {
+  if(nlp_->options->GetString("regularization_method")=="scala")) {
     nlp_->log->printf(hovScalars, "linsys: delta_w=%12.5e delta_c=%12.5e \n",
                       delta_wx_->local_data_host()[0], delta_cc_->local_data_host()[0]);  
+  } else {
+#ifndef NDEBUG
+    delta_wx_->print(nullptr, "delta_wx_");
+    delta_cc_->print(nullptr, "delta_cc_");
+#endif
   }
-      
+
   // the update of the linear system, including IC perturbations
   this->build_kkt_matrix(*delta_wx_, *delta_wd_, *delta_cc_, *delta_cd_);
 
@@ -427,12 +436,16 @@ bool hiopKKTLinSysCurvCheck::factorize_inertia_free()
       // this while loop is used to correct singularity
       assert(1==continue_re_fact);
     }
-      
-    
-    if(delta_wx_->get_size() == 1 && delta_cc_->get_size() == 1) {
+
+    if(nlp_->options->GetString("regularization_method")=="scala")) {
       nlp_->log->printf(hovScalars, "linsys: delta_w=%12.5e delta_c=%12.5e \n", delta_wx_->local_data_host()[0], delta_cc_->local_data_host()[0]);  
+    }  else {
+#ifndef NDEBUG
+      delta_wx_->print(nullptr, "delta_wx_");
+      delta_cc_->print(nullptr, "delta_cc_");
+#endif
     }
-  
+
     // the update of the linear system, including IC perturbations
     this->build_kkt_matrix(*delta_wx_, *delta_wd_, *delta_cc_, *delta_cd_);
 

--- a/src/Optimization/hiopKKTLinSys.cpp
+++ b/src/Optimization/hiopKKTLinSys.cpp
@@ -340,7 +340,7 @@ bool hiopKKTLinSysCurvCheck::factorize()
 #ifdef HIOP_DEEPCHECKS
     assert(perturb_calc_->check_consistency() && "something went wrong with IC");
 #endif
-      if(nlp_->options->GetString("regularization_method")=="scala") {
+      if(nlp_->options->GetString("regularization_method")=="scalar") {
         nlp_->log->printf(hovScalars, "linsys: delta_w=%12.5e delta_c=%12.5e (ic %d)\n",
                           delta_wx_->local_data_host_const()[0], delta_cc_->local_data_host_const()[0], num_refactorization);  
       } else {
@@ -397,7 +397,7 @@ bool hiopKKTLinSysCurvCheck::factorize_inertia_free()
 #ifdef HIOP_DEEPCHECKS
     assert(perturb_calc_->check_consistency() && "something went wrong with IC");
 #endif
-  if(nlp_->options->GetString("regularization_method")=="scala") {
+  if(nlp_->options->GetString("regularization_method")=="scalar") {
     nlp_->log->printf(hovScalars, "linsys: delta_w=%12.5e delta_c=%12.5e \n",
                       delta_wx_->local_data_host_const()[0], delta_cc_->local_data_host_const()[0]);  
   } else {
@@ -431,7 +431,7 @@ bool hiopKKTLinSysCurvCheck::factorize_inertia_free()
       assert(1==continue_re_fact);
     }
 
-    if(nlp_->options->GetString("regularization_method")=="scala") {
+    if(nlp_->options->GetString("regularization_method")=="scalar") {
       nlp_->log->printf(hovScalars, "linsys: delta_w=%12.5e delta_c=%12.5e \n", delta_wx_->local_data_host_const()[0], delta_cc_->local_data_host_const()[0]);  
     }  else {
         nlp_->log->printf(hovScalars, "linsys: norm2(delta_w)=%12.5e norm2(delta_c)=%12.5e \n",

--- a/src/Optimization/hiopKKTLinSys.cpp
+++ b/src/Optimization/hiopKKTLinSys.cpp
@@ -345,7 +345,7 @@ bool hiopKKTLinSysCurvCheck::factorize()
 #ifdef HIOP_DEEPCHECKS
     assert(perturb_calc_->check_consistency() && "something went wrong with IC");
 #endif
-      if(nlp_->options->GetString("regularization_method")=="scala")) {
+      if(nlp_->options->GetString("regularization_method")=="scala") {
         nlp_->log->printf(hovScalars, "linsys: delta_w=%12.5e delta_c=%12.5e (ic %d)\n",
                           delta_wx_->local_data_host()[0], delta_cc_->local_data_host()[0], num_refactorization);  
       } else {
@@ -401,7 +401,7 @@ bool hiopKKTLinSysCurvCheck::factorize_inertia_free()
 #ifdef HIOP_DEEPCHECKS
     assert(perturb_calc_->check_consistency() && "something went wrong with IC");
 #endif
-  if(nlp_->options->GetString("regularization_method")=="scala")) {
+  if(nlp_->options->GetString("regularization_method")=="scala") {
     nlp_->log->printf(hovScalars, "linsys: delta_w=%12.5e delta_c=%12.5e \n",
                       delta_wx_->local_data_host()[0], delta_cc_->local_data_host()[0]);  
   } else {
@@ -437,7 +437,7 @@ bool hiopKKTLinSysCurvCheck::factorize_inertia_free()
       assert(1==continue_re_fact);
     }
 
-    if(nlp_->options->GetString("regularization_method")=="scala")) {
+    if(nlp_->options->GetString("regularization_method")=="scala") {
       nlp_->log->printf(hovScalars, "linsys: delta_w=%12.5e delta_c=%12.5e \n", delta_wx_->local_data_host()[0], delta_cc_->local_data_host()[0]);  
     }  else {
 #ifndef NDEBUG

--- a/src/Optimization/hiopKKTLinSys.hpp
+++ b/src/Optimization/hiopKKTLinSys.hpp
@@ -240,7 +240,8 @@ public:
   /** 
    * @brief updates the iterate matrix, given regularizations 'delta_wx', 'delta_wd', 'delta_cc' and 'delta_cd'.
    */
-  virtual bool build_kkt_matrix(const hiopVector& delta_wx,
+  virtual bool build_kkt_matrix(const hiopPDPerturbation& pdreg, 
+                                const hiopVector& delta_wx,
                                 const hiopVector& delta_wd,
                                 const hiopVector& delta_cc,
                                 const hiopVector& delta_cd,
@@ -287,7 +288,8 @@ public:
 
   virtual bool computeDirections(const hiopResidual* resid, hiopIterate* direction) = 0;
 
-  virtual bool build_kkt_matrix(const hiopVector& delta_wx,
+  virtual bool build_kkt_matrix(const hiopPDPerturbation& pdreg, 
+                                const hiopVector& delta_wx,
                                 const hiopVector& delta_wd,
                                 const hiopVector& delta_cc,
                                 const hiopVector& delta_cd,
@@ -323,7 +325,8 @@ public:
 
   virtual bool computeDirections(const hiopResidual* resid, hiopIterate* direction);
 
-  virtual bool build_kkt_matrix(const hiopVector& delta_wx,
+  virtual bool build_kkt_matrix(const hiopPDPerturbation& pdreg, 
+                                const hiopVector& delta_wx,
                                 const hiopVector& delta_wd,
                                 const hiopVector& delta_cc,
                                 const hiopVector& delta_cd,
@@ -370,7 +373,8 @@ public:
 
   virtual bool computeDirections(const hiopResidual* resid, hiopIterate* direction);
 
-  virtual bool build_kkt_matrix(const hiopVector& delta_wx,
+  virtual bool build_kkt_matrix(const hiopPDPerturbation& pdreg, 
+                                const hiopVector& delta_wx,
                                 const hiopVector& delta_wd,
                                 const hiopVector& delta_cc,
                                 const hiopVector& delta_cd,
@@ -427,7 +431,8 @@ public:
 		      const hiopMatrixDense* Jac_c, const hiopMatrixDense* Jac_d,
 		      hiopHessianLowRank* Hess);
 
-  virtual bool build_kkt_matrix(const hiopVector& delta_wx,
+  virtual bool build_kkt_matrix(const hiopPDPerturbation& pdreg, 
+                                const hiopVector& delta_wx,
                                 const hiopVector& delta_wd,
                                 const hiopVector& delta_cc,
                                 const hiopVector& delta_cd,
@@ -545,7 +550,8 @@ public:
 
   virtual bool computeDirections(const hiopResidual* resid, hiopIterate* direction);
 
-  virtual bool build_kkt_matrix(const hiopVector& delta_wx,
+  virtual bool build_kkt_matrix(const hiopPDPerturbation& pdreg, 
+                                const hiopVector& delta_wx,
                                 const hiopVector& delta_wd,
                                 const hiopVector& delta_cc,
                                 const hiopVector& delta_cd,
@@ -594,7 +600,8 @@ public:
 
   virtual bool computeDirections(const hiopResidual* resid, hiopIterate* direction);
 
-  virtual bool build_kkt_matrix(const hiopVector& delta_wx,
+  virtual bool build_kkt_matrix(const hiopPDPerturbation& pdreg, 
+                                const hiopVector& delta_wx,
                                 const hiopVector& delta_wd,
                                 const hiopVector& delta_cc,
                                 const hiopVector& delta_cd,

--- a/src/Optimization/hiopKKTLinSys.hpp
+++ b/src/Optimization/hiopKKTLinSys.hpp
@@ -243,7 +243,8 @@ public:
   virtual bool build_kkt_matrix(const hiopVector& delta_wx,
                                 const hiopVector& delta_wd,
                                 const hiopVector& delta_cc,
-                                const hiopVector& delta_cd) = 0;
+                                const hiopVector& delta_cd,
+                                const DeltasUpdateType delta_update_type = DeltasUpdateType::None) = 0;
 
   hiopLinSolver* linSys_;
 
@@ -289,7 +290,8 @@ public:
   virtual bool build_kkt_matrix(const hiopVector& delta_wx,
                                 const hiopVector& delta_wd,
                                 const hiopVector& delta_cc,
-                                const hiopVector& delta_cd) = 0;
+                                const hiopVector& delta_cd,
+                                const DeltasUpdateType delta_update_type = DeltasUpdateType::None) = 0;
 protected:
   hiopVector* Dx_;
   hiopVector* Dd_;
@@ -324,7 +326,8 @@ public:
   virtual bool build_kkt_matrix(const hiopVector& delta_wx,
                                 const hiopVector& delta_wd,
                                 const hiopVector& delta_cc,
-                                const hiopVector& delta_cd) = 0;
+                                const hiopVector& delta_cd,
+                                const DeltasUpdateType delta_update_type = DeltasUpdateType::None) = 0;
 
   virtual bool solveCompressed(hiopVector& rx, hiopVector& ryc, hiopVector& ryd,
                                hiopVector& dx, hiopVector& dyc, hiopVector& dyd) = 0;
@@ -370,7 +373,8 @@ public:
   virtual bool build_kkt_matrix(const hiopVector& delta_wx,
                                 const hiopVector& delta_wd,
                                 const hiopVector& delta_cc,
-                                const hiopVector& delta_cd) = 0;
+                                const hiopVector& delta_cd,
+                                const DeltasUpdateType delta_update_type = DeltasUpdateType::None) = 0;
 
   virtual bool solveCompressed(hiopVector& rx, hiopVector& rd, 
                                hiopVector& ryc, hiopVector& ryd,
@@ -426,7 +430,8 @@ public:
   virtual bool build_kkt_matrix(const hiopVector& delta_wx,
                                 const hiopVector& delta_wd,
                                 const hiopVector& delta_cc,
-                                const hiopVector& delta_cd) 
+                                const hiopVector& delta_cd,
+                                const DeltasUpdateType delta_update_type = DeltasUpdateType::None)
   {
     assert(false && "not yet implemented");
     return false;
@@ -543,7 +548,8 @@ public:
   virtual bool build_kkt_matrix(const hiopVector& delta_wx,
                                 const hiopVector& delta_wd,
                                 const hiopVector& delta_cc,
-                                const hiopVector& delta_cd) = 0;
+                                const hiopVector& delta_cd,
+                                const DeltasUpdateType delta_update_type = DeltasUpdateType::None) = 0;
   
   virtual bool solve( hiopVector& rx, hiopVector& ryc, hiopVector& ryd, hiopVector& rd,
                       hiopVector& rdl, hiopVector& rdu, hiopVector& rxl, hiopVector& rxu,
@@ -591,7 +597,8 @@ public:
   virtual bool build_kkt_matrix(const hiopVector& delta_wx,
                                 const hiopVector& delta_wd,
                                 const hiopVector& delta_cc,
-                                const hiopVector& delta_cd) = 0;
+                                const hiopVector& delta_cd,
+                                const DeltasUpdateType delta_update_type = DeltasUpdateType::None) = 0;
 
   virtual bool solveCompressed(hiopVector& ryc_tilde,
                                hiopVector& ryd_tilde,

--- a/src/Optimization/hiopKKTLinSys.hpp
+++ b/src/Optimization/hiopKKTLinSys.hpp
@@ -240,12 +240,7 @@ public:
   /** 
    * @brief updates the iterate matrix, given regularizations 'delta_wx', 'delta_wd', 'delta_cc' and 'delta_cd'.
    */
-  virtual bool build_kkt_matrix(const hiopPDPerturbation& pdreg, 
-                                const hiopVector& delta_wx,
-                                const hiopVector& delta_wd,
-                                const hiopVector& delta_cc,
-                                const hiopVector& delta_cd,
-                                const DeltasUpdateType delta_update_type = DeltasUpdateType::None) = 0;
+  virtual bool build_kkt_matrix(const hiopPDPerturbation& pdreg) = 0;
 
   hiopLinSolver* linSys_;
 
@@ -288,12 +283,7 @@ public:
 
   virtual bool computeDirections(const hiopResidual* resid, hiopIterate* direction) = 0;
 
-  virtual bool build_kkt_matrix(const hiopPDPerturbation& pdreg, 
-                                const hiopVector& delta_wx,
-                                const hiopVector& delta_wd,
-                                const hiopVector& delta_cc,
-                                const hiopVector& delta_cd,
-                                const DeltasUpdateType delta_update_type = DeltasUpdateType::None) = 0;
+  virtual bool build_kkt_matrix(const hiopPDPerturbation& pdreg) = 0;
 protected:
   hiopVector* Dx_;
   hiopVector* Dd_;
@@ -325,12 +315,7 @@ public:
 
   virtual bool computeDirections(const hiopResidual* resid, hiopIterate* direction);
 
-  virtual bool build_kkt_matrix(const hiopPDPerturbation& pdreg, 
-                                const hiopVector& delta_wx,
-                                const hiopVector& delta_wd,
-                                const hiopVector& delta_cc,
-                                const hiopVector& delta_cd,
-                                const DeltasUpdateType delta_update_type = DeltasUpdateType::None) = 0;
+  virtual bool build_kkt_matrix(const hiopPDPerturbation& pdreg) = 0;
 
   virtual bool solveCompressed(hiopVector& rx, hiopVector& ryc, hiopVector& ryd,
                                hiopVector& dx, hiopVector& dyc, hiopVector& dyd) = 0;
@@ -373,12 +358,7 @@ public:
 
   virtual bool computeDirections(const hiopResidual* resid, hiopIterate* direction);
 
-  virtual bool build_kkt_matrix(const hiopPDPerturbation& pdreg, 
-                                const hiopVector& delta_wx,
-                                const hiopVector& delta_wd,
-                                const hiopVector& delta_cc,
-                                const hiopVector& delta_cd,
-                                const DeltasUpdateType delta_update_type = DeltasUpdateType::None) = 0;
+  virtual bool build_kkt_matrix(const hiopPDPerturbation& pdreg) = 0;
 
   virtual bool solveCompressed(hiopVector& rx, hiopVector& rd, 
                                hiopVector& ryc, hiopVector& ryd,
@@ -431,12 +411,7 @@ public:
 		      const hiopMatrixDense* Jac_c, const hiopMatrixDense* Jac_d,
 		      hiopHessianLowRank* Hess);
 
-  virtual bool build_kkt_matrix(const hiopPDPerturbation& pdreg, 
-                                const hiopVector& delta_wx,
-                                const hiopVector& delta_wd,
-                                const hiopVector& delta_cc,
-                                const hiopVector& delta_cd,
-                                const DeltasUpdateType delta_update_type = DeltasUpdateType::None)
+  virtual bool build_kkt_matrix(const hiopPDPerturbation& pdreg)
   {
     assert(false && "not yet implemented");
     return false;
@@ -550,12 +525,7 @@ public:
 
   virtual bool computeDirections(const hiopResidual* resid, hiopIterate* direction);
 
-  virtual bool build_kkt_matrix(const hiopPDPerturbation& pdreg, 
-                                const hiopVector& delta_wx,
-                                const hiopVector& delta_wd,
-                                const hiopVector& delta_cc,
-                                const hiopVector& delta_cd,
-                                const DeltasUpdateType delta_update_type = DeltasUpdateType::None) = 0;
+  virtual bool build_kkt_matrix(const hiopPDPerturbation& pdreg) = 0;
   
   virtual bool solve( hiopVector& rx, hiopVector& ryc, hiopVector& ryd, hiopVector& rd,
                       hiopVector& rdl, hiopVector& rdu, hiopVector& rxl, hiopVector& rxu,
@@ -600,12 +570,7 @@ public:
 
   virtual bool computeDirections(const hiopResidual* resid, hiopIterate* direction);
 
-  virtual bool build_kkt_matrix(const hiopPDPerturbation& pdreg, 
-                                const hiopVector& delta_wx,
-                                const hiopVector& delta_wd,
-                                const hiopVector& delta_cc,
-                                const hiopVector& delta_cd,
-                                const DeltasUpdateType delta_update_type = DeltasUpdateType::None) = 0;
+  virtual bool build_kkt_matrix(const hiopPDPerturbation& pdreg) = 0;
 
   virtual bool solveCompressed(hiopVector& ryc_tilde,
                                hiopVector& ryd_tilde,

--- a/src/Optimization/hiopKKTLinSysDense.hpp
+++ b/src/Optimization/hiopKKTLinSysDense.hpp
@@ -85,7 +85,8 @@ public:
   virtual bool build_kkt_matrix(const hiopVector& delta_wx,
                                 const hiopVector& delta_wd,
                                 const hiopVector& delta_cc,
-                                const hiopVector& delta_cd)
+                                const hiopVector& delta_cd,
+                                const DeltasUpdateType delta_update_type)
   {
     assert(nlp_);
 
@@ -247,7 +248,8 @@ public:
   virtual bool build_kkt_matrix(const hiopVector& delta_wx,
                                 const hiopVector& delta_wd,
                                 const hiopVector& delta_cc,
-                                const hiopVector& delta_cd)
+                                const hiopVector& delta_cd,
+                                const DeltasUpdateType delta_update_type)
   {
     assert(nlp_);
    

--- a/src/Optimization/hiopKKTLinSysDense.hpp
+++ b/src/Optimization/hiopKKTLinSysDense.hpp
@@ -82,7 +82,8 @@ public:
     delete rhsXYcYd;
   }
 
-  virtual bool build_kkt_matrix(const hiopVector& delta_wx,
+  virtual bool build_kkt_matrix(const hiopPDPerturbation& pdreg, 
+                                const hiopVector& delta_wx,
                                 const hiopVector& delta_wd,
                                 const hiopVector& delta_cc,
                                 const hiopVector& delta_cd,
@@ -245,7 +246,8 @@ public:
   * [    Jc        0     0      0    ] [dyc] = [   ryc    ]
   * [    Jd       -I     0      0    ] [dyd]   [   ryd    ]
   */
-  virtual bool build_kkt_matrix(const hiopVector& delta_wx,
+  virtual bool build_kkt_matrix(const hiopPDPerturbation& pdreg, 
+                                const hiopVector& delta_wx,
                                 const hiopVector& delta_wd,
                                 const hiopVector& delta_cc,
                                 const hiopVector& delta_cd,

--- a/src/Optimization/hiopKKTLinSysDense.hpp
+++ b/src/Optimization/hiopKKTLinSysDense.hpp
@@ -82,13 +82,13 @@ public:
     delete rhsXYcYd;
   }
 
-  virtual bool build_kkt_matrix(const hiopPDPerturbation& pdreg, 
-                                const hiopVector& delta_wx,
-                                const hiopVector& delta_wd,
-                                const hiopVector& delta_cc,
-                                const hiopVector& delta_cd,
-                                const DeltasUpdateType delta_update_type)
+  virtual bool build_kkt_matrix(const hiopPDPerturbation& pdreg)
   {
+    delta_wx_ = perturb_calc_->get_curr_delta_wx();
+    delta_wd_ = perturb_calc_->get_curr_delta_wd();
+    delta_cc_ = perturb_calc_->get_curr_delta_cc();
+    delta_cd_ = perturb_calc_->get_curr_delta_cd();
+
     assert(nlp_);
 
     int nx  = Hess_->m();
@@ -136,10 +136,10 @@ public:
     Jac_d_->transAddToSymDenseMatrixUpperTriangle(0, nx+neq, alpha, Msys);
       
     Msys.addSubDiagonal(alpha, 0, *Dx_);
-    Msys.addSubDiagonal(alpha, 0, delta_wx);
+    Msys.addSubDiagonal(alpha, 0, *delta_wx_);
 
     //Dd=(Sdl)^{-1}Vu + (Sdu)^{-1}Vu + delta_wd*I
-    Dd_inv_->copyFrom(delta_wd);
+    Dd_inv_->copyFrom(*delta_wd_);
     Dd_inv_->axdzpy_w_pattern(1.0, *iter_->vl, *iter_->sdl, nlp_->get_idl());
     Dd_inv_->axdzpy_w_pattern(1.0, *iter_->vu, *iter_->sdu, nlp_->get_idu());
 #ifdef HIOP_DEEPCHECKS
@@ -153,7 +153,7 @@ public:
 #ifdef HIOP_DEEPCHECKS
     assert(perturb_calc_->check_consistency() && "something went wrong with IC");
 #endif
-    Msys.addSubDiagonal(alpha, nx, delta_cd);
+    Msys.addSubDiagonal(alpha, nx, *delta_cd_);
 
     nlp_->log->write("KKT Linsys:", Msys, hovMatrices);
 
@@ -246,15 +246,14 @@ public:
   * [    Jc        0     0      0    ] [dyc] = [   ryc    ]
   * [    Jd       -I     0      0    ] [dyd]   [   ryd    ]
   */
-  virtual bool build_kkt_matrix(const hiopPDPerturbation& pdreg, 
-                                const hiopVector& delta_wx,
-                                const hiopVector& delta_wd,
-                                const hiopVector& delta_cc,
-                                const hiopVector& delta_cd,
-                                const DeltasUpdateType delta_update_type)
+  virtual bool build_kkt_matrix(const hiopPDPerturbation& pdreg)
   {
     assert(nlp_);
-   
+    delta_wx_ = perturb_calc_->get_curr_delta_wx();
+    delta_wd_ = perturb_calc_->get_curr_delta_wd();
+    delta_cc_ = perturb_calc_->get_curr_delta_cc();
+    delta_cd_ = perturb_calc_->get_curr_delta_cd();
+
     int nx  = Hess_->m(); assert(nx==Hess_->n()); assert(nx==Jac_c_->n()); assert(nx==Jac_d_->n());
     int neq = Jac_c_->m(), nineq = Jac_d_->m();
     assert(nx==Hess_->n()); assert(nx==Jac_c_->n()); assert(nx==Jac_d_->n());
@@ -293,10 +292,10 @@ public:
 	
     //add diagonals and IC perturbations
     Msys.addSubDiagonal(alpha, 0, *Dx_);
-    Msys.addSubDiagonal(alpha, 0, delta_wx);
+    Msys.addSubDiagonal(alpha, 0, *delta_wx_);
 
     Msys.addSubDiagonal(alpha, nx, *Dd_);
-    Msys.addSubDiagonal(alpha, nx, delta_wd);
+    Msys.addSubDiagonal(alpha, nx, *delta_wd_);
 	
     //add -I (of size nineq) starting at index (nx, nx+nineq+neq)
     int col_start = nx+nineq+neq;
@@ -311,9 +310,9 @@ public:
     }
 
 #ifdef HIOP_DEEPCHECKS
-      assert(delta_cc.is_equal(delta_cd));
+      assert(delta_cc_->is_equal(*delta_cd_));
 #endif
-    Msys.addSubDiagonal(-alpha, nx+nineq, delta_cd);
+    Msys.addSubDiagonal(-alpha, nx+nineq, *delta_cd_);
 
     nlp_->log->write("KKT Linsys:", Msys, hovMatrices);
 

--- a/src/Optimization/hiopKKTLinSysMDS.cpp
+++ b/src/Optimization/hiopKKTLinSysMDS.cpp
@@ -174,7 +174,8 @@ namespace hiop
   bool hiopKKTLinSysCompressedMDSXYcYd::build_kkt_matrix(const hiopVector& delta_wx, 
                                                          const hiopVector& delta_wd,
                                                          const hiopVector& delta_cc,
-                                                         const hiopVector& delta_cd)
+                                                         const hiopVector& delta_cd,
+                                                         const DeltasUpdateType delta_update_type)
   {
     assert(linSys_);
     hiopLinSolverSymDense* linSys = dynamic_cast<hiopLinSolverSymDense*> (linSys_);

--- a/src/Optimization/hiopKKTLinSysMDS.cpp
+++ b/src/Optimization/hiopKKTLinSysMDS.cpp
@@ -171,16 +171,16 @@ namespace hiop
   }
 
 
-  bool hiopKKTLinSysCompressedMDSXYcYd::build_kkt_matrix(const hiopPDPerturbation& pdreg, 
-                                                         const hiopVector& delta_wx, 
-                                                         const hiopVector& delta_wd,
-                                                         const hiopVector& delta_cc,
-                                                         const hiopVector& delta_cd,
-                                                         const DeltasUpdateType delta_update_type)
+  bool hiopKKTLinSysCompressedMDSXYcYd::build_kkt_matrix(const hiopPDPerturbation& pdreg)
   {
     assert(linSys_);
     hiopLinSolverSymDense* linSys = dynamic_cast<hiopLinSolverSymDense*> (linSys_);
     assert(linSys);
+
+    delta_wx_ = perturb_calc_->get_curr_delta_wx();
+    delta_wd_ = perturb_calc_->get_curr_delta_wd();
+    delta_cc_ = perturb_calc_->get_curr_delta_cc();
+    delta_cd_ = perturb_calc_->get_curr_delta_cd();
 
     int nxs = HessMDS_->n_sp(), nxd = HessMDS_->n_de(), nx = HessMDS_->n();
     int neq = Jac_cMDS_->m(), nineq = Jac_dMDS_->m();
@@ -214,7 +214,7 @@ namespace hiop
     //update -> add Dxd to (1,1) block of KKT matrix (Hd = HessMDS_->de_mat already added above)
     Msys.addSubDiagonal(0, alpha, *Dx_, nxs, nxd);
     //add perturbation 'delta_wx' for xd
-    Msys.addSubDiagonal(0, alpha, delta_wx, nxs, nxd);
+    Msys.addSubDiagonal(0, alpha, *delta_wx_, nxs, nxd);
 
     //build the diagonal Hxs = Hsparse+Dxs
     if(NULL == Hxs_) {
@@ -225,7 +225,7 @@ namespace hiop
     Hxs_->startingAtCopyFromStartingAt(0, *Dx_, 0);
 	
     //a good time to add the IC 'delta_wx' perturbation
-    Hxs_wrk_->startingAtCopyFromStartingAt(0, delta_wx, 0);
+    Hxs_wrk_->startingAtCopyFromStartingAt(0, *delta_wx_, 0);
     Hxs_->axpy(1., *Hxs_wrk_);
   
     //Hxs +=  diag(HessMDS->sp_mat());
@@ -244,7 +244,7 @@ namespace hiop
     //printf("addMDinvMtransToDiagBlockOfSymDeMatUTri 111 took %g sec\n", tm.getElapsedTime());
     //tm.reset();
 
-    Msys.addSubDiagonal(-1., nxd, delta_cc);
+    Msys.addSubDiagonal(-1., nxd, *delta_cc_);
 	
     /* we've just done above the (1,1) and (2,2) blocks of
      *
@@ -279,7 +279,7 @@ namespace hiop
 
     // add -{Dd}^{-1}
     // Dd=(Sdl)^{-1}Vu + (Sdu)^{-1}Vu + delta_wd * I
-    Dd_inv_->copyFrom(delta_wd);
+    Dd_inv_->copyFrom(*delta_wd_);
     Dd_inv_->axdzpy_w_pattern(1.0, *iter_->vl, *iter_->sdl, nlp_->get_idl());
     Dd_inv_->axdzpy_w_pattern(1.0, *iter_->vu, *iter_->sdu, nlp_->get_idu());
 #ifdef HIOP_DEEPCHECKS
@@ -289,7 +289,7 @@ namespace hiop
 	
     alpha=-1.;
     Msys.addSubDiagonal(alpha, nxd+neq, *Dd_inv_);
-    Msys.addSubDiagonal(alpha, nxd+neq, delta_cd);
+    Msys.addSubDiagonal(alpha, nxd+neq, *delta_cd_);
 	
     nlp_->log->write("KKT_MDS_XYcYd linsys:", Msys, hovMatrices);
       

--- a/src/Optimization/hiopKKTLinSysMDS.cpp
+++ b/src/Optimization/hiopKKTLinSysMDS.cpp
@@ -171,7 +171,8 @@ namespace hiop
   }
 
 
-  bool hiopKKTLinSysCompressedMDSXYcYd::build_kkt_matrix(const hiopVector& delta_wx, 
+  bool hiopKKTLinSysCompressedMDSXYcYd::build_kkt_matrix(const hiopPDPerturbation& pdreg, 
+                                                         const hiopVector& delta_wx, 
                                                          const hiopVector& delta_wd,
                                                          const hiopVector& delta_cc,
                                                          const hiopVector& delta_cd,

--- a/src/Optimization/hiopKKTLinSysMDS.hpp
+++ b/src/Optimization/hiopKKTLinSysMDS.hpp
@@ -110,7 +110,8 @@ public:
   virtual bool build_kkt_matrix(const hiopVector& delta_wx,
                                 const hiopVector& delta_wd,
                                 const hiopVector& delta_cc,
-                                const hiopVector& delta_cd);
+                                const hiopVector& delta_cd,
+                                const DeltasUpdateType delta_update_type);
 
   virtual bool solveCompressed(hiopVector& rx, hiopVector& ryc, hiopVector& ryd,
                                hiopVector& dx, hiopVector& dyc, hiopVector& dyd);

--- a/src/Optimization/hiopKKTLinSysMDS.hpp
+++ b/src/Optimization/hiopKKTLinSysMDS.hpp
@@ -107,7 +107,8 @@ public:
 		      const hiopMatrix* Jac_c, const hiopMatrix* Jac_d,
 		      hiopMatrix* Hess);
 
-  virtual bool build_kkt_matrix(const hiopVector& delta_wx,
+  virtual bool build_kkt_matrix(const hiopPDPerturbation& pdreg, 
+                                const hiopVector& delta_wx,
                                 const hiopVector& delta_wd,
                                 const hiopVector& delta_cc,
                                 const hiopVector& delta_cd,

--- a/src/Optimization/hiopKKTLinSysMDS.hpp
+++ b/src/Optimization/hiopKKTLinSysMDS.hpp
@@ -107,12 +107,7 @@ public:
 		      const hiopMatrix* Jac_c, const hiopMatrix* Jac_d,
 		      hiopMatrix* Hess);
 
-  virtual bool build_kkt_matrix(const hiopPDPerturbation& pdreg, 
-                                const hiopVector& delta_wx,
-                                const hiopVector& delta_wd,
-                                const hiopVector& delta_cc,
-                                const hiopVector& delta_cd,
-                                const DeltasUpdateType delta_update_type);
+  virtual bool build_kkt_matrix(const hiopPDPerturbation& pdreg);
 
   virtual bool solveCompressed(hiopVector& rx, hiopVector& ryc, hiopVector& ryd,
                                hiopVector& dx, hiopVector& dyc, hiopVector& dyd);

--- a/src/Optimization/hiopKKTLinSysSparse.cpp
+++ b/src/Optimization/hiopKKTLinSysSparse.cpp
@@ -87,13 +87,13 @@ namespace hiop
     delete Hx_;
   }
 
-  bool hiopKKTLinSysCompressedSparseXYcYd::build_kkt_matrix(const hiopPDPerturbation& pdreg, 
-                                                            const hiopVector& delta_wx,
-                                                            const hiopVector& delta_wd,
-                                                            const hiopVector& delta_cc,
-                                                            const hiopVector& delta_cd,
-                                                            const DeltasUpdateType delta_update_type)
+  bool hiopKKTLinSysCompressedSparseXYcYd::build_kkt_matrix(const hiopPDPerturbation& pdreg)
   {
+    delta_wx_ = perturb_calc_->get_curr_delta_wx();
+    delta_wd_ = perturb_calc_->get_curr_delta_wd();
+    delta_cc_ = perturb_calc_->get_curr_delta_cc();
+    delta_cd_ = perturb_calc_->get_curr_delta_cd();
+
     HessSp_ = dynamic_cast<hiopMatrixSparse*>(Hess_);
     if(!HessSp_) { assert(false); return false; }
 
@@ -144,12 +144,12 @@ namespace hiop
       Hx_->startingAtCopyFromStartingAt(0, *Dx_, 0);
 
       //a good time to add the IC 'delta_wx' perturbation
-      Hx_->axpy(1., delta_wx);
+      Hx_->axpy(1., *delta_wx_);
 
       Msys->copySubDiagonalFrom(0, nx, *Hx_, dest_nnz_st); dest_nnz_st += nx;
 
       //add -delta_cc to diagonal block linSys starting at (nx, nx)
-      Msys->copySubDiagonalFrom(nx, neq, delta_cc, dest_nnz_st, -1.); dest_nnz_st += neq;
+      Msys->copySubDiagonalFrom(nx, neq, *delta_cc_, dest_nnz_st, -1.); dest_nnz_st += neq;
 
       /* we've just done above the (1,1) and (2,2) blocks of
        *
@@ -162,7 +162,7 @@ namespace hiop
        */
 
       // Dd = (Sdl)^{-1}Vu + (Sdu)^{-1}Vu + delta_wd * I
-      Dd_inv_->axpy(1., delta_wd);
+      Dd_inv_->axpy(1., *delta_wd_);
       Dd_inv_->axdzpy_w_pattern(1.0, *iter_->vl, *iter_->sdl, nlp_->get_idl());
       Dd_inv_->axdzpy_w_pattern(1.0, *iter_->vu, *iter_->sdu, nlp_->get_idu());
 
@@ -170,7 +170,7 @@ namespace hiop
       assert(true==Dd_inv_->allPositive());
 #endif
       Dd_inv_->invert();
-      Dd_inv_->axpy(1., delta_cd);
+      Dd_inv_->axpy(1., *delta_cd_);
 
       Msys->copySubDiagonalFrom(nx+neq, nineq, *Dd_inv_, dest_nnz_st, -1); dest_nnz_st += nineq;
 
@@ -412,13 +412,13 @@ namespace hiop
     delete Hd_;
   }
 
-  bool hiopKKTLinSysCompressedSparseXDYcYd::build_kkt_matrix(const hiopPDPerturbation& pdreg, 
-                                                             const hiopVector& delta_wx,
-                                                             const hiopVector& delta_wd,
-                                                             const hiopVector& delta_cc,
-                                                             const hiopVector& delta_cd,
-                                                             const DeltasUpdateType delta_update_type)
-  {    
+  bool hiopKKTLinSysCompressedSparseXDYcYd::build_kkt_matrix(const hiopPDPerturbation& pdreg)
+  {
+    delta_wx_ = perturb_calc_->get_curr_delta_wx();
+    delta_wd_ = perturb_calc_->get_curr_delta_wd();
+    delta_cc_ = perturb_calc_->get_curr_delta_cc();
+    delta_cd_ = perturb_calc_->get_curr_delta_cd();
+    
     HessSp_ = dynamic_cast<hiopMatrixSymSparseTriplet*>(Hess_);
     if(!HessSp_) { assert(false); return false; }
 
@@ -471,7 +471,7 @@ namespace hiop
       Hx_->startingAtCopyFromStartingAt(0, *Dx_, 0);
 
       //a good time to add the IC 'delta_wx' perturbation
-      Hx_->axpy(1., delta_wx);
+      Hx_->axpy(1., *delta_wx_);
 
       Msys->copySubDiagonalFrom(0, nx, *Hx_, dest_nnz_st);
       dest_nnz_st += nx;
@@ -482,16 +482,16 @@ namespace hiop
         assert(Hd_);
       }
       Hd_->startingAtCopyFromStartingAt(0, *Dd_, 0);
-      Hd_->axpy(1., delta_wd);
+      Hd_->axpy(1., *delta_wd_);
       Msys->copySubDiagonalFrom(nx, nd, *Hd_, dest_nnz_st);
       dest_nnz_st += nd;
 
       //add -delta_cc to diagonal block linSys starting at (nx+nd, nx+nd)
-      Msys->copySubDiagonalFrom(nx+nd, neq, delta_cc, dest_nnz_st, -1.);
+      Msys->copySubDiagonalFrom(nx+nd, neq, *delta_cc_, dest_nnz_st, -1.);
       dest_nnz_st += neq;
 
       //add -delta_cd to diagonal block linSys starting at (nx+nd+neq, nx+nd+neq)
-      Msys->copySubDiagonalFrom(nx+nd+neq, nineq, delta_cd, dest_nnz_st, -1.);
+      Msys->copySubDiagonalFrom(nx+nd+neq, nineq, *delta_cd_, dest_nnz_st, -1.);
       dest_nnz_st += nineq;
 
       /* we've just done
@@ -848,13 +848,13 @@ namespace hiop
     return dynamic_cast<hiopLinSolverNonSymSparse*> (linSys_);
   }
 
-  bool hiopKKTLinSysSparseFull::build_kkt_matrix(const hiopPDPerturbation& pdreg, 
-                                                 const hiopVector& delta_wx,
-                                                 const hiopVector& delta_wd,
-                                                 const hiopVector& delta_cc,
-                                                 const hiopVector& delta_cd,
-                                                 const DeltasUpdateType delta_update_type)
+  bool hiopKKTLinSysSparseFull::build_kkt_matrix(const hiopPDPerturbation& pdreg)
   {
+    delta_wx_ = perturb_calc_->get_curr_delta_wx();
+    delta_wd_ = perturb_calc_->get_curr_delta_wd();
+    delta_cc_ = perturb_calc_->get_curr_delta_cc();
+    delta_cd_ = perturb_calc_->get_curr_delta_cd();
+
     HessSp_ = dynamic_cast<hiopMatrixSymSparseTriplet*>(Hess_);
     if(!HessSp_) { assert(false); return false; }
 
@@ -1009,7 +1009,7 @@ namespace hiop
         Hx_ = LinearAlgebraFactory::create_vector(nlp_->options->GetString("mem_space"), nx);
         assert(Hx_);
       }
-      Hx_->axpy(1., delta_wx);
+      Hx_->axpy(1., *delta_wx_);
       Msys->copySubDiagonalFrom(0, nx, *Hx_, dest_nnz_st); dest_nnz_st += nx;
 
       //build the diagonal Hd = delta_wd
@@ -1018,16 +1018,16 @@ namespace hiop
         assert(Hd_);
       }
 
-      Hd_->axpy(1., delta_wd);
+      Hd_->axpy(1., *delta_wd_);
       Msys->copySubDiagonalFrom(n2st, nd, *Hd_, dest_nnz_st);
       dest_nnz_st += nd;
 
       //add -delta_cc to diagonal block linSys starting at (nx, nx)
-      Msys->copySubDiagonalFrom(nx, neq, delta_cc, dest_nnz_st, -1.);
+      Msys->copySubDiagonalFrom(nx, neq, *delta_cc_, dest_nnz_st, -1.);
       dest_nnz_st += neq;
 
       //add -delta_cd to diagonal block linSys starting at (nx+neq, nx+neq)
-      Msys->copySubDiagonalFrom(nx+neq, nineq, delta_cd, dest_nnz_st, -1.);
+      Msys->copySubDiagonalFrom(nx+neq, nineq, *delta_cd_, dest_nnz_st, -1.);
       dest_nnz_st += nineq;
 
       assert(dest_nnz_st==nnz);

--- a/src/Optimization/hiopKKTLinSysSparse.cpp
+++ b/src/Optimization/hiopKKTLinSysSparse.cpp
@@ -87,7 +87,8 @@ namespace hiop
     delete Hx_;
   }
 
-  bool hiopKKTLinSysCompressedSparseXYcYd::build_kkt_matrix(const hiopVector& delta_wx,
+  bool hiopKKTLinSysCompressedSparseXYcYd::build_kkt_matrix(const hiopPDPerturbation& pdreg, 
+                                                            const hiopVector& delta_wx,
                                                             const hiopVector& delta_wd,
                                                             const hiopVector& delta_cc,
                                                             const hiopVector& delta_cd,
@@ -411,7 +412,8 @@ namespace hiop
     delete Hd_;
   }
 
-  bool hiopKKTLinSysCompressedSparseXDYcYd::build_kkt_matrix(const hiopVector& delta_wx,
+  bool hiopKKTLinSysCompressedSparseXDYcYd::build_kkt_matrix(const hiopPDPerturbation& pdreg, 
+                                                             const hiopVector& delta_wx,
                                                              const hiopVector& delta_wd,
                                                              const hiopVector& delta_cc,
                                                              const hiopVector& delta_cd,
@@ -846,7 +848,8 @@ namespace hiop
     return dynamic_cast<hiopLinSolverNonSymSparse*> (linSys_);
   }
 
-  bool hiopKKTLinSysSparseFull::build_kkt_matrix(const hiopVector& delta_wx,
+  bool hiopKKTLinSysSparseFull::build_kkt_matrix(const hiopPDPerturbation& pdreg, 
+                                                 const hiopVector& delta_wx,
                                                  const hiopVector& delta_wd,
                                                  const hiopVector& delta_cc,
                                                  const hiopVector& delta_cd,

--- a/src/Optimization/hiopKKTLinSysSparse.cpp
+++ b/src/Optimization/hiopKKTLinSysSparse.cpp
@@ -90,7 +90,8 @@ namespace hiop
   bool hiopKKTLinSysCompressedSparseXYcYd::build_kkt_matrix(const hiopVector& delta_wx,
                                                             const hiopVector& delta_wd,
                                                             const hiopVector& delta_cc,
-                                                            const hiopVector& delta_cd)
+                                                            const hiopVector& delta_cd,
+                                                            const DeltasUpdateType delta_update_type)
   {
     HessSp_ = dynamic_cast<hiopMatrixSparse*>(Hess_);
     if(!HessSp_) { assert(false); return false; }
@@ -413,7 +414,8 @@ namespace hiop
   bool hiopKKTLinSysCompressedSparseXDYcYd::build_kkt_matrix(const hiopVector& delta_wx,
                                                              const hiopVector& delta_wd,
                                                              const hiopVector& delta_cc,
-                                                             const hiopVector& delta_cd)
+                                                             const hiopVector& delta_cd,
+                                                             const DeltasUpdateType delta_update_type)
   {    
     HessSp_ = dynamic_cast<hiopMatrixSymSparseTriplet*>(Hess_);
     if(!HessSp_) { assert(false); return false; }
@@ -847,7 +849,8 @@ namespace hiop
   bool hiopKKTLinSysSparseFull::build_kkt_matrix(const hiopVector& delta_wx,
                                                  const hiopVector& delta_wd,
                                                  const hiopVector& delta_cc,
-                                                 const hiopVector& delta_cd)
+                                                 const hiopVector& delta_cd,
+                                                 const DeltasUpdateType delta_update_type)
   {
     HessSp_ = dynamic_cast<hiopMatrixSymSparseTriplet*>(Hess_);
     if(!HessSp_) { assert(false); return false; }

--- a/src/Optimization/hiopKKTLinSysSparse.hpp
+++ b/src/Optimization/hiopKKTLinSysSparse.hpp
@@ -80,7 +80,8 @@ public:
   virtual bool build_kkt_matrix(const hiopVector& delta_wx,
                                 const hiopVector& delta_wd,
                                 const hiopVector& delta_cc,
-                                const hiopVector& delta_cd);
+                                const hiopVector& delta_cd,
+                                const DeltasUpdateType delta_update_type);
 
   virtual bool solveCompressed(hiopVector& rx, hiopVector& ryc, hiopVector& ryd,
                                hiopVector& dx, hiopVector& dyc, hiopVector& dyd);
@@ -142,7 +143,8 @@ public:
   virtual bool build_kkt_matrix(const hiopVector& delta_wx,
                                 const hiopVector& delta_wd,
                                 const hiopVector& delta_cc,
-                                const hiopVector& delta_cd);
+                                const hiopVector& delta_cd,
+                                const DeltasUpdateType delta_update_type);
 
   virtual bool solveCompressed(hiopVector& rx, hiopVector& rd, hiopVector& ryc, hiopVector& ryd,
                                hiopVector& dx, hiopVector& dd, hiopVector& dyc, hiopVector& dyd);
@@ -215,7 +217,8 @@ public:
   virtual bool build_kkt_matrix(const hiopVector& delta_wx,
                                 const hiopVector& delta_wd,
                                 const hiopVector& delta_cc,
-                                const hiopVector& delta_cd);
+                                const hiopVector& delta_cd,
+                                const DeltasUpdateType delta_update_type);
 
   bool solve(hiopVector& rx, hiopVector& ryc, hiopVector& ryd, hiopVector& rd,
              hiopVector& rvl, hiopVector& rvu, hiopVector& rzl, hiopVector& rzu,

--- a/src/Optimization/hiopKKTLinSysSparse.hpp
+++ b/src/Optimization/hiopKKTLinSysSparse.hpp
@@ -77,7 +77,8 @@ public:
   hiopKKTLinSysCompressedSparseXYcYd(hiopNlpFormulation* nlp);
   virtual ~hiopKKTLinSysCompressedSparseXYcYd();
 
-  virtual bool build_kkt_matrix(const hiopVector& delta_wx,
+  virtual bool build_kkt_matrix(const hiopPDPerturbation& pdreg, 
+                                const hiopVector& delta_wx,
                                 const hiopVector& delta_wd,
                                 const hiopVector& delta_cc,
                                 const hiopVector& delta_cd,
@@ -140,7 +141,8 @@ public:
   hiopKKTLinSysCompressedSparseXDYcYd(hiopNlpFormulation* nlp);
   virtual ~hiopKKTLinSysCompressedSparseXDYcYd();
 
-  virtual bool build_kkt_matrix(const hiopVector& delta_wx,
+  virtual bool build_kkt_matrix(const hiopPDPerturbation& pdreg, 
+                                const hiopVector& delta_wx,
                                 const hiopVector& delta_wd,
                                 const hiopVector& delta_cc,
                                 const hiopVector& delta_cd,
@@ -214,7 +216,8 @@ public:
 
   virtual ~hiopKKTLinSysSparseFull();
 
-  virtual bool build_kkt_matrix(const hiopVector& delta_wx,
+  virtual bool build_kkt_matrix(const hiopPDPerturbation& pdreg, 
+                                const hiopVector& delta_wx,
                                 const hiopVector& delta_wd,
                                 const hiopVector& delta_cc,
                                 const hiopVector& delta_cd,

--- a/src/Optimization/hiopKKTLinSysSparse.hpp
+++ b/src/Optimization/hiopKKTLinSysSparse.hpp
@@ -77,12 +77,7 @@ public:
   hiopKKTLinSysCompressedSparseXYcYd(hiopNlpFormulation* nlp);
   virtual ~hiopKKTLinSysCompressedSparseXYcYd();
 
-  virtual bool build_kkt_matrix(const hiopPDPerturbation& pdreg, 
-                                const hiopVector& delta_wx,
-                                const hiopVector& delta_wd,
-                                const hiopVector& delta_cc,
-                                const hiopVector& delta_cd,
-                                const DeltasUpdateType delta_update_type);
+  virtual bool build_kkt_matrix(const hiopPDPerturbation& pdreg);
 
   virtual bool solveCompressed(hiopVector& rx, hiopVector& ryc, hiopVector& ryd,
                                hiopVector& dx, hiopVector& dyc, hiopVector& dyd);
@@ -141,12 +136,7 @@ public:
   hiopKKTLinSysCompressedSparseXDYcYd(hiopNlpFormulation* nlp);
   virtual ~hiopKKTLinSysCompressedSparseXDYcYd();
 
-  virtual bool build_kkt_matrix(const hiopPDPerturbation& pdreg, 
-                                const hiopVector& delta_wx,
-                                const hiopVector& delta_wd,
-                                const hiopVector& delta_cc,
-                                const hiopVector& delta_cd,
-                                const DeltasUpdateType delta_update_type);
+  virtual bool build_kkt_matrix(const hiopPDPerturbation& pdreg);
 
   virtual bool solveCompressed(hiopVector& rx, hiopVector& rd, hiopVector& ryc, hiopVector& ryd,
                                hiopVector& dx, hiopVector& dd, hiopVector& dyc, hiopVector& dyd);
@@ -216,12 +206,7 @@ public:
 
   virtual ~hiopKKTLinSysSparseFull();
 
-  virtual bool build_kkt_matrix(const hiopPDPerturbation& pdreg, 
-                                const hiopVector& delta_wx,
-                                const hiopVector& delta_wd,
-                                const hiopVector& delta_cc,
-                                const hiopVector& delta_cd,
-                                const DeltasUpdateType delta_update_type);
+  virtual bool build_kkt_matrix(const hiopPDPerturbation& pdreg);
 
   bool solve(hiopVector& rx, hiopVector& ryc, hiopVector& ryd, hiopVector& rd,
              hiopVector& rvl, hiopVector& rvu, hiopVector& rzl, hiopVector& rzu,

--- a/src/Optimization/hiopKKTLinSysSparseCondensed.cpp
+++ b/src/Optimization/hiopKKTLinSysSparseCondensed.cpp
@@ -111,7 +111,8 @@ hiopKKTLinSysCondensedSparse::~hiopKKTLinSysCondensedSparse()
 bool hiopKKTLinSysCondensedSparse::build_kkt_matrix(const hiopVector& delta_wx_in,
                                                     const hiopVector& delta_wd_in,
                                                     const hiopVector& dcc,
-                                                    const hiopVector& dcd)
+                                                    const hiopVector& dcd,
+                                                    const DeltasUpdateType delta_update_type)
 {
   nlp_->runStats.kkt.tmUpdateInit.start();
 

--- a/src/Optimization/hiopKKTLinSysSparseCondensed.cpp
+++ b/src/Optimization/hiopKKTLinSysSparseCondensed.cpp
@@ -108,7 +108,8 @@ hiopKKTLinSysCondensedSparse::~hiopKKTLinSysCondensedSparse()
   delete Hess_lower_csr_;
 }
 
-bool hiopKKTLinSysCondensedSparse::build_kkt_matrix(const hiopVector& delta_wx_in,
+bool hiopKKTLinSysCondensedSparse::build_kkt_matrix(const hiopPDPerturbation& pdreg, 
+                                                    const hiopVector& delta_wx_in,
                                                     const hiopVector& delta_wd_in,
                                                     const hiopVector& dcc,
                                                     const hiopVector& dcd,

--- a/src/Optimization/hiopKKTLinSysSparseCondensed.cpp
+++ b/src/Optimization/hiopKKTLinSysSparseCondensed.cpp
@@ -108,13 +108,18 @@ hiopKKTLinSysCondensedSparse::~hiopKKTLinSysCondensedSparse()
   delete Hess_lower_csr_;
 }
 
-bool hiopKKTLinSysCondensedSparse::build_kkt_matrix(const hiopPDPerturbation& pdreg, 
-                                                    const hiopVector& delta_wx_in,
-                                                    const hiopVector& delta_wd_in,
-                                                    const hiopVector& dcc,
-                                                    const hiopVector& dcd,
-                                                    const DeltasUpdateType delta_update_type)
+bool hiopKKTLinSysCondensedSparse::build_kkt_matrix(const hiopPDPerturbation& pdreg)
 {
+  delta_wx_ = perturb_calc_->get_curr_delta_wx();
+  delta_wd_ = perturb_calc_->get_curr_delta_wd();
+  delta_cc_ = perturb_calc_->get_curr_delta_cc();
+  delta_cd_ = perturb_calc_->get_curr_delta_cd();
+
+  const hiopVector& delta_wx_in = *delta_wx_;
+  const hiopVector& delta_wd_in = *delta_wd_;
+  const hiopVector& dcc = *delta_cc_;
+  const hiopVector& dcd = *delta_cd_;
+
   nlp_->runStats.kkt.tmUpdateInit.start();
 
   hiopMatrixSymSparseTriplet* Hess_triplet = dynamic_cast<hiopMatrixSymSparseTriplet*>(Hess_);

--- a/src/Optimization/hiopKKTLinSysSparseCondensed.hpp
+++ b/src/Optimization/hiopKKTLinSysSparseCondensed.hpp
@@ -109,7 +109,8 @@ public:
   hiopKKTLinSysCondensedSparse() = delete;
   virtual ~hiopKKTLinSysCondensedSparse();
 
-  virtual bool build_kkt_matrix(const hiopVector& delta_wx,
+  virtual bool build_kkt_matrix(const hiopPDPerturbation& pdreg, 
+                                const hiopVector& delta_wx,
                                 const hiopVector& delta_wd,
                                 const hiopVector& delta_cc,
                                 const hiopVector& delta_cd,

--- a/src/Optimization/hiopKKTLinSysSparseCondensed.hpp
+++ b/src/Optimization/hiopKKTLinSysSparseCondensed.hpp
@@ -112,7 +112,8 @@ public:
   virtual bool build_kkt_matrix(const hiopVector& delta_wx,
                                 const hiopVector& delta_wd,
                                 const hiopVector& delta_cc,
-                                const hiopVector& delta_cd);
+                                const hiopVector& delta_cd,
+                                const DeltasUpdateType delta_update_type);
 
   virtual bool solveCompressed(hiopVector& rx,
                                hiopVector& rd,

--- a/src/Optimization/hiopKKTLinSysSparseCondensed.hpp
+++ b/src/Optimization/hiopKKTLinSysSparseCondensed.hpp
@@ -109,12 +109,7 @@ public:
   hiopKKTLinSysCondensedSparse() = delete;
   virtual ~hiopKKTLinSysCondensedSparse();
 
-  virtual bool build_kkt_matrix(const hiopPDPerturbation& pdreg, 
-                                const hiopVector& delta_wx,
-                                const hiopVector& delta_wd,
-                                const hiopVector& delta_cc,
-                                const hiopVector& delta_cd,
-                                const DeltasUpdateType delta_update_type);
+  virtual bool build_kkt_matrix(const hiopPDPerturbation& pdreg);
 
   virtual bool solveCompressed(hiopVector& rx,
                                hiopVector& rd,

--- a/src/Optimization/hiopKKTLinSysSparseNormalEqn.cpp
+++ b/src/Optimization/hiopKKTLinSysSparseNormalEqn.cpp
@@ -121,17 +121,17 @@ hiopKKTLinSysSparseNormalEqn::~hiopKKTLinSysSparseNormalEqn()
   delete M_normaleqn_;
 }
 
-bool hiopKKTLinSysSparseNormalEqn::build_kkt_matrix(const hiopPDPerturbation& pdreg, 
-                                                    const hiopVector& delta_wx_in,
-                                                    const hiopVector& delta_wd_in,
-                                                    const hiopVector& delta_cc_in,
-                                                    const hiopVector& delta_cd_in,
-                                                    const DeltasUpdateType delta_update_type)
+bool hiopKKTLinSysSparseNormalEqn::build_kkt_matrix(const hiopPDPerturbation& pdreg)
 {
 
 #ifdef HIOP_DEEPCHECKS
     assert(perturb_calc_->check_consistency() && "something went wrong with IC");
 #endif
+
+  delta_wx_ = perturb_calc_->get_curr_delta_wx();
+  delta_wd_ = perturb_calc_->get_curr_delta_wd();
+  delta_cc_ = perturb_calc_->get_curr_delta_cc();
+  delta_cd_ = perturb_calc_->get_curr_delta_cd();
 
   HessSp_ = dynamic_cast<hiopMatrixSparse*>(Hess_);
   if(!HessSp_) { 
@@ -211,12 +211,12 @@ bool hiopKKTLinSysSparseNormalEqn::build_kkt_matrix(const hiopPDPerturbation& pd
   }
   //build the diagonal Hx = Dx + delta_wx + diag(Hess)
   Hx_->copyFrom(*Dx_);
-  Hx_->axpy(1., delta_wx_in);
+  Hx_->axpy(1., *delta_wx_);
   Hx_->axpy(1., *Hess_diag_);
 
   // HD = Dd_ + delta_wd
   Hd_->copyFrom(*Dd_);
-  Hd_->axpy(1., delta_wd_in);
+  Hd_->axpy(1., *delta_wd_);
 
   //temporary code, see above note
   {
@@ -255,10 +255,10 @@ bool hiopKKTLinSysSparseNormalEqn::build_kkt_matrix(const hiopPDPerturbation& pd
       Hess_diag_copy_->copyFrom(*Hess_diag_);
       Hx_copy_->copyFrom(*Hx_);
       Hd_copy_->copyFrom(*Hd_);
-      deltawx_->copyFrom(delta_wx_in);
-      deltawd_->copyFrom(delta_wd_in);
-      deltacc_->copyFrom(delta_cc_in);
-      deltacd_->copyFrom(delta_cd_in);
+      deltawx_->copyFrom(*delta_wx_);
+      deltawd_->copyFrom(*delta_wd_);
+      deltacc_->copyFrom(*delta_cc_);
+      deltacd_->copyFrom(*delta_cd_);
     }
   }
 

--- a/src/Optimization/hiopKKTLinSysSparseNormalEqn.cpp
+++ b/src/Optimization/hiopKKTLinSysSparseNormalEqn.cpp
@@ -124,7 +124,8 @@ hiopKKTLinSysSparseNormalEqn::~hiopKKTLinSysSparseNormalEqn()
 bool hiopKKTLinSysSparseNormalEqn::build_kkt_matrix(const hiopVector& delta_wx_in,
                                                     const hiopVector& delta_wd_in,
                                                     const hiopVector& delta_cc_in,
-                                                    const hiopVector& delta_cd_in)
+                                                    const hiopVector& delta_cd_in,
+                                                    const DeltasUpdateType delta_update_type)
 {
 
 #ifdef HIOP_DEEPCHECKS

--- a/src/Optimization/hiopKKTLinSysSparseNormalEqn.cpp
+++ b/src/Optimization/hiopKKTLinSysSparseNormalEqn.cpp
@@ -318,7 +318,7 @@ bool hiopKKTLinSysSparseNormalEqn::build_kkt_matrix(const hiopPDPerturbation& pd
 
   t.reset(); t.start();
 
-  if(pdreg.get_curr_delta_type() != DeltasUpdateType::DualUpdate) {
+  if(pdreg.get_curr_delta_type() != hiopPDPerturbation::DeltasUpdateType::DualUpdate) {
     // build the diagonal Hxd_inv_copy_ = [H+Dx+delta_wx, Dd+delta_wd ]^{-1}
     Hx_copy_->copyToStarting(*Hxd_inv_copy_, 0);
     Hd_copy_->copyToStarting(*Hxd_inv_copy_, nx);
@@ -502,7 +502,7 @@ int hiopKKTLinSysSparseNormalEqn::factorizeWithCurvCheck()
   size_type n_neg_eig = hiopKKTLinSysCurvCheck::factorizeWithCurvCheck();
 
   if(n_neg_eig == -1) {
-    nlp_->log->printf(hovWarning,
+    nlp_->log->printf(hovScalars,
                 "KKT_SPARSE_NormalEqn linsys: Detected null eigenvalues.\n");
     n_neg_eig = -1;
   } else {

--- a/src/Optimization/hiopKKTLinSysSparseNormalEqn.cpp
+++ b/src/Optimization/hiopKKTLinSysSparseNormalEqn.cpp
@@ -121,7 +121,8 @@ hiopKKTLinSysSparseNormalEqn::~hiopKKTLinSysSparseNormalEqn()
   delete M_normaleqn_;
 }
 
-bool hiopKKTLinSysSparseNormalEqn::build_kkt_matrix(const hiopVector& delta_wx_in,
+bool hiopKKTLinSysSparseNormalEqn::build_kkt_matrix(const hiopPDPerturbation& pdreg, 
+                                                    const hiopVector& delta_wx_in,
                                                     const hiopVector& delta_wd_in,
                                                     const hiopVector& delta_cc_in,
                                                     const hiopVector& delta_cd_in,

--- a/src/Optimization/hiopKKTLinSysSparseNormalEqn.cpp
+++ b/src/Optimization/hiopKKTLinSysSparseNormalEqn.cpp
@@ -238,10 +238,10 @@ bool hiopKKTLinSysSparseNormalEqn::build_kkt_matrix(const hiopPDPerturbation& pd
       auto deltawd_raja = dynamic_cast<hiopVectorRajaPar*>(deltawd_);
       auto deltacc_raja = dynamic_cast<hiopVectorRajaPar*>(deltacc_);
       auto deltacd_raja = dynamic_cast<hiopVectorRajaPar*>(deltacd_);
-      const hiopVectorPar& deltawx_host = dynamic_cast<const hiopVectorPar&>(delta_wx_in);
-      const hiopVectorPar& deltawd_host = dynamic_cast<const hiopVectorPar&>(delta_wd_in);
-      const hiopVectorPar& deltacc_host = dynamic_cast<const hiopVectorPar&>(delta_cc_in);
-      const hiopVectorPar& deltacd_host = dynamic_cast<const hiopVectorPar&>(delta_cd_in);
+      const hiopVectorPar& deltawx_host = dynamic_cast<const hiopVectorPar&>(*delta_wx_);
+      const hiopVectorPar& deltawd_host = dynamic_cast<const hiopVectorPar&>(*delta_wd_);
+      const hiopVectorPar& deltacc_host = dynamic_cast<const hiopVectorPar&>(*delta_cc_);
+      const hiopVectorPar& deltacd_host = dynamic_cast<const hiopVectorPar&>(*delta_cd_);
 
       deltawx_raja->copy_from_host_vec(deltawx_host);
       deltawd_raja->copy_from_host_vec(deltawd_host);

--- a/src/Optimization/hiopKKTLinSysSparseNormalEqn.cpp
+++ b/src/Optimization/hiopKKTLinSysSparseNormalEqn.cpp
@@ -318,18 +318,20 @@ bool hiopKKTLinSysSparseNormalEqn::build_kkt_matrix(const hiopPDPerturbation& pd
 
   t.reset(); t.start();
 
-  // build the diagonal Hxd_inv_copy_ = [H+Dx+delta_wx, Dd+delta_wd ]^{-1}
-  Hx_copy_->copyToStarting(*Hxd_inv_copy_, 0);
-  Hd_copy_->copyToStarting(*Hxd_inv_copy_, nx);
-  Hxd_inv_copy_->invert();
-  // J * D * Jt
-  JacDt_->form_transpose_from_numeric(*JacD_);
-  JacDt_->scale_rows(*Hxd_inv_copy_);
-  JacD_->times_mat_numeric(0.0, *JDiagJt_, 1.0, *JacDt_);
+  if(pdreg.get_curr_delta_type() != DeltasUpdateType::DualUpdate) {
+    // build the diagonal Hxd_inv_copy_ = [H+Dx+delta_wx, Dd+delta_wd ]^{-1}
+    Hx_copy_->copyToStarting(*Hxd_inv_copy_, 0);
+    Hd_copy_->copyToStarting(*Hxd_inv_copy_, nx);
+    Hxd_inv_copy_->invert();
+    // J * D * Jt
+    JacDt_->form_transpose_from_numeric(*JacD_);
+    JacDt_->scale_rows(*Hxd_inv_copy_);
+    JacD_->times_mat_numeric(0.0, *JDiagJt_, 1.0, *JacDt_);
 
 #ifdef HIOP_DEEPCHECKS
-  JDiagJt_->check_csr_is_ordered();
+    JDiagJt_->check_csr_is_ordered();
 #endif
+  }
 
   if(nullptr == M_normaleqn_) {
     t.reset(); t.start();

--- a/src/Optimization/hiopKKTLinSysSparseNormalEqn.hpp
+++ b/src/Optimization/hiopKKTLinSysSparseNormalEqn.hpp
@@ -96,7 +96,8 @@ public:
   virtual bool build_kkt_matrix(const hiopVector& delta_wx,
                                 const hiopVector& delta_wd,
                                 const hiopVector& delta_cc,
-                                const hiopVector& delta_cd);
+                                const hiopVector& delta_cd,
+                                const DeltasUpdateType delta_update_type);
 
   virtual bool solveCompressed(hiopVector& ryc_tilde,
                                hiopVector& ryd_tilde,

--- a/src/Optimization/hiopKKTLinSysSparseNormalEqn.hpp
+++ b/src/Optimization/hiopKKTLinSysSparseNormalEqn.hpp
@@ -93,7 +93,8 @@ public:
   hiopKKTLinSysSparseNormalEqn(hiopNlpFormulation* nlp);
   virtual ~hiopKKTLinSysSparseNormalEqn();
 
-  virtual bool build_kkt_matrix(const hiopVector& delta_wx,
+  virtual bool build_kkt_matrix(const hiopPDPerturbation& pdreg, 
+                                const hiopVector& delta_wx,
                                 const hiopVector& delta_wd,
                                 const hiopVector& delta_cc,
                                 const hiopVector& delta_cd,

--- a/src/Optimization/hiopKKTLinSysSparseNormalEqn.hpp
+++ b/src/Optimization/hiopKKTLinSysSparseNormalEqn.hpp
@@ -93,12 +93,7 @@ public:
   hiopKKTLinSysSparseNormalEqn(hiopNlpFormulation* nlp);
   virtual ~hiopKKTLinSysSparseNormalEqn();
 
-  virtual bool build_kkt_matrix(const hiopPDPerturbation& pdreg, 
-                                const hiopVector& delta_wx,
-                                const hiopVector& delta_wd,
-                                const hiopVector& delta_cc,
-                                const hiopVector& delta_cd,
-                                const DeltasUpdateType delta_update_type);
+  virtual bool build_kkt_matrix(const hiopPDPerturbation& pdreg);
 
   virtual bool solveCompressed(hiopVector& ryc_tilde,
                                hiopVector& ryd_tilde,

--- a/src/Optimization/hiopPDPerturbation.cpp
+++ b/src/Optimization/hiopPDPerturbation.cpp
@@ -99,6 +99,7 @@ namespace hiop
     num_degen_iters_ = 0;
 
     deltas_test_type_ = dttNoTest;
+    deltas_curr_update_ = None;
     return true;
   }
 
@@ -214,6 +215,7 @@ namespace hiop
     delta_cc.copyFrom(*delta_cc_curr_);
     delta_cd.copyFrom(*delta_cd_curr_);
 
+    deltas_curr_update_ = Initialized;
     return true;
   }
 
@@ -393,6 +395,7 @@ namespace hiop
 
   void hiopPDPerturbationPrimalFirstScala::set_delta_curr_vec(DeltasUpdateType taskid)
   {
+    deltas_curr_update_ = taskid;
     if(DualUpdate == taskid) {
       // only update dual deltas
       delta_cc_curr_->setToConstant(delta_cc_curr_db_);
@@ -454,6 +457,7 @@ namespace hiop
 
   void hiopPDPerturbationPrimalFirstRand::set_delta_curr_vec(DeltasUpdateType taskid)
   {
+    deltas_curr_update_ = taskid;
     if(DualUpdate == taskid) {
       // only update dual deltas
       delta_cc_curr_->set_to_random_uniform(min_uniform_ratio_*delta_cc_curr_db_, max_uniform_ratio_*delta_cc_curr_db_);
@@ -663,6 +667,7 @@ namespace hiop
 
   void hiopPDPerturbationDualFirstScala::set_delta_curr_vec(DeltasUpdateType taskid)
   {
+    deltas_curr_update_ = taskid;
     if(DualUpdate == taskid) {
       // only update dual deltas
       delta_cc_curr_->setToConstant(delta_cc_curr_db_);
@@ -724,6 +729,7 @@ namespace hiop
 
   void hiopPDPerturbationDualFirstRand::set_delta_curr_vec(DeltasUpdateType taskid)
   {
+    deltas_curr_update_ = taskid;
     if(DualUpdate == taskid) {
       // only update dual deltas
       delta_cc_curr_->set_to_random_uniform(min_uniform_ratio_*delta_cc_curr_db_, max_uniform_ratio_*delta_cc_curr_db_);

--- a/src/Optimization/hiopPDPerturbation.cpp
+++ b/src/Optimization/hiopPDPerturbation.cpp
@@ -158,7 +158,7 @@ namespace hiop
 
   /** Called when a new linear system is attempted to be factorized 
    */
-  bool hiopPDPerturbationPrimalFirstScala::compute_initial_deltas()
+  bool hiopPDPerturbationPrimalFirstScalar::compute_initial_deltas()
   {
     double delta_temp;
     double delta_temp2;
@@ -212,7 +212,7 @@ namespace hiop
   }
 
   /** Method for correcting inertia */
-  bool hiopPDPerturbationPrimalFirstScala::compute_perturb_wrong_inertia()
+  bool hiopPDPerturbationPrimalFirstScalar::compute_perturb_wrong_inertia()
   {    
     update_degeneracy_type();
 
@@ -245,7 +245,7 @@ namespace hiop
   /** Method for correcting singular Jacobian 
    *  (follows Ipopt closely since the paper seems to be outdated)
    */
-  bool hiopPDPerturbationPrimalFirstScala::compute_perturb_singularity()
+  bool hiopPDPerturbationPrimalFirstScalar::compute_perturb_singularity()
   {    
     assert(delta_wx_curr_db_ == delta_wd_curr_db_);
     assert(delta_cc_curr_db_ == delta_cd_curr_db_);
@@ -326,7 +326,7 @@ namespace hiop
   /** 
    * Internal method implementing the computation of delta_w's to correct wrong inertia
    */
-  bool hiopPDPerturbationPrimalFirstScala::guts_of_compute_perturb_wrong_inertia(double& delta_wx, double& delta_wd)
+  bool hiopPDPerturbationPrimalFirstScalar::guts_of_compute_perturb_wrong_inertia(double& delta_wx, double& delta_wd)
   {
     assert(delta_wx_curr_db_ == delta_wd_curr_db_ && "these should be equal");
     assert(delta_wx_last_db_ == delta_wd_last_db_ && "these should be equal");
@@ -356,17 +356,17 @@ namespace hiop
     return true;
   }
 
-  double hiopPDPerturbationPrimalFirstScala::compute_delta_c(const double& mu) const
+  double hiopPDPerturbationPrimalFirstScalar::compute_delta_c(const double& mu) const
   {
     return delta_c_bar_ * std::pow(mu, kappa_c_);
   }
 
-  bool hiopPDPerturbationPrimalFirstScala::check_consistency() 
+  bool hiopPDPerturbationPrimalFirstScalar::check_consistency() 
   {
     return (delta_wx_curr_db_ == delta_wd_curr_db_) && (delta_cc_curr_db_ == delta_cd_curr_db_);
   }
 
-  void hiopPDPerturbationPrimalFirstScala::set_delta_curr_vec(DeltasUpdateType taskid)
+  void hiopPDPerturbationPrimalFirstScalar::set_delta_curr_vec(DeltasUpdateType taskid)
   {
     deltas_curr_update_ = taskid;
     if(DualUpdate == taskid) {
@@ -386,7 +386,7 @@ namespace hiop
     }
   }
 
-  void hiopPDPerturbationPrimalFirstScala::set_delta_last_vec(DeltasUpdateType taskid)
+  void hiopPDPerturbationPrimalFirstScalar::set_delta_last_vec(DeltasUpdateType taskid)
   {
     if(DualUpdate == taskid) {
       // only update dual deltas
@@ -452,20 +452,20 @@ namespace hiop
 
 
   /*
-  *  class hiopPDPerturbationDualFirstScala
+  *  class hiopPDPerturbationDualFirstScalar
   */
-  hiopPDPerturbationDualFirstScala::hiopPDPerturbationDualFirstScala()
+  hiopPDPerturbationDualFirstScalar::hiopPDPerturbationDualFirstScalar()
     : hiopPDPerturbation(),
       delta_c_min_bar_(1e-20),
       kappa_c_plus_(10.)
   {
   }
 
-  hiopPDPerturbationDualFirstScala::~hiopPDPerturbationDualFirstScala()
+  hiopPDPerturbationDualFirstScalar::~hiopPDPerturbationDualFirstScalar()
   {
   }
 
-  bool hiopPDPerturbationDualFirstScala::compute_initial_deltas()            
+  bool hiopPDPerturbationDualFirstScalar::compute_initial_deltas()            
   {
     update_degeneracy_type();
       
@@ -510,7 +510,7 @@ namespace hiop
     return true;
   }
 
-  bool hiopPDPerturbationDualFirstScala::compute_perturb_wrong_inertia()  
+  bool hiopPDPerturbationDualFirstScalar::compute_perturb_wrong_inertia()  
   {    
     /** 
     * for normal equation, wrong inertia means the KKT 1x1 matrix is not PD 
@@ -545,16 +545,16 @@ namespace hiop
     return ret;
   }
 
-  bool hiopPDPerturbationDualFirstScala::compute_perturb_singularity()
+  bool hiopPDPerturbationDualFirstScalar::compute_perturb_singularity()
   {
     /**
      * we try to corret the dual regularization first, and then primal regularizaion
-     * same implementation as  hiopPDPerturbationDualFirstScala::compute_perturb_wrong_inertia
+     * same implementation as  hiopPDPerturbationDualFirstScalar::compute_perturb_wrong_inertia
      */
     return compute_perturb_wrong_inertia();
   }
 
-  bool hiopPDPerturbationDualFirstScala::compute_dual_perturb_impl(const double& mu)
+  bool hiopPDPerturbationDualFirstScalar::compute_dual_perturb_impl(const double& mu)
   {
     assert(delta_cc_curr_db_ == delta_cd_curr_db_ && "these should be equal");
     assert(delta_cc_last_db_ == delta_cd_last_db_ && "these should be equal");
@@ -585,7 +585,7 @@ namespace hiop
     return true;
   }
 
-  bool hiopPDPerturbationDualFirstScala::compute_primal_perturb_impl()
+  bool hiopPDPerturbationDualFirstScalar::compute_primal_perturb_impl()
   {
     assert(delta_wx_curr_db_ == delta_wd_curr_db_ && "these should be equal");
     assert(delta_wx_last_db_ == delta_wd_last_db_ && "these should be equal");
@@ -617,12 +617,12 @@ namespace hiop
     return bval;
   }
 
-  bool hiopPDPerturbationDualFirstScala::check_consistency() 
+  bool hiopPDPerturbationDualFirstScalar::check_consistency() 
   {
     return (delta_wx_curr_db_ == delta_wd_curr_db_) && (delta_cc_curr_db_ == delta_cd_curr_db_);
   }
 
-  void hiopPDPerturbationDualFirstScala::set_delta_curr_vec(DeltasUpdateType taskid)
+  void hiopPDPerturbationDualFirstScalar::set_delta_curr_vec(DeltasUpdateType taskid)
   {
     deltas_curr_update_ = taskid;
     if(DualUpdate == taskid) {
@@ -642,7 +642,7 @@ namespace hiop
     }
   }
 
-  void hiopPDPerturbationDualFirstScala::set_delta_last_vec(DeltasUpdateType taskid)
+  void hiopPDPerturbationDualFirstScalar::set_delta_last_vec(DeltasUpdateType taskid)
   {
     if(DualUpdate == taskid) {
       // only update dual deltas

--- a/src/Optimization/hiopPDPerturbation.hpp
+++ b/src/Optimization/hiopPDPerturbation.hpp
@@ -335,5 +335,17 @@ protected: // methods
   virtual void set_delta_last_vec(DeltasUpdateType taskid);  
 };
 
+class hiopPDPerturbationDualFirstDynamic : public hiopPDPerturbationDualFirstScala
+{
+public:
+  hiopPDPerturbationDualFirstDynamic() : hiopPDPerturbationDualFirstScala() {}
+
+  virtual ~hiopPDPerturbationDualFirstDynamic() {}
+
+protected: // methods
+  virtual void set_delta_curr_vec(DeltasUpdateType taskid); 
+  virtual void set_delta_last_vec(DeltasUpdateType taskid);  
+};
+
 } //end of namespace
 #endif

--- a/src/Optimization/hiopPDPerturbation.hpp
+++ b/src/Optimization/hiopPDPerturbation.hpp
@@ -9,7 +9,7 @@ namespace hiop
 
 enum DeltasUpdateType
 {
-  None  = -1,
+  None  = -2,
   Initialized  = -1,
   DualUpdate   =  0,
   PrimalUpdate =  1,
@@ -113,6 +113,8 @@ public:
   inline hiopVector* get_curr_delta_wd() const {return delta_wd_curr_;}
   inline hiopVector* get_curr_delta_cc() const {return delta_cc_curr_;}
   inline hiopVector* get_curr_delta_cd() const {return delta_cd_curr_;}
+
+  inline DeltasUpdateType get_curr_delta_type() const {return deltas_curr_update_;}
 
   virtual bool check_consistency() = 0;
 

--- a/src/Optimization/hiopPDPerturbation.hpp
+++ b/src/Optimization/hiopPDPerturbation.hpp
@@ -114,18 +114,6 @@ public:
   inline hiopVector* get_curr_delta_cc() const {return delta_cc_curr_;}
   inline hiopVector* get_curr_delta_cd() const {return delta_cd_curr_;}
 
-  inline bool get_curr_perturbations_const(hiopVector* delta_wx, 
-                                     hiopVector* delta_wd,
-                                     hiopVector* delta_cc,
-                                     hiopVector* delta_cd) const
-  {
-    delta_wx = get_curr_delta_wx();
-    delta_wd = get_curr_delta_wd();
-    delta_cc = get_curr_delta_cc();
-    delta_cd = get_curr_delta_cd();
-    return true;
-  }
-
   virtual bool check_consistency() = 0;
 
 protected:

--- a/src/Optimization/hiopPDPerturbation.hpp
+++ b/src/Optimization/hiopPDPerturbation.hpp
@@ -87,34 +87,42 @@ public:
 
   /** Called when a new linear system is attempted to be factorized 
    */
-  virtual bool compute_initial_deltas(hiopVector& delta_wx, 
-                                      hiopVector& delta_wd,
-                                      hiopVector& delta_cc,
-                                      hiopVector& delta_cd) = 0;
+  virtual bool compute_initial_deltas() = 0;
 
   /** Method for correcting inertia */
-  virtual bool compute_perturb_wrong_inertia(hiopVector& delta_wx, 
-                                             hiopVector& delta_wd,
-                                             hiopVector& delta_cc,
-                                             hiopVector& delta_cd) = 0;
+  virtual bool compute_perturb_wrong_inertia() = 0;
 
   /** Method for correcting singular Jacobian 
    *  (follows Ipopt closely since the paper seems to be outdated)
    */
-  virtual bool compute_perturb_singularity(hiopVector& delta_wx, 
+  virtual bool compute_perturb_singularity() = 0;
+
+  inline bool copy_from_curr_perturbations(hiopVector& delta_wx, 
                                            hiopVector& delta_wd,
                                            hiopVector& delta_cc,
-                                           hiopVector& delta_cd) = 0;
-
-  inline bool get_curr_perturbations(hiopVector& delta_wx, 
-                                     hiopVector& delta_wd,
-                                     hiopVector& delta_cc,
-                                     hiopVector& delta_cd)
+                                           hiopVector& delta_cd)
   {
     delta_wx.copyFrom(*delta_wx_curr_);
     delta_wd.copyFrom(*delta_wd_curr_);
     delta_cc.copyFrom(*delta_cc_curr_);
     delta_cd.copyFrom(*delta_cd_curr_);
+    return true;
+  }
+
+  inline hiopVector* get_curr_delta_wx() const {return delta_wx_curr_;}
+  inline hiopVector* get_curr_delta_wd() const {return delta_wd_curr_;}
+  inline hiopVector* get_curr_delta_cc() const {return delta_cc_curr_;}
+  inline hiopVector* get_curr_delta_cd() const {return delta_cd_curr_;}
+
+  inline bool get_curr_perturbations_const(hiopVector* delta_wx, 
+                                     hiopVector* delta_wd,
+                                     hiopVector* delta_cc,
+                                     hiopVector* delta_cd) const
+  {
+    delta_wx = get_curr_delta_wx();
+    delta_wd = get_curr_delta_wd();
+    delta_cc = get_curr_delta_cc();
+    delta_cd = get_curr_delta_cd();
     return true;
   }
 
@@ -213,6 +221,38 @@ protected: //methods
   virtual void set_delta_last_vec(DeltasUpdateType taskid) = 0;
 };
 
+/* method used for quasi newton's method */
+class hiopPDPerturbationDummy : public hiopPDPerturbation
+{
+public:
+  /** Default constructor 
+   * Provides complete initialization, but uses algorithmic parameters from the Ipopt
+   * implementation paper. \ref initialize(hiopNlpFormulation*) should be used to initialize
+   * this class based on HiOp option file or HiOp user-supplied runtime options.
+   */
+  hiopPDPerturbationDummy() : hiopPDPerturbation() {}
+  virtual ~hiopPDPerturbationDummy() {}
+
+  /** Called when a new linear system is attempted to be factorized 
+   */
+  virtual bool compute_initial_deltas() {return true;}
+
+  /** Method for correcting inertia */
+  virtual bool compute_perturb_wrong_inertia() {return true;}
+
+  /** Method for correcting singular Jacobian 
+   *  (follows Ipopt closely since the paper seems to be outdated)
+   */
+  virtual bool compute_perturb_singularity() {return true;}
+                  
+  virtual bool check_consistency() {return true;}
+
+protected: //methods
+  virtual void set_delta_curr_vec(DeltasUpdateType taskid) {}
+  virtual void set_delta_last_vec(DeltasUpdateType taskid) {}              
+};
+
+
 class hiopPDPerturbationPrimalFirstScala : public hiopPDPerturbation
 {
 public:
@@ -226,24 +266,15 @@ public:
 
   /** Called when a new linear system is attempted to be factorized 
    */
-  virtual bool compute_initial_deltas(hiopVector& delta_wx, 
-                                      hiopVector& delta_wd,
-                                      hiopVector& delta_cc,
-                                      hiopVector& delta_cd);
+  virtual bool compute_initial_deltas();
 
   /** Method for correcting inertia */
-  virtual bool compute_perturb_wrong_inertia(hiopVector& delta_wx, 
-                                             hiopVector& delta_wd,
-                                             hiopVector& delta_cc,
-                                             hiopVector& delta_cd);
+  virtual bool compute_perturb_wrong_inertia();
 
   /** Method for correcting singular Jacobian 
    *  (follows Ipopt closely since the paper seems to be outdated)
    */
-  virtual bool compute_perturb_singularity(hiopVector& delta_wx, 
-                                           hiopVector& delta_wd,
-                                           hiopVector& delta_cc,
-                                           hiopVector& delta_cd);
+  virtual bool compute_perturb_singularity();
                   
   virtual bool check_consistency();
                          
@@ -285,24 +316,15 @@ public:
 
   /** Called when a new linear system is attempted to be factorized 
    */
-  virtual bool compute_initial_deltas(hiopVector& delta_wx,
-                                      hiopVector& delta_wd,
-                                      hiopVector& delta_cc,
-                                      hiopVector& delta_cd);
+  virtual bool compute_initial_deltas();
 
   /** Method for correcting inertia */
-  virtual bool compute_perturb_wrong_inertia(hiopVector& delta_wx, 
-                                             hiopVector& delta_wd,
-                                             hiopVector& delta_cc,
-                                             hiopVector& delta_cd);
+  virtual bool compute_perturb_wrong_inertia();
                             
   /** Method for correcting singular Jacobian 
    *  (follows Ipopt closely since the paper seems to be outdated)
    */  
-  virtual bool compute_perturb_singularity(hiopVector& delta_wx,
-                                           hiopVector& delta_wd,
-                                           hiopVector& delta_cc,
-                                           hiopVector& delta_cd);
+  virtual bool compute_perturb_singularity();
 
   virtual bool check_consistency();
                          

--- a/src/Optimization/hiopPDPerturbation.hpp
+++ b/src/Optimization/hiopPDPerturbation.hpp
@@ -7,18 +7,19 @@
 namespace hiop
 {
 
-enum DeltasUpdateType
-{
-  None  = -2,
-  Initialized  = -1,
-  DualUpdate   =  0,
-  PrimalUpdate =  1,
-  PDUpdate     =  2
-};
-
 class hiopPDPerturbation
 {
 public:
+
+  enum DeltasUpdateType
+  {
+    None  = -2,
+    Initialized  = -1,
+    DualUpdate   =  0,
+    PrimalUpdate =  1,
+    PDUpdate     =  2
+  };
+
   /** Default constructor 
    * Provides complete initialization, but uses algorithmic parameters from the Ipopt
    * implementation paper. \ref initialize(hiopNlpFormulation*) should be used to initialize
@@ -212,7 +213,7 @@ protected: //methods
 };
 
 /* method used for quasi newton's method */
-class hiopPDPerturbationDummy : public hiopPDPerturbation
+class hiopPDPerturbationNull : public hiopPDPerturbation
 {
 public:
   /** Default constructor 
@@ -220,8 +221,8 @@ public:
    * implementation paper. \ref initialize(hiopNlpFormulation*) should be used to initialize
    * this class based on HiOp option file or HiOp user-supplied runtime options.
    */
-  hiopPDPerturbationDummy() : hiopPDPerturbation() {}
-  virtual ~hiopPDPerturbationDummy() {}
+  hiopPDPerturbationNull() : hiopPDPerturbation() {}
+  virtual ~hiopPDPerturbationNull() {}
 
   /** Called when a new linear system is attempted to be factorized 
    */
@@ -242,8 +243,11 @@ protected: //methods
   virtual void set_delta_last_vec(DeltasUpdateType taskid) {}              
 };
 
-
-class hiopPDPerturbationPrimalFirstScala : public hiopPDPerturbation
+/**
+ * @brief When inertia correction is required, update primal regularization before dual regularzation.
+ *        Both regularizations are computed as \delta*I, i.e., a scalar times an identity matrix
+ */
+class hiopPDPerturbationPrimalFirstScalar : public hiopPDPerturbation
 {
 public:
   /** Default constructor 
@@ -251,8 +255,8 @@ public:
    * implementation paper. \ref initialize(hiopNlpFormulation*) should be used to initialize
    * this class based on HiOp option file or HiOp user-supplied runtime options.
    */
-  hiopPDPerturbationPrimalFirstScala() : hiopPDPerturbation() {}
-  virtual ~hiopPDPerturbationPrimalFirstScala() {}
+  hiopPDPerturbationPrimalFirstScalar() : hiopPDPerturbation() {}
+  virtual ~hiopPDPerturbationPrimalFirstScalar() {}
 
   /** Called when a new linear system is attempted to be factorized 
    */
@@ -284,10 +288,15 @@ protected: // methods
 
 };
 
-class hiopPDPerturbationPrimalFirstRand : public hiopPDPerturbationPrimalFirstScala
+/**
+ * @brief When inertia correction is required, update primal regularization before dual regularzation.
+ *        Both regularizations are computed as a random vector.
+ *        v0.7: uniform distribution has been implemented
+ */
+class hiopPDPerturbationPrimalFirstRand : public hiopPDPerturbationPrimalFirstScalar
 {
 public:
-  hiopPDPerturbationPrimalFirstRand() : hiopPDPerturbationPrimalFirstScala() {}
+  hiopPDPerturbationPrimalFirstRand() : hiopPDPerturbationPrimalFirstScalar() {}
 
   virtual ~hiopPDPerturbationPrimalFirstRand() {}
 
@@ -296,13 +305,16 @@ protected: // methods
   virtual void set_delta_last_vec(DeltasUpdateType taskid);  
 };
 
-
-class hiopPDPerturbationDualFirstScala : public hiopPDPerturbation
+/**
+ * @brief When inertia correction is required, update dual regularization before primal regularzation.
+ *        Both regularizations are computed as \delta*I, i.e., a scalar times an identity matrix
+ */
+class hiopPDPerturbationDualFirstScalar : public hiopPDPerturbation
 {
 public:
-  hiopPDPerturbationDualFirstScala();
+  hiopPDPerturbationDualFirstScalar();
 
-  virtual ~hiopPDPerturbationDualFirstScala();
+  virtual ~hiopPDPerturbationDualFirstScalar();
 
   /** Called when a new linear system is attempted to be factorized 
    */
@@ -338,24 +350,17 @@ protected: // methods
 
 };
 
-class hiopPDPerturbationDualFirstRand : public hiopPDPerturbationDualFirstScala
+/**
+ * @brief When inertia correction is required, update dual regularization before primal regularzation.
+ *        Both regularizations are computed as a random vector.
+ *        v0.7: uniform distribution has been implemented
+ */
+class hiopPDPerturbationDualFirstRand : public hiopPDPerturbationDualFirstScalar
 {
 public:
-  hiopPDPerturbationDualFirstRand() : hiopPDPerturbationDualFirstScala() {}
+  hiopPDPerturbationDualFirstRand() : hiopPDPerturbationDualFirstScalar() {}
 
   virtual ~hiopPDPerturbationDualFirstRand() {}
-
-protected: // methods
-  virtual void set_delta_curr_vec(DeltasUpdateType taskid); 
-  virtual void set_delta_last_vec(DeltasUpdateType taskid);  
-};
-
-class hiopPDPerturbationDualFirstDynamic : public hiopPDPerturbationDualFirstScala
-{
-public:
-  hiopPDPerturbationDualFirstDynamic() : hiopPDPerturbationDualFirstScala() {}
-
-  virtual ~hiopPDPerturbationDualFirstDynamic() {}
 
 protected: // methods
   virtual void set_delta_curr_vec(DeltasUpdateType taskid); 

--- a/src/Optimization/hiopPDPerturbation.hpp
+++ b/src/Optimization/hiopPDPerturbation.hpp
@@ -7,6 +7,15 @@
 namespace hiop
 {
 
+enum DeltasUpdateType
+{
+  None  = -1,
+  Initialized  = -1,
+  DualUpdate   =  0,
+  PrimalUpdate =  1,
+  PDUpdate     =  2
+};
+
 class hiopPDPerturbation
 {
 public:
@@ -186,15 +195,9 @@ protected:
     dttDeltacposDeltawpos
   };
 
-  enum DeltasUpdateType
-  {
-    DualUpdate = -1,
-    PrimalUpdate = 0,
-    PDUpdate
-  };
-
   /** Current status */
   DeltasTestType deltas_test_type_;
+  DeltasUpdateType deltas_curr_update_;
   
   /** Log barrier mu in the outer loop. */
   double mu_;

--- a/src/Utils/hiopOptions.cpp
+++ b/src/Utils/hiopOptions.cpp
@@ -1056,11 +1056,14 @@ void hiopOptionsNLP::register_options()
                         "try to update primal regularizations, while the default option `dual_first` always tries to "
                         "update dual regularization first.");
 
-    range[0]="standard"; range[1]="randomized";
+    range = {"scala", "randomized", "dynamic"};
     register_str_option("regularization_method",
-                        "standard",
+                        "scala",
                         range,
-                        "The method used to compute regularizations. (TODO)");
+                        "The method used to compute regularizations. By default, `scala` sets all the primal "
+                        "regularzations to a constant computed by HiOp. `randomized` approach sets regularization "
+                        "to a randomized vector around a constant. `dynamic` exploits the KKT numerical values and "
+                        "sets the regularization dynamically.");
     
   }
   // performance profiling

--- a/src/Utils/hiopOptions.cpp
+++ b/src/Utils/hiopOptions.cpp
@@ -1056,14 +1056,13 @@ void hiopOptionsNLP::register_options()
                         "try to update primal regularizations, while the default option `dual_first` always tries to "
                         "update dual regularization first.");
 
-    range = {"scala", "randomized", "dynamic"};
+    range = {"scalar", "randomized"};
     register_str_option("regularization_method",
-                        "scala",
+                        "scalar",
                         range,
-                        "The method used to compute regularizations. By default, `scala` sets all the primal "
-                        "regularzations to a constant computed by HiOp. `randomized` approach sets regularization "
-                        "to a randomized vector around a constant. `dynamic` exploits the KKT numerical values and "
-                        "sets the regularization dynamically.");
+                        "The method used to compute regularizations. By default, `scalar` sets all the primal "
+                        "regularizations to a constant computed by HiOp. `randomized` approach sets regularization "
+                        "to a randomized vector around a constant.");
     
   }
   // performance profiling


### PR DESCRIPTION
1. Re-engineer the code to use object `hiopPDPerturbation` in `build_kkt_matrix`, to have a better OO design.
2. Remove unnecessary copies of `delta(s)`
3. if normal equation is used and primal regularization is unchanged within a step, skip building the expensive condensed matrix `J^T(H+Diag)^{-1}J` for the reason of efficiency.
