### PR TITLE
Update comments for HiOp interface

### DIFF
--- a/src/Drivers/MDS/NlpMdsEx1.hpp
+++ b/src/Drivers/MDS/NlpMdsEx1.hpp
@@ -450,8 +450,12 @@ public:
                           bool& duals_avail,
                           double* z_bndL0,
                           double* z_bndU0,
-                          double* lambda0)
+                          double* lambda0,
+                          bool& slacks_avail,
+                          double* ineq_slack)
   {
+    slacks_avail = false;
+
     if(sol_x_ && sol_zl_ && sol_zu_ && sol_lambda_) {
 
       duals_avail = true;

--- a/src/Drivers/MDS/NlpMdsRajaEx1.cpp
+++ b/src/Drivers/MDS/NlpMdsRajaEx1.cpp
@@ -707,7 +707,7 @@ bool MdsEx1::get_starting_point(const size_type& n,
                                 double* z_bndU0,
                                 double* lambda0,
                                 bool& slacks_avail,
-                                double* )
+                                double* ineq_slack)
 {
   slacks_avail = false;
   

--- a/src/Drivers/MDS/NlpMdsRajaEx1.hpp
+++ b/src/Drivers/MDS/NlpMdsRajaEx1.hpp
@@ -350,15 +350,15 @@ public:
                           bool& slacks_avail,
                           double* ineq_slack);
 
-  bool get_starting_point(const size_type& n,
-                          const size_type& m,
-                          double* x0,
-                          double* z_bndL0, 
-                          double* z_bndU0,
-                          double* lambda0,
-                          double* ineq_slack,
-                          double* vl0,
-                          double* vu0)
+  bool get_warmstart_point(const size_type& n,
+                           const size_type& m,
+                           double* x0,
+                           double* z_bndL0, 
+                           double* z_bndU0,
+                           double* lambda0,
+                           double* ineq_slack,
+                           double* vl0,
+                           double* vu0)
   {
     return false;
   }

--- a/src/Drivers/PriDec/NlpPriDecEx1.cpp
+++ b/src/Drivers/PriDec/NlpPriDecEx1.cpp
@@ -149,9 +149,12 @@ bool PriDecEx1::get_starting_point(const size_type& n,
                                    bool& duals_avail,
                                    double* z_bndL0, 
                                    double* z_bndU0,
-                                   double* lambda0)
+                                   double* lambda0,
+                                   bool& slacks_avail,
+                                   double* ineq_slack)
 {
   duals_avail = false;
+  slacks_avail = false;
   return false;
 };
 

--- a/src/Drivers/PriDec/NlpPriDecEx1.hpp
+++ b/src/Drivers/PriDec/NlpPriDecEx1.hpp
@@ -77,11 +77,15 @@ public:
   // Implementation of the primal starting point specification //
   virtual bool get_starting_point(const size_type& global_n, double* x0_);
   
-  virtual bool get_starting_point(const size_type& n, const size_type& m,
+  virtual bool get_starting_point(const size_type& n,
+                                  const size_type& m,
                                   double* x0_,
                                   bool& duals_avail,
-                                  double* z_bndL0, double* z_bndU0,
-                                  double* lambda0);
+                                  double* z_bndL0, 
+                                  double* z_bndU0,
+                                  double* lambda0,
+                                  bool& slacks_avail,
+                                  double* ineq_slack);
   
   // pass the COMM_SELF communicator since this example is only intended to run inside 1 MPI process //
   virtual bool get_MPI_comm(MPI_Comm& comm_out);

--- a/src/Drivers/PriDec/NlpPriDecEx2UserRecourseMds.hpp
+++ b/src/Drivers/PriDec/NlpPriDecEx2UserRecourseMds.hpp
@@ -420,9 +420,13 @@ public:
                           bool& duals_avail,
                           double* z_bndL0, 
                           double* z_bndU0,
-                          double* lambda0)
+                          double* lambda0,
+                          bool& slacks_avail,
+                          double* ineq_slack)
   {
     //assert(false && "not implemented");
+    duals_avail = false;
+    slacks_avail = false;
     return false;
   }
 

--- a/src/Drivers/PriDec/NlpPriDecEx2UserRecourseSparse.hpp
+++ b/src/Drivers/PriDec/NlpPriDecEx2UserRecourseSparse.hpp
@@ -353,7 +353,9 @@ public:
                           bool& duals_avail,
                           double* z_bndL0, 
                           double* z_bndU0,
-                          double* lambda0)
+                          double* lambda0,
+                          bool& slacks_avail,
+                          double* ineq_slack)
   {
     return false;
   }

--- a/src/Drivers/PriDec/NlpPriDecEx2UserRecourseSparseRaja.hpp
+++ b/src/Drivers/PriDec/NlpPriDecEx2UserRecourseSparseRaja.hpp
@@ -513,29 +513,29 @@ public:
     return true;
   }
   bool get_starting_point(const size_type& n,
-                                  const size_type& m,
-                                  double* x0,
-                                  bool& duals_avail,
-                                  double* z_bndL0, 
-                                  double* z_bndU0,
-                                  double* lambda0,
-                                  bool& slacks_avail,
-                                  double* ineq_slack)
+                          const size_type& m,
+                          double* x0,
+                          bool& duals_avail,
+                          double* z_bndL0, 
+                          double* z_bndU0,
+                          double* lambda0,
+                          bool& slacks_avail,
+                          double* ineq_slack)
   {
     duals_avail = false;
     slacks_avail = false;
     return false;
   }
 
-  bool get_starting_point(const size_type& n,
-                          const size_type& m,
-                          double* x0,
-                          double* z_bndL0, 
-                          double* z_bndU0,
-                          double* lambda0,
-                          double* ineq_slack,
-                          double* vl0,
-                          double* vu0)
+  bool get_warmstart_point(const size_type& n,
+                           const size_type& m,
+                           double* x0,
+                           double* z_bndL0, 
+                           double* z_bndU0,
+                           double* lambda0,
+                           double* ineq_slack,
+                           double* vl0,
+                           double* vu0)
   {
     return false;
   }

--- a/src/Drivers/Sparse/NlpSparseEx1.hpp
+++ b/src/Drivers/Sparse/NlpSparseEx1.hpp
@@ -95,15 +95,15 @@ public:
                                   double*)
   { return false; }
 
-  virtual bool get_starting_point(const size_type&,
-                                  const size_type&,
-                                  double*,
-                                  double*, 
-                                  double*,
-                                  double*,
-                                  double*,
-                                  double*,
-                                  double*)
+  virtual bool get_warmstart_point(const size_type&,
+                                   const size_type&,
+                                   double*,
+                                   double*, 
+                                   double*,
+                                   double*,
+                                   double*,
+                                   double*,
+                                   double*)
   { return false; }
 
 private:

--- a/src/Interface/hiopInterface.hpp
+++ b/src/Interface/hiopInterface.hpp
@@ -118,7 +118,7 @@ enum hiopSolveStatus {
  *
  * @note Please take notice of the following notes regarding the implementation of 
  * hiop::hiopInterfaceMDS on the device. All pointers marked as "managed by Umpire" 
- * are allocated by HiOp using the Umpire's API. They all are addresses in the 
+ * are allocated by HiOp using the Umpire's API. They all are addressed in the 
  * same memory space; however, the memory space can be host (typically CPU), 
  * device (typically GPU), or unified memory (um) spaces as per Umpire 
  * specification. The selection of the memory space is done via the option 
@@ -211,13 +211,13 @@ public:
    *  iteration separately for the equality constraints subset and for the inequality constraints subset.
    *  This is done for performance considerations, to avoid auxiliary/temporary storage and copying.
    *
-   *   @param[in] n the global number of variables
-   *   @param[in] m the number of constraints
-   *   @param[in] num_cons the number constraints/size of subset to be evaluated
-   *   @param[in] idx_cons: indexes in {1,2,...,m} of the constraints to be evaluated  (managed by Umpire)
-   *   @param[in] x the point where the constraints need to be evaluated  (managed by Umpire)
-   *   @param[in] new_x whether x has been changed from the previous call to f, grad_f, or Jac
-   *   @param[out] cons array of size num_cons containing the value of the  constraints indicated by 
+   * @param[in] n the global number of variables
+   * @param[in] m the number of constraints
+   * @param[in] num_cons the number constraints/size of subset to be evaluated
+   * @param[in] idx_cons: indexes in {1,2,...,m} of the constraints to be evaluated  (managed by Umpire)
+   * @param[in] x the point where the constraints need to be evaluated  (managed by Umpire)
+   * @param[in] new_x whether x has been changed from the previous call to f, grad_f, or Jac
+   * @param[out] cons array of size num_cons containing the value of the  constraints indicated by 
    *                    @p idx_cons  (managed by Umpire)
    *  
    *  @note When MPI is enabled, every rank populates @p cons since the constraints are not distributed.
@@ -232,11 +232,11 @@ public:
   
   /** Evaluates the constraints body @p cons(@p x), both equalities and inequalities, in one call. 
    *
-   *   @param[in] n the global number of variables
-   *   @param[in] m the number of constraints
-   *   @param[in] x the point where the constraints need to be evaluated  (managed by Umpire)
-   *   @param[in] new_x whether x has been changed from the previous call to f, grad_f, or Jac
-   *   @param[out] cons array of size num_cons containing the value of the  constraints indicated by 
+   * @param[in] n the global number of variables
+   * @param[in] m the number of constraints
+   * @param[in] x the point where the constraints need to be evaluated  (managed by Umpire)
+   * @param[in] new_x whether x has been changed from the previous call to f, grad_f, or Jac
+   * @param[out] cons array of size num_cons containing the value of the  constraints indicated by 
    *                     @p idx_cons  (managed by Umpire)
    *
    * HiOp will first call the other hiopInterfaceBase::eval_cons() twice. If the implementer/user wants the 
@@ -282,9 +282,12 @@ public:
    * internally set @p x0 to all zero (still subject to internal adjustements).
    *
    * By default, HiOp first calls the overloaded primal-dual starting point specification
-   * (overloaded) method get_starting_point(). If the above returns false, HiOp will then call 
+   * (overloaded) method get_starting_point() (see below). If the above returns false, HiOp will then call 
    * this method.
    *
+   * @param[in] n the global number of variables
+   * @param[out] x0 the user-defined initial values for the primal variablers (managed by Umpire)
+   * 
    */
   virtual bool get_starting_point(const size_type&n, double* x0)
   {
@@ -310,9 +313,21 @@ public:
    * return false (see note below).
    *
    * @note When this method returns false, HiOp will call the overload 
-   * get_starting_point(). This behaviour is for backward compatibility and 
+   * get_starting_point() for only primal variables (see the above function). This behaviour is for backward compatibility and 
    * will be removed in a future release.
-   * 
+   *
+   * @param[in] n the global number of variables
+   * @param[in] m the number of constraints
+   * @param[out] x0 the user-defined initial values for the primal variablers (managed by Umpire)
+   * @param[out] duals_avail a boolean argument which indicates whether the initial values of duals are given by the user
+   * @param[out] z_bndL0 the user-defined initial values for the duals of the variable lower bounds (managed by Umpire)
+   * @param[out] z_bndU0 the user-defined initial values for the duals of the variable upper bounds (managed by Umpire)
+   * @param[out] lambda0 the user-defined initial values for the duals of the constraints (managed by Umpire)
+   * @param[out] slacks_avail a boolean argument which indicates whether the initial values for the inequality slacks 
+   *                            (added by HiOp internally) are given by the user
+   * @param[out] ineq_slack the user-defined initial values for the slacks added to transfer inequalities to equalities 
+   *                          (managed by Umpire)
+   *  
    */
   virtual bool get_starting_point(const size_type& n,
                                   const size_type& m,
@@ -334,17 +349,29 @@ public:
    * to internal adjustments in HiOp.
    *
    * User provides starting point for all the iterate variable used in HiOp.
-   * 
+   * This method is for advanced users, as it will skip all the other safeguard in HiOp, e.g., project x into bounds.
+   *
+   * @param[in] n the global number of variables
+   * @param[in] m the number of constraints
+   * @param[out] x0 the user-defined initial values for the primal variablers (managed by Umpire)
+   * @param[out] z_bndL0 the user-defined initial values for the duals of the variable lower bounds (managed by Umpire)
+   * @param[out] z_bndU0 the user-defined initial values for the duals of the variable upper bounds (managed by Umpire)
+   * @param[out] lambda0 the user-defined initial values for the duals of the constraints (managed by Umpire)
+   * @param[out] ineq_slack the user-defined initial values for the slacks added to transfer inequalities to equalities 
+   *                          (managed by Umpire)
+   * @param[out] vl0 the user-defined initial values for the duals of the constraint lower bounds (managed by Umpire)
+   * @param[out] vu0 the user-defined initial values for the duals of the constraint upper bounds (managed by Umpire)
+   *
    */
-  virtual bool get_starting_point(const size_type& n,
-                                  const size_type& m,
-                                  double* x0,
-                                  double* z_bndL0, 
-                                  double* z_bndU0,
-                                  double* lambda0,
-                                  double* ineq_slack,
-                                  double* vl0,
-                                  double* vu0)
+  virtual bool get_warmstart_point(const size_type& n,
+                                   const size_type& m,
+                                   double* x0,
+                                   double* z_bndL0, 
+                                   double* z_bndU0,
+                                   double* lambda0,
+                                   double* ineq_slack,
+                                   double* vl0,
+                                   double* vu0)
   {
     return false;
   }
@@ -353,15 +380,20 @@ public:
    * Callback method called by HiOp when the optimal solution is reached. User should use it
    * to retrieve primal-dual optimal solution. 
    *
-   * @param status status of the solution process
-   * @param n global number of variables
-   * @param x array of (local) entries of the primal variable
-   * @param z_L array of (local) entries of the dual variables for lower bounds
-   * @param z_U array of (local) entries of the dual variables for upper bounds
-   * @param g array of the values of the constraints body
-   * @param lambda array of (local) entries of the dual variables for constraints
-   * @param obj_value objective value
+   * @param[in] status status of the solution process
+   * @param[in] n global number of variables
+   * @param[in] x array of (local) entries of the primal variables at solution (managed by Umpire)
+   * @param[in] z_L array of (local) entries of the dual variables for lower bounds at solution (managed by Umpire)
+   * @param[in] z_U array of (local) entries of the dual variables for upper bounds at solution (managed by Umpire)
+   * @param[in] g array of the values of the constraints body at solution (managed by Umpire)
+   * @param[in] lambda array of (local) entries of the dual variables for constraints at solution (managed by Umpire)
+   * @param[in] obj_value objective value at solution 
    *
+   * @note this callback function passed the Umpire-managed arrays to users. By default, if data is on device/host,
+   * this function will pass the Umpire-managed arrays on devic/host to users, respectively. If data is on deivice 
+   * and HiOp option `callback_mem_space` is set to `host`, HiOp transfers the data from device to host first, and then 
+   * passes the Umpire-managed arrays on host to user.
+   * 
    */
   virtual void solution_callback(hiopSolveStatus status,
                                  size_type n,
@@ -381,6 +413,32 @@ public:
    *
    * @note If the user (implementer) of this methods returns false, HiOp will stop the 
    * the optimization with hiop::hiopSolveStatus ::User_Stopped return code.
+   * 
+   * @param[in] int the current iteration number
+   * @param[in] obj_value objective value
+   * @param[in] logbar_obj_value log barrier objective value
+   * @param[in] n global number of variables
+   * @param[in] x array of (local) entries of the primal variables (managed by Umpire)
+   * @param[in] z_L array of (local) entries of the dual variables for lower bounds (managed by Umpire)
+   * @param[in] z_U array of (local) entries of the dual variables for upper bounds (managed by Umpire)
+   * @param[in] m_ineq the number of inequality constraints
+   * @param[in] s array of the slacks added to transfer inequalities to equalities (managed by Umpire)
+   * @param[in] m the number of constraints
+   * @param[in] g array of the values of the constraints body (managed by Umpire)
+   * @param[in] lambda array of (local) entries of the dual variables for constraints (managed by Umpire)
+   * @param[in] inf_pr inf norm of the primal infeasibilities
+   * @param[in] inf_du inf norm of the dual infeasibilities
+   * @param[in] onenorm_pr_ one norm of the primal infeasibilities
+   * @param[in] mu the log barrier parameter
+   * @param[in] alpha_du dual step size
+   * @param[in] alpha_pr primal step size
+   * @param[in] ls_trials the number of line search iterations
+   * 
+   * @note this callback function passed the Umpire-managed arrays to users. By default, if data is on device/host,
+   * this function will pass the Umpire-managed arrays on devic/host to users, respectively. If data is on deivice 
+   * and HiOp option `callback_mem_space` is set to `host`, HiOp transfers the data from device to host first, and then 
+   * passes the Umpire-managed arrays on host to user.
+   * 
    */
   virtual bool iterate_callback(int iter,
                                 double obj_value,

--- a/src/Optimization/hiopAlgFilterIPM.cpp
+++ b/src/Optimization/hiopAlgFilterIPM.cpp
@@ -281,17 +281,22 @@ int hiopAlgFilterIPMBase::startingProcedure(hiopIterate& it_ini,
   bool ret_bool = false;
   
   if(nlp->options->GetString("warm_start")=="yes") {
-    ret_bool = nlp->get_starting_point(*it_ini.get_x(),
-                                       *it_ini.get_zl(), *it_ini.get_zu(),
-                                       *it_ini.get_yc(), *it_ini.get_yd(),
-                                       *it_ini.get_d(),
-                                       *it_ini.get_vl(), *it_ini.get_vu());
+    ret_bool = nlp->get_warmstart_point(*it_ini.get_x(),
+                                        *it_ini.get_zl(),
+                                        *it_ini.get_zu(),
+                                        *it_ini.get_yc(),
+                                        *it_ini.get_yd(),
+                                        *it_ini.get_d(),
+                                        *it_ini.get_vl(),
+                                        *it_ini.get_vu());
     warmstart_avail = duals_avail = slacks_avail = true;
   } else {
     ret_bool = nlp->get_starting_point(*it_ini.get_x(),
                                        duals_avail,
-                                       *it_ini.get_zl(), *it_ini.get_zu(),
-                                       *it_ini.get_yc(), *it_ini.get_yd(),
+                                       *it_ini.get_zl(),
+                                       *it_ini.get_zu(),
+                                       *it_ini.get_yc(), 
+                                       *it_ini.get_yd(),
                                        slacks_avail,
                                        *it_ini.get_d());
     

--- a/src/Optimization/hiopFRProb.cpp
+++ b/src/Optimization/hiopFRProb.cpp
@@ -416,15 +416,15 @@ bool hiopFRProbSparse::eval_Hess_Lagr(const size_type& n,
   return true;
 }
 
-bool hiopFRProbSparse::get_starting_point(const size_type& n,
-                                          const size_type& m,
-                                          double* x0,
-                                          double* z_bndL0, 
-                                          double* z_bndU0,
-                                          double* lambda0,
-                                          double* ineq_slack,
-                                          double* vl0,
-                                          double* vu0 )
+bool hiopFRProbSparse::get_warmstart_point(const size_type& n,
+                                           const size_type& m,
+                                           double* x0,
+                                           double* z_bndL0, 
+                                           double* z_bndU0,
+                                           double* lambda0,
+                                           double* ineq_slack,
+                                           double* vl0,
+                                           double* vu0 )
 {
   assert( n == n_);
   assert( m == m_);
@@ -1042,15 +1042,15 @@ bool hiopFRProbMDS::eval_Jac_cons(const size_type& n,
   return true;
 }
 
-bool hiopFRProbMDS::get_starting_point(const size_type& n,
-                                       const size_type& m,
-                                       double* x0,
-                                       double* z_bndL0, 
-                                       double* z_bndU0,
-                                       double* lambda0,
-                                       double* ineq_slack,
-                                       double* vl0,
-                                       double* vu0 )
+bool hiopFRProbMDS::get_warmstart_point(const size_type& n,
+                                        const size_type& m,
+                                        double* x0,
+                                        double* z_bndL0, 
+                                        double* z_bndU0,
+                                        double* lambda0,
+                                        double* ineq_slack,
+                                        double* vl0,
+                                        double* vu0 )
 {
   assert( n == n_);
   assert( m == m_);

--- a/src/Optimization/hiopFRProb.hpp
+++ b/src/Optimization/hiopFRProb.hpp
@@ -125,15 +125,15 @@ public:
                              int* jJacS,
                              double* MJacS);
 
-  virtual bool get_starting_point(const size_type& n,
-                                  const size_type& m,
-                                  double* x0,
-                                  double* z_bndL0, 
-                                  double* z_bndU0,
-                                  double* lambda0,
-                                  double* ineq_slack,
-                                  double* vl0,
-                                  double* vu0);
+  virtual bool get_warmstart_point(const size_type& n,
+                                   const size_type& m,
+                                   double* x0,
+                                   double* z_bndL0, 
+                                   double* z_bndU0,
+                                   double* lambda0,
+                                   double* ineq_slack,
+                                   double* vl0,
+                                   double* vu0);
 
   virtual bool eval_Hess_Lagr(const size_type& n,
                               const size_type& m,
@@ -307,15 +307,15 @@ public:
                          double* cons);
   virtual bool eval_grad_f(const size_type& n, const double* x, bool new_x, double* gradf);
 
-  virtual bool get_starting_point(const size_type& n,
-                                  const size_type& m,
-                                  double* x0,
-                                  double* z_bndL0, 
-                                  double* z_bndU0,
-                                  double* lambda0,
-                                  double* ineq_slack,
-                                  double* vl0,
-                                  double* vu0);
+  virtual bool get_warmstart_point(const size_type& n,
+                                   const size_type& m,
+                                   double* x0,
+                                   double* z_bndL0, 
+                                   double* z_bndU0,
+                                   double* lambda0,
+                                   double* ineq_slack,
+                                   double* vl0,
+                                   double* vu0);
 
   virtual bool iterate_callback(int iter,
                                 double obj_value,

--- a/src/Optimization/hiopNlpFormulation.cpp
+++ b/src/Optimization/hiopNlpFormulation.cpp
@@ -782,14 +782,14 @@ bool hiopNlpFormulation::get_starting_point(hiopVector& x0_for_hiop,
   return bret;
 }
 
-bool hiopNlpFormulation::get_starting_point(hiopVector& x0_for_hiop,
-                                            hiopVector& zL0_for_hiop,
-                                            hiopVector& zU0_for_hiop,
-                                            hiopVector& yc0_for_hiop,
-                                            hiopVector& yd0_for_hiop,
-                                            hiopVector& d0,
-                                            hiopVector& vl0,
-                                            hiopVector& vu0)
+bool hiopNlpFormulation::get_warmstart_point(hiopVector& x0_for_hiop,
+                                             hiopVector& zL0_for_hiop,
+                                             hiopVector& zU0_for_hiop,
+                                             hiopVector& yc0_for_hiop,
+                                             hiopVector& yd0_for_hiop,
+                                             hiopVector& d0,
+                                             hiopVector& vl0,
+                                             hiopVector& vu0)
 {
   bool bret; 
 
@@ -804,15 +804,15 @@ bool hiopNlpFormulation::get_starting_point(hiopVector& x0_for_hiop,
   double* vl_for_user = vl0.local_data();
   double* vu_for_user = vu0.local_data();
   
-  bret = interface_base.get_starting_point(nlp_transformations_.n_pre(),
-                                           n_cons_,
-                                           x0_for_user->local_data(),
-                                           zL0_for_user,
-                                           zU0_for_user,
-                                           lambda_for_user,
-                                           d_for_user,
-                                           vl_for_user,
-                                           vu_for_user);
+  bret = interface_base.get_warmstart_point(nlp_transformations_.n_pre(),
+                                            n_cons_,
+                                            x0_for_user->local_data(),
+                                            zL0_for_user,
+                                            zU0_for_user,
+                                            lambda_for_user,
+                                            d_for_user,
+                                            vl_for_user,
+                                            vu_for_user);
   {
     double* yc0d = yc0_for_hiop.local_data();
     double* yd0d = yd0_for_hiop.local_data();

--- a/src/Optimization/hiopNlpFormulation.hpp
+++ b/src/Optimization/hiopNlpFormulation.hpp
@@ -138,14 +138,14 @@ public:
                                   bool& slacks_avail,
                                   hiopVector& d0);
 
-  virtual bool get_starting_point(hiopVector& x0,
-                                  hiopVector& zL0,
-                                  hiopVector& zU0,
-                                  hiopVector& yc0,
-                                  hiopVector& yd0,
-                                  hiopVector& d0,
-                                  hiopVector& vl0,
-                                  hiopVector& vu0);
+  virtual bool get_warmstart_point(hiopVector& x0,
+                                   hiopVector& zL0,
+                                   hiopVector& zU0,
+                                   hiopVector& yc0,
+                                   hiopVector& yd0,
+                                   hiopVector& d0,
+                                   hiopVector& vl0,
+                                   hiopVector& vu0);
 
   /* Allocates the LSQ duals update class. */
   virtual hiopDualsLsqUpdate* alloc_duals_lsq_updater() = 0;

--- a/src/Utils/hiopOptions.cpp
+++ b/src/Utils/hiopOptions.cpp
@@ -1143,11 +1143,14 @@ void hiopOptionsNLP::register_options()
     register_str_option("mem_space",
                         range[0],
                         range,
-                        "Determines the memory space in which future internal linear algebra objects will be created");
+                        "Determines the memory space in which future internal linear algebra objects will be created. "
+                        "When HiOp is built with RAJA/Umpire, user can set this option to either `default`, `host`, "
+                        "`device` or `um`, and internally the data of HiOp vectors/matrices will be managed by Umpire. "
+                        "If HiOp was built without RAJA/Umpire support, only `default` is available for this option.");
     register_str_option("callback_mem_space",
                         range[0],
                         range,
-                        "Determines the memory space to which HiOp will return the solutions.");
+                        "Determines the memory space to which HiOp will return the solutions. By default,");
   }
 }
 
@@ -1310,6 +1313,9 @@ void hiopOptionsNLP::ensure_consistence()
                 "value '%s' is not supported by HiOp with the provided values of 'mem_space'.\n",
                 GetString("mem_space").c_str(),
                 GetString("callback_mem_space").c_str());
+      set_val("callback_mem_space", GetString("mem_space").c_str());
+    } else if(GetString("callback_mem_space") == "default") {
+      // user didn't specify this option, set it to the value of `mem_space`
       set_val("callback_mem_space", GetString("mem_space").c_str());
     }
   }


### PR DESCRIPTION
Address issue #533 
Change one function name to distinguish the `warm start` process from other users' initial point.

Note that the base of this PR is #536 