### PR TITLE
Fix the bug that magma returns wrong inertia

### DIFF
--- a/src/LinAlg/hiopLinSolverSymDenseMagma.cpp
+++ b/src/LinAlg/hiopLinSolverSymDenseMagma.cpp
@@ -144,7 +144,9 @@ namespace hiop
     int info;
     int retcode;
     magma_uplo_t uplo=MagmaLower; // M is upper in C++ so it's lower in fortran
-
+#ifdef HIOP_USE_HIP
+    uplo = MagmaUpper; // M is upper in C++ so it's lower in fortran
+#endif
     nlp_->runStats.linsolv.tmInertiaComp.start();
 
     info = magmablas_dsiinertia(uplo, N, device_M_, ldda_, ipiv, dinert_, magma_device_queue_);
@@ -197,7 +199,7 @@ namespace hiop
     nlp_->runStats.linsolv.tmTriuSolves.start();
     
     magma_uplo_t uplo=MagmaLower; // M is upper in C++ so it's lower in fortran
- #ifdef HIOP_USE_HIP
+#ifdef HIOP_USE_HIP
     uplo = MagmaUpper; // M is upper in C++ so it's lower in fortran
 #endif
     int info;

--- a/src/Optimization/hiopKKTLinSys.cpp
+++ b/src/Optimization/hiopKKTLinSys.cpp
@@ -996,6 +996,8 @@ bool hiopKKTLinSys::compute_directions_w_IR(const hiopResidual* resid, hiopItera
 
     // accept the stpe since this is IR
     bret = true;
+  } else {
+    nlp_->log->printf(hovScalars, "%s", bicgIR_->get_convergence_info().c_str());
   }
 
   nlp_->runStats.tmSolverInternal.stop();


### PR DESCRIPTION
We also need to use `MagmaUpper` before calling `magmablas_dsiinertia`, to return the correct inertia on hipblas.
See PR #444 for more detail about this change.