### PR TITLE
Fix segfault, remove nonsymmetric ginkgo solver

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: tests
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   test:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -156,8 +156,7 @@ build_on_marianas:
     MY_CLUSTER: "marianas"
     TIMELIMIT: '1:30:00'
     SLURM_ARGS: --gres=gpu:1 --exclusive
-  # Through the steps, the argument to -E is automatically surrounded by quotes
-    CTEST_CMD: 'ctest -VV -E NlpSparse1_6|NlpSparse2_5'
+    CTEST_CMD: 'ctest -VV'
   <<: *pnnl_tags_definition
   <<: *pnnl_script_definition
   rules:

--- a/scripts/gcc-cuda.cmake
+++ b/scripts/gcc-cuda.cmake
@@ -25,7 +25,7 @@ set(HIOP_SPARSE ON CACHE BOOL "")
 message(STATUS "Enabling HiOp's deepchecking")
 set(HIOP_DEEPCHECKS ON CACHE BOOL "")
 
-message(STATUS "Setting default cuda architecture to 60")
-set(CMAKE_CUDA_ARCHITECTURES 60 CACHE STRING "")
+set(CMAKE_CUDA_ARCHITECTURES 60 70 75 80 CACHE STRING "")
+message(STATUS "Setting default cuda architecture to ${CMAKE_CUDA_ARCHITECTURES}")
 
 message(STATUS "Done preloading CMake cache with values for continuous integration")

--- a/scripts/marianasVariables.sh
+++ b/scripts/marianasVariables.sh
@@ -91,5 +91,4 @@ EOD
 export NVBLAS_CONFIG_FILE=$PWD/nvblas.conf
 echo "Generated $PWD/nvblas.conf"
 
-export EXTRA_CMAKE_ARGS="$EXTRA_CMAKE_ARGS -DCMAKE_CUDA_ARCHITECTURES=60,70,75,80"
 export CMAKE_CACHE_SCRIPT=gcc-cuda.cmake

--- a/scripts/marianasVariables.sh
+++ b/scripts/marianasVariables.sh
@@ -1,68 +1,80 @@
 #  NOTE: The following is required when running from Gitlab CI via slurm job
 source /etc/profile.d/modules.sh
-module use -a /qfs/projects/exasgd/src/cameron/spack/share/spack/modules/linux-centos7-zen2
+module use -a /qfs/projects/exasgd/src/ci-deception/ci-modules/linux-centos7-zen2
 
 # Load spack-built modules
-# autoconf@2.69%gcc@10.2.0 patches=35c4492,7793209,a49dd5b arch=linux-centos7-zen2
-module load autoconf-2.69-gcc-10.2.0-r677m42
-# autoconf-archive@2022.02.11%gcc@10.2.0 patches=130cd48 arch=linux-centos7-zen2
-module load autoconf-archive-2022.02.11-gcc-10.2.0-pbrbzut
-# automake@1.16.5%gcc@10.2.0 arch=linux-centos7-zen2
-module load automake-1.16.5-gcc-10.2.0-j4bwm4o
-# blt@0.4.1%gcc@10.2.0 arch=linux-centos7-zen2
-module load blt-0.4.1-gcc-10.2.0-tanugdw
-# ca-certificates-mozilla@2022-07-19%gcc@10.2.0 arch=linux-centos7-zen2
-module load ca-certificates-mozilla-2022-07-19-gcc-10.2.0-h2opehw
-# camp@0.2.3%gcc@10.2.0+cuda~ipo~rocm~tests build_type=RelWithDebInfo cuda_arch=60 arch=linux-centos7-zen2
-module load camp-0.2.3-gcc-10.2.0-vpkkybx
-# cmake@3.23.2%gcc@10.2.0~doc+ncurses+ownlibs~qt build_type=Release arch=linux-centos7-zen2
-module load cmake-3.23.2-gcc-10.2.0-i24avzq
-# coinhsl@2019.05.21%gcc@10.2.0+blas arch=linux-centos7-zen2
-module load coinhsl-2019.05.21-gcc-10.2.0-j7hsujd
-# cub@1.16.0%gcc@10.2.0 arch=linux-centos7-zen2
-module load cub-1.16.0-gcc-10.2.0-ovgrtom
-# diffutils@3.8%gcc@10.2.0 arch=linux-centos7-zen2
-module load diffutils-3.8-gcc-10.2.0-mjfwces
-# ginkgo@glu_experimental%gcc@10.2.0+cuda~develtools~full_optimizations~hwloc~ipo~oneapi+openmp~rocm+shared build_type=Release cuda_arch=60 arch=linux-centos7-zen2
-module load ginkgo-glu_experimental-gcc-10.2.0-dbmokiq
-# gmp@6.2.1%gcc@10.2.0 libs=shared,static arch=linux-centos7-zen2
-module load gmp-6.2.1-gcc-10.2.0-ac4z3oa
-# libiconv@1.16%gcc@10.2.0 libs=shared,static arch=linux-centos7-zen2
-module load libiconv-1.16-gcc-10.2.0-gbg7l5p
-# libsigsegv@2.13%gcc@10.2.0 arch=linux-centos7-zen2
-module load libsigsegv-2.13-gcc-10.2.0-aj5goyi
-# libtool@2.4.7%gcc@10.2.0 arch=linux-centos7-zen2
-module load libtool-2.4.7-gcc-10.2.0-mzc2mvw
-# m4@1.4.19%gcc@10.2.0+sigsegv patches=9dc5fbd,bfdffa7 arch=linux-centos7-zen2
-module load m4-1.4.19-gcc-10.2.0-k5kkyx6
-# magma@2.6.2%gcc@10.2.0+cuda+fortran~ipo~rocm+shared build_type=RelWithDebInfocuda_arch=60 arch=linux-centos7-zen2
-module load magma-2.6.2-gcc-10.2.0-o7gg2nj
-# metis@5.1.0%gcc@10.2.0~gdb~int64~real64+shared build_type=Release patches=4991da9,b1225da arch=linux-centos7-zen2
-module load metis-5.1.0-gcc-10.2.0-h2r63pj
-# mpfr@4.1.0%gcc@10.2.0 libs=shared,static arch=linux-centos7-zen2
-module load mpfr-4.1.0-gcc-10.2.0-ixeo4lu
-# ncurses@6.2%gcc@10.2.0~symlinks+termlib abi=none arch=linux-centos7-zen2
-module load ncurses-6.2-gcc-10.2.0-3b2uqgl
-# openblas@0.3.20%gcc@10.2.0~bignuma~consistent_fpcsr~ilp64+locking+pic+shared symbol_suffix=none threads=none arch=linux-centos7-zen2
-module load openblas-0.3.20-gcc-10.2.0-qhcutll
-# openmpi@4.1.0%gcc@10.2.0~atomics~cuda~cxx~cxx_exceptions~gpfs~internal-hwloc~java~legacylaunchers~lustre~memchecker+romio+rsh~singularity+static+vt+wrapper-rpath fabrics=none patches=60ce20b schedulers=none arch=linux-centos7-zen2
-module load openmpi-4.1.0-gcc-10.2.0-wnndpcg
-# openssl@1.1.1q%gcc@10.2.0~docs~shared certs=mozilla patches=3fdcf2d arch=linux-centos7-zen2
-module load openssl-1.1.1q-gcc-10.2.0-t5hsb3s
-# perl@5.26.0%gcc@10.2.0+cpanm+shared+threads patches=0eac10e,8cf4302 arch=linux-centos7-zen2
-module load perl-5.26.0-gcc-10.2.0-l2yiybo
 # pkgconf@1.8.0%gcc@10.2.0 arch=linux-centos7-zen2
 module load pkgconf-1.8.0-gcc-10.2.0-fuflwbl
-# raja@0.14.0%gcc@10.2.0+cuda~examples~exercises~ipo+openmp~rocm+shared~tests build_type=RelWithDebInfo cuda_arch=60 arch=linux-centos7-zen2
-module load raja-0.14.0-gcc-10.2.0-pc2ckhw
-# suite-sparse@5.10.1%gcc@10.2.0~cuda~graphblas~openmp+pic~tbb arch=linux-centos7-zen2
-module load suite-sparse-5.10.1-gcc-10.2.0-jkighdn
-# texinfo@6.5%gcc@10.2.0 patches=12f6edb,1732115 arch=linux-centos7-zen2
-module load texinfo-6.5-gcc-10.2.0-mzqgqla
-# umpire@6.0.0%gcc@10.2.0+c+cuda~device_alloc~deviceconst~examples~fortran~ipo~numa~openmp~rocm~shared build_type=RelWithDebInfo cuda_arch=60 tests=none arch=linux-centos7-zen2
-module load umpire-6.0.0-gcc-10.2.0-eunwzka
+# ncurses@6.3%gcc@10.2.0~symlinks+termlib abi=none arch=linux-centos7-zen2
+module load ncurses-6.3-gcc-10.2.0-4wlnxto
+# ca-certificates-mozilla@2022-07-19%gcc@10.2.0 arch=linux-centos7-zen2
+module load ca-certificates-mozilla-2022-07-19-gcc-10.2.0-h2opehw
+# berkeley-db@18.1.40%gcc@10.2.0+cxx~docs+stl patches=b231fcc arch=linux-centos7-zen2
+module load berkeley-db-18.1.40-gcc-10.2.0-hltd4j3
+# libiconv@1.16%gcc@10.2.0 libs=shared,static arch=linux-centos7-zen2
+module load libiconv-1.16-gcc-10.2.0-gbg7l5p
+# diffutils@3.8%gcc@10.2.0 arch=linux-centos7-zen2
+module load diffutils-3.8-gcc-10.2.0-mjfwces
+# bzip2@1.0.8%gcc@10.2.0~debug~pic+shared arch=linux-centos7-zen2
+module load bzip2-1.0.8-gcc-10.2.0-bxh46iv
+# readline@8.1.2%gcc@10.2.0 arch=linux-centos7-zen2
+module load readline-8.1.2-gcc-10.2.0-vtya5ay
+# gdbm@1.19%gcc@10.2.0 arch=linux-centos7-zen2
+module load gdbm-1.19-gcc-10.2.0-efj5agg
 # zlib@1.2.12%gcc@10.2.0+optimize+pic+shared patches=0d38234 arch=linux-centos7-zen2
 module load zlib-1.2.12-gcc-10.2.0-gnkqokp
+# perl@5.34.1%gcc@10.2.0+cpanm+shared+threads arch=linux-centos7-zen2
+module load perl-5.34.1-gcc-10.2.0-xp4fpdr
+# openssl@1.1.1q%gcc@10.2.0~docs~shared certs=mozilla patches=3fdcf2d arch=linux-centos7-zen2
+## module load openssl-1.1.1q-gcc-10.2.0-xhxspos
+# cmake@3.23.3%gcc@10.2.0~doc+ncurses+ownlibs~qt build_type=Release arch=linux-centos7-zen2
+module load cmake-3.23.3-gcc-10.2.0-ggyj7bs
+# blt@0.4.1%gcc@10.2.0 arch=linux-centos7-zen2
+module load blt-0.4.1-gcc-10.2.0-oabae2w
+# cub@1.16.0%gcc@10.2.0 arch=linux-centos7-zen2
+module load cub-1.16.0-gcc-10.2.0-ovgrtom
+# cuda@11.4%gcc@10.2.0~allow-unsupported-compilers~dev arch=linux-centos7-zen2
+module load cuda-11.4-gcc-10.2.0-ewurpsv
+# camp@0.2.3%gcc@10.2.0+cuda~ipo+openmp~rocm~tests build_type=RelWithDebInfo cuda_arch=60,70,75,80 arch=linux-centos7-zen2
+module load camp-0.2.3-gcc-10.2.0-36lcy72
+# openblas@0.3.20%gcc@10.2.0~bignuma~consistent_fpcsr~ilp64+locking+pic+shared patches=9f12903 symbol_suffix=none threads=none arch=linux-centos7-zen2
+module load openblas-0.3.20-gcc-10.2.0-x6v3mwm
+# coinhsl@2019.05.21%gcc@10.2.0+blas arch=linux-centos7-zen2
+module load coinhsl-2019.05.21-gcc-10.2.0-gkzkws6
+# ginkgo@1.5.0.glu_experimental%gcc@10.2.0+cuda~develtools~full_optimizations~hwloc~ipo~oneapi+openmp~rocm+shared build_type=Release cuda_arch=60,70,75,80 arch=linux-centos7-zen2
+module load ginkgo-1.5.0.glu_experimental-gcc-10.2.0-x73b7k3
+# magma@2.6.2%gcc@10.2.0+cuda+fortran~ipo~rocm+shared build_type=RelWithDebInfo cuda_arch=60,70,75,80 arch=linux-centos7-zen2
+module load magma-2.6.2-gcc-10.2.0-caockkq
+# metis@5.1.0%gcc@10.2.0~gdb~int64~real64+shared build_type=Release patches=4991da9,b1225da arch=linux-centos7-zen2
+module load metis-5.1.0-gcc-10.2.0-k4z4v6l
+# openmpi@4.1.0mlx5.0%gcc@10.2.0~atomics~cuda~cxx~cxx_exceptions~gpfs~internal-hwloc~java~legacylaunchers~lustre~memchecker+romio+rsh~singularity+static+vt+wrapper-rpath fabrics=none patches=60ce20b schedulers=none arch=linux-centos7-zen2
+module load openmpi-4.1.0mlx5.0-gcc-10.2.0-ytj7jxb
+# raja@0.14.0%gcc@10.2.0+cuda~examples~exercises~ipo+openmp~rocm+shared~tests build_type=RelWithDebInfo cuda_arch=60,70,75,80arch=linux-centos7-zen2
+module load raja-0.14.0-gcc-10.2.0-tyzamiy
+# libsigsegv@2.13%gcc@10.2.0 arch=linux-centos7-zen2
+module load libsigsegv-2.13-gcc-10.2.0-aj5goyi
+# m4@1.4.19%gcc@10.2.0+sigsegv patches=9dc5fbd,bfdffa7 arch=linux-centos7-zen2
+module load m4-1.4.19-gcc-10.2.0-k5kkyx6
+# autoconf@2.69%gcc@10.2.0 patches=35c4492,7793209,a49dd5b arch=linux-centos7-zen2
+module load autoconf-2.69-gcc-10.2.0-jnh4mbw
+# automake@1.16.5%gcc@10.2.0 arch=linux-centos7-zen2
+module load automake-1.16.5-gcc-10.2.0-pgpzgqq
+# libtool@2.4.7%gcc@10.2.0 arch=linux-centos7-zen2
+module load libtool-2.4.7-gcc-10.2.0-mzc2mvw
+# gmp@6.2.1%gcc@10.2.0 libs=shared,static arch=linux-centos7-zen2
+module load gmp-6.2.1-gcc-10.2.0-tpo7i4x
+# autoconf-archive@2022.02.11%gcc@10.2.0 patches=139214f arch=linux-centos7-zen2
+module load autoconf-archive-2022.02.11-gcc-10.2.0-tirhdzr
+# texinfo@6.5%gcc@10.2.0 patches=12f6edb,1732115 arch=linux-centos7-zen2
+module load texinfo-6.5-gcc-10.2.0-mcrbwnj
+# mpfr@4.1.0%gcc@10.2.0 libs=shared,static arch=linux-centos7-zen2
+module load mpfr-4.1.0-gcc-10.2.0-3yutkz3
+# suite-sparse@5.10.1%gcc@10.2.0~cuda~graphblas~openmp+pic~tbb arch=linux-centos7-zen2
+module load suite-sparse-5.10.1-gcc-10.2.0-add65sb
+# umpire@6.0.0%gcc@10.2.0+c+cuda~device_alloc~deviceconst~examples~fortran~ipo~numa~openmp~rocm~shared build_type=RelWithDebInfo cuda_arch=60,70,75,80 tests=none arch=linux-centos7-zen2
+module load umpire-6.0.0-gcc-10.2.0-lrjkuun
+# hiop@develop%gcc@10.2.0+cuda~cusolver+deepchecking~full_optimizations+ginkgo~ipo~jsrun+kron+mpi+raja~rocm~shared+sparse build_type=RelWithDebInfo cuda_arch=60,70,75,80 arch=linux-centos7-zen2
+## module load hiop-develop-gcc-10.2.0-bgzxttu
 
 # Load system modules
 module load gcc/10.2.0
@@ -79,5 +91,5 @@ EOD
 export NVBLAS_CONFIG_FILE=$PWD/nvblas.conf
 echo "Generated $PWD/nvblas.conf"
 
-export EXTRA_CMAKE_ARGS="$EXTRA_CMAKE_ARGS -DCMAKE_CUDA_ARCHITECTURES=60"
+export EXTRA_CMAKE_ARGS="$EXTRA_CMAKE_ARGS -DCMAKE_CUDA_ARCHITECTURES=60,70,75,80"
 export CMAKE_CACHE_SCRIPT=gcc-cuda.cmake

--- a/src/LinAlg/hiopLinSolverSparseGinkgo.cpp
+++ b/src/LinAlg/hiopLinSolverSparseGinkgo.cpp
@@ -182,12 +182,13 @@ std::shared_ptr<gko::matrix::Csr<double, int>> transferTripletToCSR(std::shared_
 
 void update_matrix(hiopMatrixSparse* M_,
                    std::shared_ptr<gko::matrix::Csr<double, int>> mtx,
+                   std::shared_ptr<gko::matrix::Csr<double, int>> host_mtx,
                    int* index_covert_CSR2Triplet_,
                    int* index_covert_extra_Diag2CSR_)
 {
     int n_ = mtx->get_size()[0];
     int nnz_= mtx->get_num_stored_elements();
-    auto values = mtx->get_values();
+    auto values = host_mtx->get_values();
     int rowID_tmp{0};
     for(int k=0; k<nnz_; k++) {
         values[k] = M_->M()[index_covert_CSR2Triplet_[k]];
@@ -196,6 +197,10 @@ void update_matrix(hiopMatrixSparse* M_,
         if(index_covert_extra_Diag2CSR_[i] != -1) {
             values[index_covert_extra_Diag2CSR_[i]] += M_->M()[M_->numberOfNonzeros() - n_ + i];
         }
+    }
+    auto exec = mtx->get_executor();
+    if (exec != exec->get_master()) {
+        mtx->copy_from(host_mtx.get());
     }
 }
 
@@ -283,9 +288,10 @@ std::shared_ptr<gko::LinOpFactory> setup_solver_factory(std::shared_ptr<const gk
     assert(n_==M_->n() && M_->n()==M_->m());
     assert(n_>0);
 
-    exec_ = create_exec(nlp_->options->GetString("ginkgo_exec"));//gko::HipExecutor::create(0, gko::ReferenceExecutor::create());
+    exec_ = create_exec(nlp_->options->GetString("ginkgo_exec"));
 
-    mtx_ = transferTripletToCSR(exec_, n_, M_, &index_covert_CSR2Triplet_, &index_covert_extra_Diag2CSR_);
+    host_mtx_ = transferTripletToCSR(exec_->get_master(), n_, M_, &index_covert_CSR2Triplet_, &index_covert_extra_Diag2CSR_);
+    mtx_ = exec_ == (exec_->get_master()) ? host_mtx_ : gko::clone(exec_, host_mtx_);
     nnz_ = mtx_->get_num_stored_elements();
 
     reusable_factory_ = setup_solver_factory(exec_, mtx_);
@@ -301,7 +307,7 @@ std::shared_ptr<gko::LinOpFactory> setup_solver_factory(std::shared_ptr<const gk
     if( !mtx_ ) {
       this->firstCall();
     } else {
-      update_matrix(M_, mtx_, index_covert_CSR2Triplet_, index_covert_extra_Diag2CSR_);
+      update_matrix(M_, mtx_, host_mtx_, index_covert_CSR2Triplet_, index_covert_extra_Diag2CSR_);
     }
     
     gko_solver_ = gko::share(reusable_factory_->generate(mtx_));
@@ -341,90 +347,5 @@ std::shared_ptr<gko::LinOpFactory> setup_solver_factory(std::shared_ptr<const gk
     delete rhs; rhs=nullptr;
     return 1;
   }
-
-
-  hiopLinSolverNonSymSparseGinkgo::hiopLinSolverNonSymSparseGinkgo(const int& n,
-                                                                   const int& nnz,
-                                                                   hiopNlpFormulation* nlp)
-    : hiopLinSolverNonSymSparse(n, nnz, nlp),
-      index_covert_CSR2Triplet_{nullptr},
-      index_covert_extra_Diag2CSR_{nullptr},
-      n_{n},
-      nnz_{0}
-  {}
-
-  hiopLinSolverNonSymSparseGinkgo::~hiopLinSolverNonSymSparseGinkgo()
-  {
-    if(index_covert_CSR2Triplet_) {
-      delete [] index_covert_CSR2Triplet_;
-    }
-    if(index_covert_extra_Diag2CSR_) {
-      delete [] index_covert_extra_Diag2CSR_;
-    }
-  }
-  
-  void hiopLinSolverNonSymSparseGinkgo::firstCall()
-  {
-    nlp_->log->printf(hovSummary, "Setting up Ginkgo solver ... \n");
-    assert(n_==M_->n() && M_->n()==M_->m());
-    assert(n_>0);
-
-    exec_ = create_exec(nlp_->options->GetString("ginkgo_exec"));//gko::HipExecutor::create(0, gko::ReferenceExecutor::create());
-
-    mtx_ = transferTripletToCSR(exec_, n_, M_, &index_covert_CSR2Triplet_, &index_covert_extra_Diag2CSR_);
-    nnz_ = mtx_->get_num_stored_elements();
-
-    reusable_factory_ = setup_solver_factory(exec_, mtx_);
-  }
-
-  int hiopLinSolverNonSymSparseGinkgo::matrixChanged()
-  {
-    assert(n_==M_->n() && M_->n()==M_->m());
-    assert(n_>0);
-
-    nlp_->runStats.linsolv.tmFactTime.start();
-
-    if( !mtx_ ) {
-      this->firstCall();
-    } else {
-      update_matrix(M_, mtx_, index_covert_CSR2Triplet_, index_covert_extra_Diag2CSR_);
-    }
-
-    gko_solver_ = gko::share(reusable_factory_->generate(mtx_));
-
-    // Temporary solution for the ginkgo GLU integration.
-    auto sol = gko::as<gko::solver::Gmres<>>(gko::as<gko::solver::ScaledReordered<>>(gko_solver_)->get_solver());
-    auto precond = gko::as<gko::experimental::solver::Direct<double, int>>(sol->get_preconditioner());
-    auto status = precond->get_factorization_status();
-    
-    return status == gko::experimental::factorization::status::success ? 0 : -1;
-  }
-
-  bool hiopLinSolverNonSymSparseGinkgo::solve(hiopVector& x_)
-  {
-    assert(n_==M_->n() && M_->n()==M_->m());
-    assert(n_>0);
-    assert(x_.get_size()==M_->n());
-
-    nlp_->runStats.linsolv.tmTriuSolves.start();
-
-    hiopVectorPar* x = dynamic_cast<hiopVectorPar*>(&x_);
-    assert(x != NULL);
-    hiopVectorPar* rhs = dynamic_cast<hiopVectorPar*>(x->new_copy());
-    double* dx = x->local_data();
-    double* drhs = rhs->local_data();
-    auto x_array = gko::Array<double>::view(exec_, n_, dx);
-    auto b_array = gko::Array<double>::view(exec_, n_, drhs);
-    auto dense_x = gko::matrix::Dense<double>::create(exec_, gko::dim<2>{n_, 1}, x_array, 1);
-    auto dense_b = gko::matrix::Dense<double>::create(exec_, gko::dim<2>{n_, 1}, b_array, 1);
-
-    gko_solver_->apply(dense_b.get(), dense_x.get());
-
-    nlp_->runStats.linsolv.tmTriuSolves.stop();
-    
-    delete rhs; rhs=nullptr;
-    return 1;
-  }
-
 
 } //end namespace hiop

--- a/src/LinAlg/hiopLinSolverSparseGinkgo.hpp
+++ b/src/LinAlg/hiopLinSolverSparseGinkgo.hpp
@@ -78,10 +78,6 @@ public:
    * exit is contains the solution(s).  */
   bool solve ( hiopVector& x_ );
 
-//protected:
-//  int* ipiv;
-//  hiopVector* dwork;
-
 private:
 
   int      m_;                         // number of rows of the whole matrix
@@ -93,6 +89,7 @@ private:
 
   std::shared_ptr<gko::Executor> exec_;
   std::shared_ptr<gko::matrix::Csr<double, int>> mtx_;
+  std::shared_ptr<gko::matrix::Csr<double, int>> host_mtx_;
   std::shared_ptr<gko::LinOpFactory> reusable_factory_;
   std::shared_ptr<gko::LinOp> gko_solver_;
 
@@ -102,59 +99,8 @@ public:
   /** called the very first time a matrix is factored. Allocates space
    * for the factorization and performs ordering */
   virtual void firstCall();
-//  virtual void diagonalChanged( int idiag, int extent );
-
-
-friend class hiopLinSolverNonSymSparseGinkgo;
 
 };
-
-class hiopLinSolverNonSymSparseGinkgo: public hiopLinSolverNonSymSparse
-{
-public:
-  hiopLinSolverNonSymSparseGinkgo(const int& n, const int& nnz, hiopNlpFormulation* nlp);
-
-  virtual ~hiopLinSolverNonSymSparseGinkgo();
-
-  /** Triggers a refactorization of the matrix, if necessary.
-   * Overload from base class. */
-  int matrixChanged();
-
-  /** solves a linear system.
-   * param 'x' is on entry the right hand side(s) of the system to be solved. On
-   * exit is contains the solution(s).  */
-  bool solve ( hiopVector& x_ );
-  
-//protected:
-//  int* ipiv;
-//  hiopVector* dwork;
-
-private:
-
-  int      m_;                         // number of rows of the whole matrix
-  int      n_;                         // number of cols of the whole matrix
-  int      nnz_;                       // number of nonzeros in the matrix
-
-  int *index_covert_CSR2Triplet_;
-  int *index_covert_extra_Diag2CSR_;
-  std::unordered_map<int,int> extra_diag_nnz_map_;
-
-  std::shared_ptr<gko::Executor> exec_;
-  std::shared_ptr<gko::matrix::Csr<double, int>> mtx_;
-  std::shared_ptr<gko::LinOpFactory> reusable_factory_;
-  std::shared_ptr<gko::LinOp> gko_solver_;
-
-public:
-
-  /** called the very first time a matrix is factored. Allocates space
-   * for the factorization and performs ordering */
-  void firstCall();
-//  virtual void diagonalChanged( int idiag, int extent );
-
-friend class hiopLinSolverSymSparseGinkgo;
-
-};
-
 
 } // end namespace
 #endif


### PR DESCRIPTION
This PR should fix issues #540 and #542. It also removes the nonsymmetric ginkgo solver as previously suggested by @pelesh.

The problem were a missing host side copy of the rhs vector for #540 and directly accessing matrix and vector values located in GPU memory in `update_matrix` for 
#542. This is fine as long as they are in unified memory, which the apparently are when built with Debug. I added a host side copy of the matrix that gets updated and moved back to the GPU instead.