### PR TITLE
fixing memory leaks in cuSolver

### DIFF
--- a/src/LinAlg/hiopLinSolverSparseCUSOLVER.cpp
+++ b/src/LinAlg/hiopLinSolverSparseCUSOLVER.cpp
@@ -754,7 +754,6 @@ namespace hiop
     assert(CUSOLVER_STATUS_SUCCESS == sp_status_);
 
     buffer_size_ = size_M_;
-    //cudaFree(d_work_);
     checkCudaErrors(cudaMalloc((void**)&d_work_, buffer_size_));
 
     sp_status_ = cusolverSpDgluAnalysis(handle_cusolver_, info_M_, d_work_);

--- a/src/LinAlg/hiopLinSolverSparseCUSOLVER.cpp
+++ b/src/LinAlg/hiopLinSolverSparseCUSOLVER.cpp
@@ -222,6 +222,11 @@ namespace hiop
       cusolverSpDestroyGluInfo(info_M_);
     }
 
+    if(refact_ == "rf") {
+      cudaFree(d_P_);
+      cudaFree(d_Q_);
+      cudaFree(d_T_);
+    }
     klu_free_symbolic(&Symbolic_, &Common_);
     klu_free_numeric(&Numeric_, &Common_);
     delete [] mia_;
@@ -749,7 +754,7 @@ namespace hiop
     assert(CUSOLVER_STATUS_SUCCESS == sp_status_);
 
     buffer_size_ = size_M_;
-    cudaFree(d_work_);
+    //cudaFree(d_work_);
     checkCudaErrors(cudaMalloc((void**)&d_work_, buffer_size_));
 
     sp_status_ = cusolverSpDgluAnalysis(handle_cusolver_, info_M_, d_work_);
@@ -970,6 +975,16 @@ namespace hiop
                                        handle_rf_);
     cudaDeviceSynchronize();
     sp_status_ = cusolverRfAnalyze(handle_rf_);
+ 
+    //clean up 
+    cudaFree(d_Lp_csr);
+    cudaFree(d_Li_csr);
+    cudaFree(d_Lx_csr);
+    
+    cudaFree(d_Up_csr);
+    cudaFree(d_Ui_csr);
+    cudaFree(d_Ux_csr);
+    
     return 0;
   }
 
@@ -1061,7 +1076,11 @@ namespace hiop
     cudaFree(d_V_);
     cudaFree(d_Z_);
     cudaFree(d_rvGPU_);
-    cudaFree(d_H_col_);
+    cudaFree(d_Hcolumn_);
+     
+    if(orth_option_ == "cgs2") {
+      cudaFree(d_H_col_);
+    }
     // delete all CPU GMRES variables
     delete[] h_H_;
 


### PR DESCRIPTION
I fixed  several memory leaks (9 variables were not freed and 1 was freed without a guard). 

At the end of ` hiopLinSolverSymSparseCUSOLVER::refactorizationSetupCusolverRf()`, I added
```
 cudaFree(d_Lp_csr);
    cudaFree(d_Li_csr);
    cudaFree(d_Lx_csr);

    cudaFree(d_Up_csr);
    cudaFree(d_Ui_csr);
    cudaFree(d_Ux_csr);
```

In the `~hiopLinSolverSymSparseCUSOLVER()`, I added
```
 if(refact_ == "rf") {
      cudaFree(d_P_);
      cudaFree(d_Q_);
      cudaFree(d_T_);
    }

```
In IR class, in ` hiopLinSolverSymSparseCUSOLVERInnerIR::~hiopLinSolverSymSparseCUSOLVERInnerIR()`, I added:
```
    if(orth_option_ == "cgs2") {
      cudaFree(d_H_col_);
    }
```
