### PR TITLE
moves pnnl_cleanup to .pre stage and removes files based on age

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -191,14 +191,14 @@ build_on_incline:
     - if: '$CI_PROJECT_ROOT_NAMESPACE == "exasgd"'
 
 pnnl_cleanup:
-  stage: test
-  dependencies:
-    - build_on_incline
+  stage: .pre
   script:
+  # clears directory of files more than 6 hours/360 minutes old
   - |
     set -xv
-    export WORKDIR="$HOME/gitlab/$CI_JOB_ID/"
-    rm -rf "$WORKDIR"
+    export WORKDIR="$HOME/gitlab/"
+    find $WORKDIR -type d -mmin +360 -prune -print -exec rm -rf {} \; || true
+    ls -hal $WORKDIR
   <<: *pnnl_tags_definition
   rules:
     - if: '$CI_PROJECT_ROOT_NAMESPACE == "exasgd"'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -192,6 +192,8 @@ build_on_incline:
 
 pnnl_cleanup:
   stage: .pre
+  variables:
+    GIT_STRATEGY: none
   script:
   # clears directory of files more than 6 hours/360 minutes old
   - |
@@ -215,6 +217,8 @@ build_on_login_node:
 
 test_on_compute_node:
   stage: test
+  variables:
+    GIT_STRATEGY: none
   dependencies:
     - build_on_login_node
   tags:
@@ -239,6 +243,7 @@ build_on_quartz:
 test_on_quartz:
   stage: test
   variables:
+    GIT_STRATEGY: none
     MY_CLUSTER: quartz
   dependencies:
     - build_on_quartz
@@ -261,6 +266,7 @@ build_on_lassen:
 test_on_lassen:
   stage: test
   variables:
+    GIT_STRATEGY: none
     MY_CLUSTER: lassen
   dependencies:
     - build_on_lassen


### PR DESCRIPTION
Updates the pnnl_cleanup job in .gitlab-ci.yml to:
- run during the .pre stage
- remove files based on age (over 6 hours old) to cleanup ci account space