### PR TITLE
Condensed/normaleqn linear system without CUDA/RAJA

### DIFF
--- a/src/LinAlg/hiopMatrixSparseCsrCuda.cpp
+++ b/src/LinAlg/hiopMatrixSparseCsrCuda.cpp
@@ -1242,7 +1242,7 @@ void hiopMatrixSparseCSRCUDA::set_diagonal(const double& val)
 void hiopMatrixSparseCSRCUDA::extract_diagonal(hiopVector& diag_out) const
 {
 #ifdef HIOP_USE_RAJA
-  assert(dynamic_cast<const hiopVectorRajaPar*>(&D) && "input vector must be Raja (and data on the device)");
+  assert(dynamic_cast<const hiopVectorRajaPar*>(&diag_out) && "input vector must be Raja (and data on the device)");
 #else
   assert( "input vector must be Raja (and data on the device)");
 #endif

--- a/src/LinAlg/hiopMatrixSparseCsrCuda.cpp
+++ b/src/LinAlg/hiopMatrixSparseCsrCuda.cpp
@@ -298,7 +298,11 @@ void hiopMatrixSparseCSRCUDA::addDiagonal(const double& alpha, const hiopVector&
 {
   assert(nrows_ == D.get_size());
   assert(nrows_ == ncols_ && "Matrix must be square");
+#ifdef HIOP_USE_RAJA
   assert(dynamic_cast<const hiopVectorRajaPar*>(&D) && "input vector must be Raja (and data on the device)");
+#else
+  assert( "input vector must be Raja (and data on the device)");
+#endif
   hiop::cuda::csr_add_diag_kernel(nrows_, nnz_, irowptr_, jcolind_, values_, alpha, D.local_data_const());
 }
 
@@ -1030,7 +1034,11 @@ void hiopMatrixSparseCSRCUDA::form_diag_from_numeric(const hiopVector& D)
 {
   assert(D.get_size()==ncols_ && D.get_size()==nrows_ && D.get_size()==nnz_);
   assert(irowptr_ && jcolind_ && values_);
+#ifdef HIOP_USE_RAJA
   assert(dynamic_cast<const hiopVectorRajaPar*>(&D) && "input vector must be Raja (and data on the device)");
+#else
+  assert( "input vector must be Raja (and data on the device)");
+#endif
   cudaError_t ret = cudaMemcpy(values_,
                                D.local_data_const(),
                                nrows_*sizeof(double),
@@ -1049,7 +1057,11 @@ void hiopMatrixSparseCSRCUDA::scale_cols(const hiopVector& D)
 void hiopMatrixSparseCSRCUDA::scale_rows(const hiopVector& D)
 {
   assert(nrows_ == D.get_size());
-  assert(dynamic_cast<const hiopVectorRajaPar*>(&D) && "input vector must have data on the device)");
+#ifdef HIOP_USE_RAJA
+  assert(dynamic_cast<const hiopVectorRajaPar*>(&D) && "input vector must be Raja (and data on the device)");
+#else
+  assert( "input vector must be Raja (and data on the device)");
+#endif
   hiop::cuda::csr_scalerows_kernel(nrows_, ncols_, nnz_, irowptr_, jcolind_, values_, D.local_data_const());
 }
 
@@ -1229,7 +1241,11 @@ void hiopMatrixSparseCSRCUDA::set_diagonal(const double& val)
 
 void hiopMatrixSparseCSRCUDA::extract_diagonal(hiopVector& diag_out) const
 {
-  assert(dynamic_cast<const hiopVectorRajaPar*>(&diag_out) && "input vector must be Raja (and data on the device)");
+#ifdef HIOP_USE_RAJA
+  assert(dynamic_cast<const hiopVectorRajaPar*>(&D) && "input vector must be Raja (and data on the device)");
+#else
+  assert( "input vector must be Raja (and data on the device)");
+#endif
   hiop::cuda::csr_get_diag_kernel(nrows_, nnz_, irowptr_, jcolind_, values_, diag_out.local_data());
 }
 

--- a/src/Optimization/CMakeLists.txt
+++ b/src/Optimization/CMakeLists.txt
@@ -17,6 +17,8 @@ set(hiopOptimization_SRC
 
 set(hiopOptimization_SPARSE_SRC
   hiopKKTLinSysSparse.cpp
+  hiopKKTLinSysSparseCondensed.cpp
+  hiopKKTLinSysSparseNormalEqn.cpp
   )
 
 set(hiopOptimization_INTERFACE_HEADERS
@@ -39,10 +41,6 @@ set(hiopOptimization_INTERFACE_HEADERS
   hiopPDPerturbation.hpp
   hiopResidual.hpp
   )
-
-if(HIOP_USE_RAJA)
-  list(APPEND hiopOptimization_SPARSE_SRC hiopKKTLinSysSparseCondensed.cpp hiopKKTLinSysSparseNormalEqn.cpp)
-endif()
 
 if(HIOP_SPARSE)
   list(APPEND hiopOptimization_SRC ${hiopOptimization_SPARSE_SRC})

--- a/src/Optimization/hiopAlgFilterIPM.cpp
+++ b/src/Optimization/hiopAlgFilterIPM.cpp
@@ -1445,12 +1445,10 @@ hiopKKTLinSys* hiopAlgFilterIPMNewton::decideAndCreateLinearSystem(hiopNlpFormul
         return new hiopKKTLinSysSparseFull(nlp);
       } else if(strKKT == "xdycyd") {
         return new hiopKKTLinSysCompressedSparseXDYcYd(nlp);
-#ifdef HIOP_USE_RAJA
       } else if(strKKT == "condensed") {
         return new hiopKKTLinSysCondensedSparse(nlp);
       } else if(strKKT == "normaleqn") {
         return new hiopKKTLinSysSparseNormalEqn(nlp);
-#endif
       } else {
         //'auto' or 'XYcYd'
         return new hiopKKTLinSysCompressedSparseXYcYd(nlp);
@@ -1479,7 +1477,6 @@ hiopAlgFilterIPMNewton::switch_to_safer_KKT(hiopKKTLinSys* kkt_curr,
                                             bool& switched)
 {
 #ifdef HIOP_SPARSE
-#ifdef HIOP_USE_RAJA
   if(linsol_safe_mode_on) {
     //attempt switching only when running under "condensed" KKT formulation 
     auto* kkt_condensed = dynamic_cast<hiopKKTLinSysCondensedSparse*>(kkt_curr);
@@ -1513,7 +1510,6 @@ hiopAlgFilterIPMNewton::switch_to_safer_KKT(hiopKKTLinSys* kkt_curr,
       return kkt;
     } // end of if(kkt)
   }
-#endif
 #endif
 
 // TODO: turn to 0 --- keep using fast mode till linear solver (kkt->update) fails
@@ -1564,7 +1560,6 @@ hiopAlgFilterIPMNewton::switch_to_fast_KKT(hiopKKTLinSys* kkt_curr,
   assert("speculative"==hiop::tolower(nlp->options->GetString("linsol_mode")));
   
 #ifdef HIOP_SPARSE
-#ifdef HIOP_USE_RAJA
   //
   // Switch to quick mode for condensed
   //
@@ -1609,7 +1604,6 @@ hiopAlgFilterIPMNewton::switch_to_fast_KKT(hiopKKTLinSys* kkt_curr,
     }  
   }
 #endif
-#endif
 
   // MDS system
   // if linsol_mode = speculative, linsol_safe_mode_on = false by initialization, and hiop starts from fast mode.
@@ -1644,15 +1638,13 @@ decideAndCreateFactAcceptor(hiopPDPerturbation* p, hiopNlpFormulation* nlp, hiop
   std::string strKKT = nlp->options->GetString("fact_acceptor");
   if(strKKT == "inertia_free")
   {
-#ifdef HIOP_SPARSE   
-#ifdef HIOP_USE_RAJA
+#ifdef HIOP_SPARSE
     if(nullptr != dynamic_cast<hiopKKTLinSysCondensedSparse*>(kkt)) {
       // for LinSysCondensedSparse correct inertia is different
       assert(nullptr != dynamic_cast<hiopNlpSparseIneq*>(nlp) &&
              "wrong combination of optimization objects was created");
       return new hiopFactAcceptorInertiaFreeDWD(p, 0);      
     }
-#endif
 #endif
     return new hiopFactAcceptorInertiaFreeDWD(p, nlp->m_eq()+nlp->m_ineq());
   } else {

--- a/src/Optimization/hiopKKTLinSysSparseCondensed.cpp
+++ b/src/Optimization/hiopKKTLinSysSparseCondensed.cpp
@@ -57,16 +57,16 @@
 #include "hiopLinSolverSymSparseMA57.hpp"
 #endif
 
+#ifdef HIOP_USE_RAJA
+#include "hiopVectorRajaPar.hpp"
+
 #ifdef HIOP_USE_CUDA
 #include "hiopLinSolverCholCuSparse.hpp"
 #include "hiopMatrixSparseCsrCuda.hpp"
-
-#ifdef HIOP_USE_RAJA
-#include "hiopVectorRajaPar.hpp"
 #else
 #error "RAJA (HIOP_USE_RAJA) build needed with HIOP_USE_CUDA"
-#endif // HIOP_USE_RAJA
 #endif // HIOP_USE_CUDA
+#endif // HIOP_USE_RAJA
 
 #include "hiopMatrixSparseTripletStorage.hpp"
 #include "hiopMatrixSparseCSRSeq.hpp"

--- a/src/Optimization/hiopKKTLinSysSparseCondensed.cpp
+++ b/src/Optimization/hiopKKTLinSysSparseCondensed.cpp
@@ -171,7 +171,7 @@ bool hiopKKTLinSysCondensedSparse::build_kkt_matrix(const hiopVector& delta_wx_i
   //temporary code, see above note
   {
     if(mem_space_internal == "DEVICE") {
-#ifdef HIOP_USE_CUDA
+#ifdef HIOP_USE_RAJA
       auto Hd_raja = dynamic_cast<hiopVectorRajaPar*>(Hd_copy_);
       auto Hd_par =  dynamic_cast<hiopVectorPar*>(Hd_);
       assert(Hd_raja && "incorrect type for vector class");
@@ -495,12 +495,13 @@ hiopKKTLinSysCondensedSparse::determine_and_create_linsys()
 
     assert((linsolv=="cusolver-chol" || linsolv=="auto") && "Only cusolver-chol or auto is supported on gpu.");
     
+#ifdef HIOP_USE_RAJA
 #ifdef HIOP_USE_CUDA
     nlp_->log->printf(hovWarning,
                       "KKT_SPARSE_Condensed linsys: alloc cuSOLVER-chol matrix size %d\n", n);
     assert(M_condensed_);
     linSys_ = new hiopLinSolverCholCuSparse(M_condensed_, nlp_);
-
+#endif
 #endif    
     
     //Return NULL (and assert) if a GPU sparse linear solver is not present

--- a/src/Optimization/hiopKKTLinSysSparseNormalEqn.cpp
+++ b/src/Optimization/hiopKKTLinSysSparseNormalEqn.cpp
@@ -219,7 +219,7 @@ bool hiopKKTLinSysSparseNormalEqn::build_kkt_matrix(const hiopVector& delta_wx_i
   //temporary code, see above note
   {
     if(mem_space_internal == "DEVICE") {
-#ifdef HIOP_USE_CUDA
+#ifdef HIOP_USE_RAJA
       auto Hess_diag_raja = dynamic_cast<hiopVectorRajaPar*>(Hess_diag_copy_);
       auto Hess_diag_par = dynamic_cast<hiopVectorPar*>(Hess_diag_);
       auto Hx_raja = dynamic_cast<hiopVectorRajaPar*>(Hx_copy_);
@@ -411,12 +411,13 @@ hiopLinSolverSymSparse* hiopKKTLinSysSparseNormalEqn::determine_and_create_linsy
 
     assert((linsolv=="cusolver-chol" || linsolv=="auto") && "Only cusolver-chol or auto is supported on gpu.");
 
+#ifdef HIOP_USE_RAJA
 #ifdef HIOP_USE_CUDA
     nlp_->log->printf(hovWarning,
                       "KKT_SPARSE_NormalEqn linsys: alloc cuSOLVER-chol matrix size %d\n", n);
     assert(M_normaleqn_);
     linSys_ = new hiopLinSolverCholCuSparse(M_normaleqn_, nlp_);
-
+#endif
 #endif
 
     //Return NULL (and assert) if a GPU sparse linear solver is not present

--- a/src/Optimization/hiopKKTLinSysSparseNormalEqn.cpp
+++ b/src/Optimization/hiopKKTLinSysSparseNormalEqn.cpp
@@ -57,15 +57,15 @@
 #include "hiopLinSolverSymSparseMA57.hpp"
 #endif
 
-#ifdef HIOP_USE_CUDA
-#include "hiopLinSolverCholCuSparse.hpp"
-
 #ifdef HIOP_USE_RAJA
 #include "hiopVectorRajaPar.hpp"
+
+#ifdef HIOP_USE_CUDA
+#include "hiopLinSolverCholCuSparse.hpp"
 #else
 #error "RAJA (HIOP_USE_RAJA) build needed with HIOP_USE_CUDA"
+#endif // HIOP_USE_CUDA
 #endif // HIOP_USE_RAJA
-#endif
 
 #include "hiopMatrixSparseCSRSeq.hpp"
 


### PR DESCRIPTION
Condensed/normaleqn linear system should work on CPU, using MA57 as the backend linear solver.

In the current `develop` branch, PR #549 changed the CI behaviors when neither RAJA nor CUDA is defined, i.e., hiop will switch `Condensed/normaleqn` to `xycyd` and solves the problem without any warning. In addition, #549 compiles the cpp files for condensed/normaleqn system only if raja is defined (see [here](https://github.com/LLNL/hiop/pull/549/files#diff-e0cb3c3e440dda836086390d5e72e9426680bd33f91225e6e7f64b749692cad8R43-R46)).

Since condensed/normaleqn system should work without raja, I correct the above issues in this PR. 
This PR also guarantees the feature @fritzgoebel introduced in #549, i.e., enable cuda build without raja. 
I believe now we can compile hiop with cuda and ginkgo, but without raja.


