### PR TITLE
git submodule fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,11 +199,18 @@ endif(NOT DEFINED LAPACK_LIBRARIES)
 target_link_libraries(hiop_tpl INTERFACE ${LAPACK_LIBRARIES})
 message(STATUS "Using LAPACK libraries: ${LAPACK_LIBRARIES}")
 
-include(HiOpCheckGitSubmodules)
-if(HIOP_USE_EIGEN)
-  message(STATUS "Eigen enabled")
-  # We don't want target_include_directories as the headers are not installed
-  include_directories(${PROJECT_SOURCE_DIR}/tpl/eigen)
+if(NOT DEFINED HIOP_EIGEN_DIR)
+  include(HiOpCheckGitSubmodules)
+  if(HIOP_USE_EIGEN)
+    message(STATUS "Eigen enabled")
+    # We don't want target_include_directories as the headers are not installed
+    include_directories(${PROJECT_SOURCE_DIR}/tpl/eigen)
+  endif()
+else()
+  if(HIOP_USE_EIGEN)
+    message(STATUS "Eigen enabled using user-provided path '${HIOP_EIGEN_DIR}'")
+    include_directories(${HIOP_EIGEN_DIR})
+  endif()
 endif()
 
 if(HIOP_USE_GPU)

--- a/cmake/HiOpCheckGitSubmodules.cmake
+++ b/cmake/HiOpCheckGitSubmodules.cmake
@@ -1,30 +1,43 @@
 find_package(Git QUIET)
-if(GIT_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git")
-  # Update submodules as needed
-  message(STATUS "Submodule update")
-  execute_process(
-    COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    RESULT_VARIABLE GIT_SUBMOD_RESULT
-  )
-  if(NOT GIT_SUBMOD_RESULT EQUAL "0")
-    message(
-      FATAL_ERROR
-        "git submodule update --init --recursive failed with ${GIT_SUBMOD_RESULT}, please checkout submodules manually"
+if(GIT_FOUND)
+  if(EXISTS "${PROJECT_SOURCE_DIR}/.git")
+    # Update submodules as needed
+    message(STATUS "Submodule update")
+    execute_process(
+      COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive
+      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+      RESULT_VARIABLE GIT_SUBMOD_RESULT
     )
-  endif()
-endif()
+    if(NOT GIT_SUBMOD_RESULT EQUAL "0")
+      message(
+        FATAL_ERROR
+        "'git submodule update --init --recursive' failed with ${GIT_SUBMOD_RESULT}. "
+        "Please checkout submodules manually with the folowing command and run cmake again:\n"
+        "\t$ git submodule update --init --recursive\n"
+        )
+    else()
+      # For each submodule, we check a file in that submodule we expect to find to
+      # make sure the submodules were downloaded correctly.
+      foreach(CHK_FILE "eigen/Eigen/Core")
+        if(NOT EXISTS "${PROJECT_SOURCE_DIR}/tpl/${CHK_FILE}")
+          message(
+           FATAL_ERROR
+           "It seems that submodule ${PROJECT_SOURCE_DIR}/tpl/${CHK_FILE} was not downloaded! "
+           "Please update submodules manually with the following command and try again:\n"
+           "\t$ git submodule update --init --recursive\n"
+           "Alternatively, use '-DHIOP_USE_EIGEN=ON -DHIOP_EIGEN_DIR=/path/to/eigen/root/dir'."
+          )
+        endif()
+      endforeach()
 
-# For each submodule, we check a file in that submodule we expect to find to
-# make sure the submodules were downloaded correctly.
-foreach(CHK_FILE "eigen/Eigen/Core")
-  if(NOT EXISTS "${PROJECT_SOURCE_DIR}/tpl/${CHK_FILE}")
+    endif()
+  else() #EXISTS .git
     message(
-      FATAL_ERROR
-      "It seems required submodule was not downloaded! "
-      "Please update submodules manually with the following command "
-      "and try again."
-      "\n\t$ git submodule update --init --recursive\n"
-    )
-  endif()
-endforeach()
+      WARNING
+      "It seems you are not using HiOp under a git repository. To enable EIGEN please use "
+      "'-DHIOP_USE_EIGEN=ON -DHIOP_EIGEN_DIR=/path/to/eigen/root/dir'."
+      )
+    set(HIOP_USE_EIGEN "OFF")
+  endif() #EXISTS .git
+endif(GIT_FOUND)
+


### PR DESCRIPTION
When the release archives are used to build HiOp, git submodule fails since the sources are not under a git repo. Failure can happen when git is simply not available on the machine. 

It appears that we need to reintroduce HIOP_EIGEN_DIR to allow user specify location of eigen. 

