### PR TITLE
Fix static culibos issue #567

### DIFF
--- a/cmake/FindHiopCudaLibraries.cmake
+++ b/cmake/FindHiopCudaLibraries.cmake
@@ -25,6 +25,7 @@ if(HIOP_BUILD_STATIC)
     CUDA::cudart_static
     CUDA::cublasLt_static
     CUDA::curand_static
+    CUDA::culibos  
     )
 endif()
 


### PR DESCRIPTION
CMAKE cannot find/add culibos when static cuda library is used.
This PR adds the static culibos library manually into our cmake file.

CLOSE #567