### PR TITLE
Instrumentation of host vectors with execution spaces

### DIFF
--- a/src/LinAlg/hiopVectorIntSeq.cpp
+++ b/src/LinAlg/hiopVectorIntSeq.cpp
@@ -54,6 +54,8 @@
  */
 
 #include "hiopVectorIntSeq.hpp"
+#include "MemBackendCppImpl.hpp"
+
 #include <cstring> //for memcpy
 
 namespace hiop
@@ -61,18 +63,20 @@ namespace hiop
 
 hiopVectorIntSeq::hiopVectorIntSeq(size_type sz) : hiopVectorInt(sz)
 {
-  buf_ = new index_type[sz_];
+  buf_ = exec_space_.template alloc_array<index_type>(sz_);
 }
 
 hiopVectorIntSeq::~hiopVectorIntSeq()
 {
-  delete[] buf_;
+  exec_space_.dealloc_array(buf_);
+  buf_ = nullptr;
 }
 
 void hiopVectorIntSeq::copy_from(const index_type* v_local)
 {
-  if(v_local)
-    memcpy(buf_, v_local, sz_*sizeof(index_type));
+  if(v_local) {
+    exec_space_.copy(buf_, v_local, sz_);
+  }
 }
 
 void hiopVectorIntSeq::set_to_zero()

--- a/src/LinAlg/hiopVectorIntSeq.hpp
+++ b/src/LinAlg/hiopVectorIntSeq.hpp
@@ -57,14 +57,13 @@
 
 #include "hiopVectorInt.hpp"
 
+#include "ExecSpace.hpp"
+
 namespace hiop
 {
 
 class hiopVectorIntSeq : public hiopVectorInt
 {
-private:
-  index_type *buf_;
-
 public:
   hiopVectorIntSeq(size_type sz);
 
@@ -100,6 +99,14 @@ public:
    *
    */ 
   virtual void linspace(const index_type& i0, const index_type& di);
+
+  const ExecSpace<MemBackendCpp, ExecPolicySeq>& exec_space() const
+  {
+    return exec_space_;
+  }  
+private:
+  ExecSpace<MemBackendCpp, ExecPolicySeq> exec_space_;
+  index_type *buf_;
 };
 
 } // namespace hiop

--- a/src/LinAlg/hiopVectorPar.hpp
+++ b/src/LinAlg/hiopVectorPar.hpp
@@ -46,13 +46,23 @@
 // Lawrence Livermore National Security, LLC, and shall not be used for advertising or 
 // product endorsement purposes.
 
+/**
+ * @file hiopVectorPar.hpp
+ *
+ * @author Cosmin G. Petra <petra1@llnl.gov>, LLNL
+ * @author Nai-Yuan Chiang <chiang7@llnl.gov>, LLNL
+ *
+ */
+
 #pragma once
+
+#include "hiopVector.hpp"
+
+#include "hiopVectorInt.hpp"
+#include "ExecSpace.hpp"
 
 #include <string>
 #include <hiopMPI.hpp>
-#include "hiopVector.hpp"
-#include "hiopVectorInt.hpp"
-
 #include <cstdio>
 
 namespace hiop
@@ -281,7 +291,13 @@ public:
                                  const hiopInterfaceBase::NonlinearityType arr_src) const;
 
   virtual bool is_equal(const hiopVector& vec) const;
+
+  const ExecSpace<MemBackendCpp, ExecPolicySeq>& exec_space() const
+  {
+    return exec_space_;
+  }
 protected:
+  ExecSpace<MemBackendCpp, ExecPolicySeq> exec_space_;
   MPI_Comm comm_;
   double* data_;
   size_type glob_il_, glob_iu_;


### PR DESCRIPTION
VectorPar and VectorIntSeq are now instrumented with `MemBackendCpp` and sequential execution policy for memory allocations and transfers.