### PR TITLE
remove copy from/to device methods in vector classes

### DIFF
--- a/src/ExecBackends/MemBackendCudaImpl.hpp
+++ b/src/ExecBackends/MemBackendCudaImpl.hpp
@@ -104,7 +104,9 @@ struct TransferImpl<MemBackendCuda, EXECPOLDEST, MemBackendCuda, EXECPOLSRC, T, 
                            const ExecSpace<MemBackendCuda, EXECPOLSRC>& hwb_src,
                            const I& n)
   {
-    return cudaSuccess == cudaMemcpy(p_dest, p_src, n*sizeof(T), cudaMemcpyDeviceToDevice);
+    cudaError_t err = cudaMemcpy(p_dest, p_src, n*sizeof(T), cudaMemcpyDeviceToDevice);
+    assert(err == cudaSuccess);
+    return cudaSuccess == err;
   }
 };
 
@@ -117,7 +119,9 @@ struct TransferImpl<MemBackendCuda, EXECPOLDEST, MemBackendCpp, EXECPOLSRC, T, I
                            const ExecSpace<MemBackendCpp, EXECPOLSRC>& hwb_src,
                            const I& n)
   {
-    return cudaSuccess == cudaMemcpy(p_dest, p_src, n*sizeof(T), cudaMemcpyHostToDevice);
+    auto err = cudaMemcpy(p_dest, p_src, n*sizeof(T), cudaMemcpyHostToDevice);
+    assert(cudaSuccess == err);
+    return cudaSuccess == err;
   }
 };
 
@@ -130,7 +134,9 @@ struct TransferImpl<MemBackendCpp, EXECPOLDEST, MemBackendCuda, EXECPOLSRC, T, I
                            const ExecSpace<MemBackendCuda, EXECPOLSRC>& hwb_src,
                            const I& n)
   {
-    return cudaSuccess == cudaMemcpy(p_dest, p_src, n*sizeof(T), cudaMemcpyDeviceToHost);
+    auto err = cudaMemcpy(p_dest, p_src, n*sizeof(T), cudaMemcpyDeviceToHost);
+    assert(cudaSuccess == err);
+    return cudaSuccess == err;
   }
 };
 

--- a/src/ExecBackends/MemBackendUmpireImpl.hpp
+++ b/src/ExecBackends/MemBackendUmpireImpl.hpp
@@ -134,7 +134,7 @@ struct TransferImpl<MemBackendCpp, EXECPOLDEST, MemBackendUmpire, EXECPOLSRC, T,
         assert(src);
 
         // This is a hack to go around the fact that Umpire cannot copy to a pointer (on host
-        // in this case) that he does not manage.
+        // in this case) that it does not manage.
         //
         // The solution is to have Umpire allocate and transfer to a pointer on host, followed
         // by a std::memcpy from the new pointer to the desired (also host) destination.

--- a/src/ExecBackends/MemBackendUmpireImpl.hpp
+++ b/src/ExecBackends/MemBackendUmpireImpl.hpp
@@ -123,7 +123,7 @@ struct TransferImpl<MemBackendCpp, EXECPOLDEST, MemBackendUmpire, EXECPOLSRC, T,
   inline static bool do_it(T* p_dest,
                            ExecSpace<MemBackendCpp, EXECPOLDEST>& hwb_dest,
                            const T* p_src,
-                           const ExecSpace<MemBackendUmpire, MemBackendUmpire>& hwb_src,
+                           const ExecSpace<MemBackendUmpire, EXECPOLSRC>& hwb_src,
                            const I& n)
   {
     if(hwb_src.mem_backend().is_host()) {

--- a/src/LinAlg/hiopVector.hpp
+++ b/src/LinAlg/hiopVector.hpp
@@ -331,9 +331,6 @@ public:
   virtual const double* local_data_const() const = 0;
   virtual double* local_data_host() = 0;
   virtual const double* local_data_host_const() const = 0;
-
-  virtual void copyToDev() = 0;
-  virtual void copyFromDev() = 0;
   
   /// @brief get number of values that are less than the given value 'val'. TODO: add unit test
   virtual size_type numOfElemsLessThan(const double &val) const = 0;

--- a/src/LinAlg/hiopVector.hpp
+++ b/src/LinAlg/hiopVector.hpp
@@ -56,6 +56,9 @@
 namespace hiop
 {
 
+//"forward" defs
+class hiopVectorPar;
+  
 class hiopVector
 {
 public:
@@ -86,6 +89,17 @@ public:
   /// @brief Copy the 'n' elements of v starting at 'start_index_in_v' into 'this'
   virtual void copy_from_starting_at(const double* v, int start_index_in_v, int n) = 0;
 
+  /** Copy to `this` the array content of the hiopVectorPar vector passed as argument.
+   *
+   * Host-device memory transfer will occur for device implementations.
+   * 
+   * @pre `this` and source vector should have the same size.
+   * @pre `this` and source vector should have the same MPI distributions (and, 
+   * hence, same number of local elements) when applicable.
+   */
+  virtual void copy_from_vectorpar(const hiopVectorPar& vsrc) = 0;
+
+  
   /**
    * @brief Copy from src the elements specified by the indices in index_in_src. 
    *
@@ -122,6 +136,17 @@ public:
 
   /// @brief Copy 'this' to double array, which is assumed to be at least of 'n_local_' size.
   virtual void copyTo(double* dest) const = 0;
+
+  /** Copy the array content `this` in the hiopVectorPar passed as argument
+   *
+   * Host-device memory transfer will occur for device implementations.
+   * 
+   * @pre `this` and destination vector should have the same size.
+   * @pre `this` and destination vector should have the same MPI distributions (and, 
+   * hence, same number of local elements) when applicable.
+   */
+  virtual void copy_to_vectorpar(hiopVectorPar& vdest) const = 0;
+  
   /// @brief Copy 'this' to v starting at start_index in 'this'.
   virtual void copyToStarting(int start_index_in_src, hiopVector& v) const = 0;
   /// @brief Copy 'this' to v starting at start_index in 'v'.

--- a/src/LinAlg/hiopVectorCuda.cpp
+++ b/src/LinAlg/hiopVectorCuda.cpp
@@ -995,6 +995,7 @@ bool hiopVectorCuda::isfinite_local() const
 void hiopVectorCuda::print(FILE* file/*=nullptr*/, const char* msg/*=nullptr*/, int max_elems/*=-1*/, int rank/*=-1*/) const
 {
   // TODO. no fprintf. use printf to print everything on screen?
+  // Alternative: create a hiopVectorPar copy and use hiopVectorPar::print
   assert(false && "Not implemented in CUDA device");
 }
 

--- a/src/LinAlg/hiopVectorCuda.cpp
+++ b/src/LinAlg/hiopVectorCuda.cpp
@@ -210,7 +210,7 @@ void hiopVectorCuda::copy_from_w_pattern(const hiopVector& vv, const hiopVector&
   componentMult(select);
 }
 
-/// @brief Copy the 'n' elements of v starting at 'start_index_in_dest' in 'this'
+/// @brief Copy the `n` elements of v starting at `start_index_in_dest` in `this`
 void hiopVectorCuda::copyFromStarting(int start_index_in_dest, const double* v, int nv)
 {
   assert(start_index_in_dest+nv <= n_local_);
@@ -218,7 +218,7 @@ void hiopVectorCuda::copyFromStarting(int start_index_in_dest, const double* v, 
   assert(cuerr == cudaSuccess);
 }
 
-/// @brief Copy v_src into 'this' starting at start_index_in_dest in 'this'. */
+/// @brief Copy v_src into `this` starting at start_index_in_dest in `this`. */
 void hiopVectorCuda::copyFromStarting(int start_index_in_dest, const hiopVector& v_src)
 {
   assert(n_local_==n_ && "only for local/non-distributed vectors");
@@ -232,7 +232,7 @@ void hiopVectorCuda::copyFromStarting(int start_index_in_dest, const hiopVector&
   assert(b);
 }
 
-/// @brief Copy the 'n' elements of v starting at 'start_index_in_v' into 'this'
+/// @brief Copy the `n` elements of v starting at `start_index_in_v` into `this`
 void hiopVectorCuda::copy_from_starting_at(const double* v, int start_index_in_v, int nv)
 {
   cudaError_t cuerr = cudaMemcpy(data_, v+start_index_in_v, (nv)*sizeof(double), cudaMemcpyDeviceToDevice);
@@ -259,7 +259,7 @@ void hiopVectorCuda::copy_from_indexes(const double* src, const hiopVectorInt& i
   hiop::cuda::copy_from_index_kernel(n_local_, data_, src, index_in_src.local_data_const());
 }
 
-///  @brief Copy from 'v' starting at 'start_idx_src' to 'this' starting at 'start_idx_dest'
+///  @brief Copy from `v` starting at `start_idx_src` to `this` starting at `start_idx_dest`
 void hiopVectorCuda::startingAtCopyFromStartingAt(int start_idx_dest,
                                                   const hiopVector& vec_src,
                                                   int start_idx_src)
@@ -284,7 +284,7 @@ void hiopVectorCuda::startingAtCopyFromStartingAt(int start_idx_dest,
   exec_space_.copy(data_+start_idx_dest, v_src.data_+start_idx_src, howManyToCopyDest, v_src.exec_space());
 }
 
-/// @brief Copy 'this' to double array, which is assumed to be at least of 'n_local_' size.
+/// @brief Copy `this` to double array, which is assumed to be at least of `n_local_` size.
 void hiopVectorCuda::copyTo(double* dest) const
 {
   cudaError_t cuerr = cudaMemcpy(dest,
@@ -294,7 +294,7 @@ void hiopVectorCuda::copyTo(double* dest) const
   assert(cuerr == cudaSuccess);
 }
 
-/// @brief Copy 'this' to dst starting at start_index in 'this'.
+/// @brief Copy `this` to dst starting at `start_index` in `this`.
 void hiopVectorCuda::copyToStarting(int start_index, hiopVector& dst) const
 {
   int v_size = dst.get_local_size();
@@ -325,7 +325,7 @@ void hiopVectorCuda::copyToStarting(hiopVector& dst, int start_index) const
   dst_cu.exec_space().copy(dst_cu.data_+start_index, data_, n_local_, exec_space_);
 }
 
-/// @brief Copy the entries in 'this' where corresponding 'ix' is nonzero, to v starting at start_index in 'v'.
+/// @brief Copy the entries in `this` where corresponding `ix` is nonzero, to v starting at start_index in `v`.
 void hiopVectorCuda::copyToStartingAt_w_pattern(hiopVector& vec, int start_index_in_dest, const hiopVector& select) const
 {
   if(n_local_ == 0) {
@@ -388,7 +388,7 @@ void hiopVectorCuda::copy_to_two_vec_w_pattern(hiopVector& c,
   hiop::cuda::copy_mapped_src_to_dest_kernel(d_size, local_data_const(), d.local_data(), d_map.local_data_const());
 }
 
-/// @brief Copy 'this' (source) starting at 'start_idx_in_src' to 'dest' starting at index 'int start_idx_dest' 
+/// @brief Copy `this` (source) starting at `start_idx_in_src` to `dest` starting at index `int start_idx_dest` 
 void hiopVectorCuda::startingAtCopyToStartingAt(int start_idx_in_src, 
                                                 hiopVector& dest, 
                                                 int start_idx_dest, 
@@ -424,8 +424,8 @@ void hiopVectorCuda::startingAtCopyToStartingAt(int start_idx_in_src,
 }
 
 /**
-* @brief Copy 'this' (source) starting at 'start_idx_in_src' to 'dest' starting at index 'int start_idx_dest'
-* The values are copy to 'dest' where the corresponding entry in 'selec_dest' is nonzero
+* @brief Copy `this` (source) starting at `start_idx_in_src` to `dest` starting at index `int start_idx_dest`
+* The values are copy to `dest` where the corresponding entry in `selec_dest` is nonzero
 */ 
 void hiopVectorCuda::startingAtCopyToStartingAt_w_pattern(index_type start_idx_in_src,
                                                           hiopVector& destination,
@@ -523,7 +523,7 @@ void hiopVectorCuda::component_min(const double constant)
   hiop::cuda::component_min_kernel(n_local_, data_, constant);
 }
 
-/** @brief Set each component of this hiopVector to the minimum of itself and the corresponding component of 'v'. */
+/** @brief Set each component of this hiopVector to the minimum of itself and the corresponding component of `v`. */
 void hiopVectorCuda::component_min(const hiopVector& vec)
 {
   assert(vec.get_local_size() == n_local_);
@@ -537,7 +537,7 @@ void hiopVectorCuda::component_max(const double constant)
   hiop::cuda::component_max_kernel(n_local_, data_, constant);
 }
 
-/** @brief Set each component of this hiopVector to the maximum of itself and the corresponding component of 'v'. */
+/** @brief Set each component of this hiopVector to the maximum of itself and the corresponding component of `v`. */
 void hiopVectorCuda::component_max(const hiopVector& vec)
 {
   assert(vec.get_local_size() == n_local_);
@@ -581,7 +581,7 @@ void hiopVectorCuda::axpy(double alpha, const hiopVector& xvec)
   assert(ret_cublas == CUBLAS_STATUS_SUCCESS);
 }
 
-/// @brief this += alpha * x, for the entries in 'this' where corresponding 'select' is nonzero.
+/// @brief this += alpha * x, for the entries in `this` where corresponding `select` is nonzero.
 void hiopVectorCuda::axpy_w_pattern(double alpha, const hiopVector& xvec, const hiopVector& select) 
 {
   axpy(alpha, xvec);
@@ -742,7 +742,7 @@ double hiopVectorCuda::linearDampingTerm_local(const hiopVector& ixleft,
 }
 
 /** 
-* @brief Performs `this[i] = alpha*this[i] + sign*ct` where sign=1 when EXACTLY one of 
+* @brief Performs `this[i] = alpha*this[i] + sign*ct` where sign=1 when exactly one of 
 * ixleft[i] and ixright[i] is 1.0 and sign=0 otherwise. 
 */
 void hiopVectorCuda::addLinearDampingTerm(const hiopVector& ixleft,
@@ -1044,19 +1044,19 @@ void hiopVectorCuda::copyFromDev() const
   assert(cuerr == cudaSuccess);
 }
 
-/// @brief get number of values that are less than the given value 'val'. TODO: add unit test
+/// @brief get number of values that are less than the given value `val`. TODO: add unit test
 size_type hiopVectorCuda::numOfElemsLessThan(const double &val) const
 {
   return hiop::cuda::num_of_elem_less_than_kernel(n_local_, data_, val);
 }
 
-/// @brief get number of values whose absolute value are less than the given value 'val'. TODO: add unit test
+/// @brief get number of values whose absolute value are less than the given value `val`. TODO: add unit test
 size_type hiopVectorCuda::numOfElemsAbsLessThan(const double &val) const
 {
   return hiop::cuda::num_of_elem_absless_than_kernel(n_local_, data_, val);
 }
 
-/// @brief set int array 'arr', starting at `start` and ending at `end`, to the values in `arr_src` from 'start_src`
+/// @brief set int array `arr`, starting at `start` and ending at `end`, to the values in `arr_src` from `start_src`
 void hiopVectorCuda::set_array_from_to(hiopInterfaceBase::NonlinearityType* arr, 
                                        const int start, 
                                        const int end, 
@@ -1074,7 +1074,7 @@ void hiopVectorCuda::set_array_from_to(hiopInterfaceBase::NonlinearityType* arr,
   hiop::cuda::set_array_from_to_kernel(n_local_, arr, start, length, arr_src, start_src);
 }
 
-/// @brief set int array 'arr', starting at `start` and ending at `end`, to the values in `arr_src` from 'start_src`
+/// @brief set int array `arr`, starting at `start` and ending at `end`, to the values in `arr_src` from `start_src`
 void hiopVectorCuda::set_array_from_to(hiopInterfaceBase::NonlinearityType* arr, 
                                        const int start, 
                                        const int end, 

--- a/src/LinAlg/hiopVectorCuda.cpp
+++ b/src/LinAlg/hiopVectorCuda.cpp
@@ -195,7 +195,7 @@ void hiopVectorCuda::copy_from_w_pattern(const hiopVector& vv, const hiopVector&
 }
 
 
-void hiopVectorCuda::copy_from_vec_par(const hiopVectorPar& src)
+void hiopVectorCuda::copy_from_vectorpar(const hiopVectorPar& src)
 {
   assert(n_local_ == src.get_size());
   cudaError_t cu_err = cudaMemcpy(data_,

--- a/src/LinAlg/hiopVectorCuda.hpp
+++ b/src/LinAlg/hiopVectorCuda.hpp
@@ -69,14 +69,19 @@
 
 namespace hiop
 {
-
+//Forward declarations
 class hiopVectorPar;
+//Forward declarations of tester classes that needs to be friends with this vector
+namespace tests
+{
+class VectorTestsCuda;
+}
   
 /// Implementation of abstract class hiopVector using CUDA API
 class hiopVectorCuda : public hiopVector
 {
 public:
-  hiopVectorCuda(const size_type& glob_n, index_type* col_part=NULL, MPI_Comm comm=MPI_COMM_SELF);
+  hiopVectorCuda(const size_type& glob_n, index_type* col_part=nullptr, MPI_Comm comm=MPI_COMM_SELF);
   virtual ~hiopVectorCuda();
 
   /// @brief Set all elements to zero.
@@ -306,12 +311,13 @@ public:
   inline const double* local_data_const() const { return data_; }
   inline double* local_data_host() { return data_host_mirror_; }
   inline const double* local_data_host_const() const { return data_host_mirror_; }
-
+private:
   virtual void copyToDev();
   virtual void copyFromDev();
   virtual void copyToDev() const;
   virtual void copyFromDev() const;
-
+  friend class tests::VectorTestsCuda;
+public:
   /// @brief get number of values that are less than the given value 'val'. TODO: add unit test
   virtual size_type numOfElemsLessThan(const double &val) const;
   /// @brief get number of values whose absolute value are less than the given value 'val'. TODO: add unit test

--- a/src/LinAlg/hiopVectorCuda.hpp
+++ b/src/LinAlg/hiopVectorCuda.hpp
@@ -103,8 +103,10 @@ public:
   /// @brief Copy from src the elements specified by the indices in index_in_src. 
   virtual void copy_from_indexes(const double* src, const hiopVectorInt& index_in_src);
 
-  /// Copy from a (host) hiopVectorPar of the same size.
-  void copy_from_vec_par(const hiopVectorPar& src);
+  /// @brief Copy entries from a hiopVectorPar, see method documentation in the parent class.
+  void copy_from_vectorpar(const hiopVectorPar& vsrc);
+  /// @brief Copy entries to a hiopVectorPar, see method documentation in the parent class.
+  void copy_to_vectorpar(hiopVectorPar& vdest) const;
   
   ///  @brief Copy from 'v' starting at 'start_idx_src' to 'this' starting at 'start_idx_dest'
   virtual void startingAtCopyFromStartingAt(int start_idx_dest, const hiopVector& v, int start_idx_src);

--- a/src/LinAlg/hiopVectorCuda.hpp
+++ b/src/LinAlg/hiopVectorCuda.hpp
@@ -59,6 +59,8 @@
 #include <cassert>
 #include <cstring>
 
+#include "ExecSpace.hpp"
+
 #include <hiopMPI.hpp>
 
 #include "hiopVector.hpp"
@@ -144,7 +146,11 @@ public:
    * either source ('this') or destination ('dest') is reached
    * The values are copy to 'dest' where the corresponding entry in 'selec_dest' is nonzero
   */ 
-  virtual void startingAtCopyToStartingAt_w_pattern(int start_idx_in_src, hiopVector& dest, int start_idx_dest, const hiopVector& selec_dest, int num_elems=-1) const;
+  virtual void startingAtCopyToStartingAt_w_pattern(int start_idx_in_src,
+                                                    hiopVector& dest,
+                                                    int start_idx_dest,
+                                                    const hiopVector& selec_dest,
+                                                    int num_elems=-1) const;
 
   /** @brief Return the two norm */
   virtual double twonorm() const;
@@ -332,7 +338,17 @@ public:
   /* functions for this class */
   inline MPI_Comm get_mpi_comm() const { return comm_; }
 
+  ExecSpace<MemBackendCuda, ExecPolicyCuda>& exec_space()
+  {
+    return exec_space_;
+  }
+  const ExecSpace<MemBackendCuda, ExecPolicyCuda>& exec_space() const
+  {
+    return exec_space_;
+  }
+  
 private:
+  ExecSpace<MemBackendCuda, ExecPolicyCuda> exec_space_;
   MPI_Comm comm_;
   double* data_host_mirror_;
   double* data_;

--- a/src/LinAlg/hiopVectorCuda.hpp
+++ b/src/LinAlg/hiopVectorCuda.hpp
@@ -98,11 +98,11 @@ public:
   virtual void copyFrom(const double* v_local_data);
   /// @brief Copy from vec the elements specified by the indices in select
   virtual void copy_from_w_pattern(const hiopVector& src, const hiopVector& select);
-  /// @brief Copy the 'n' elements of v starting at 'start_index_in_dest' in 'this'
+  /// @brief Copy the `n` elements of v starting at `start_index_in_dest` in `this`
   virtual void copyFromStarting(int start_index_in_dest, const double* v, int n);
-  /// @brief Copy v_src into 'this' starting at start_index_in_dest in 'this'. */
+  /// @brief Copy v_src into `this` starting at start_index_in_dest in `this`. */
   virtual void copyFromStarting(int start_index_in_dest, const hiopVector& v_src);
-  /// @brief Copy the 'n' elements of v starting at 'start_index_in_v' into 'this'
+  /// @brief Copy the `n` elements of v starting at `start_index_in_v` into `this`
   virtual void copy_from_starting_at(const double* v, int start_index_in_v, int n);
 
   /// @brief Copy from src the elements specified by the indices in index_in_src. 
@@ -115,16 +115,16 @@ public:
   /// @brief Copy entries to a hiopVectorPar, see method documentation in the parent class.
   void copy_to_vectorpar(hiopVectorPar& vdest) const;
   
-  ///  @brief Copy from 'v' starting at 'start_idx_src' to 'this' starting at 'start_idx_dest'
+  ///  @brief Copy from `v` starting at `start_idx_src` to `this` starting at `start_idx_dest`
   virtual void startingAtCopyFromStartingAt(int start_idx_dest, const hiopVector& v, int start_idx_src);
 
-  /// @brief Copy 'this' to double array, which is assumed to be at least of 'n_local_' size.
+  /// @brief Copy `this` to double array, which is assumed to be at least of `n_local_` size.
   virtual void copyTo(double* dest) const;
-  /// @brief Copy 'this' to dst starting at start_index in 'this'.
+  /// @brief Copy `this` to dst starting at start_index in `this`.
   virtual void copyToStarting(int start_index_in_src, hiopVector& v) const;
-  /// @brief Copy 'this' to dst starting at start_index in 'dst'.
+  /// @brief Copy `this` to dst starting at start_index in `dst`.
   virtual void copyToStarting(hiopVector& dst, int start_index_in_dest) const;
-  /// @brief Copy the entries in 'this' where corresponding 'ix' is nonzero, to v starting at start_index in 'v'.
+  /// @brief Copy the entries in `this` where corresponding `ix` is nonzero, to v starting at start_index in `v`.
   virtual void copyToStartingAt_w_pattern(hiopVector& v, int start_index_in_dest, const hiopVector& ix) const;
 
   /// @brief Copy the entries in `c` and `d` to `this`, according to the mapping in `c_map` and `d_map`
@@ -140,16 +140,16 @@ public:
                                          const hiopVectorInt& d_map) const;
 
   /**
-   * copy 'this' (source) starting at 'start_idx_in_src' to 'dest' starting at index 'int start_idx_dest' 
-   * If num_elems>=0, 'num_elems' will be copied; if num_elems<0, elements will be copied till the end of
-   * either source ('this') or destination ('dest') is reached
+   * copy `this` (source) starting at `start_idx_in_src` to `dest` starting at index `int start_idx_dest` 
+   * If num_elems>=0, `num_elems` will be copied; if num_elems<0, elements will be copied till the end of
+   * either source (`this`) or destination (`dest`) is reached
   */
   virtual void startingAtCopyToStartingAt(int start_idx_in_src, hiopVector& dest, int start_idx_dest, int num_elems=-1) const;
   /**
-   * @brief Copy 'this' (source) starting at 'start_idx_in_src' to 'dest' starting at index 'int start_idx_dest'
-   * If num_elems>=0, 'num_elems' will be copied; if num_elems<0, elements will be copied till the end of
-   * either source ('this') or destination ('dest') is reached
-   * The values are copy to 'dest' where the corresponding entry in 'selec_dest' is nonzero
+   * @brief Copy `this` (source) starting at `start_idx_in_src` to `dest` starting at index `int start_idx_dest`
+   * If num_elems>=0, `num_elems` will be copied; if num_elems<0, elements will be copied till the end of
+   * either source (`this`) or destination (`dest`) is reached
+   * The values are copy to `dest` where the corresponding entry in `selec_dest` is nonzero
   */ 
   virtual void startingAtCopyToStartingAt_w_pattern(int start_idx_in_src,
                                                     hiopVector& dest,
@@ -180,11 +180,11 @@ public:
 
   /** @brief Set each component of this hiopVector to the minimum of itself and the given constant. */
   virtual void component_min(const double constant);
-  /** @brief Set each component of this hiopVector to the minimum of itself and the corresponding component of 'v'. */
+  /** @brief Set each component of this hiopVector to the minimum of itself and the corresponding component of `v`. */
   virtual void component_min(const hiopVector& v );
   /** @brief Set each component of this hiopVector to the maximum of itself and the given constant. */
   virtual void component_max(const double constant);
-  /** @brief Set each component of this hiopVector to the maximum of itself and the corresponding component of 'v'. */
+  /** @brief Set each component of this hiopVector to the maximum of itself and the corresponding component of `v`. */
   virtual void component_max(const hiopVector& v);
   /** @brief Set each component to its absolute value */
   virtual void component_abs();
@@ -197,7 +197,7 @@ public:
   virtual void scale(double alpha);
   /// @brief this += alpha * x
   virtual void axpy(double alpha, const hiopVector& x);
-  /// @brief this += alpha * x, for the entries in 'this' where corresponding 'select' is nonzero.
+  /// @brief this += alpha * x, for the entries in `this` where corresponding `select` is nonzero.
   virtual void axpy_w_pattern(double alpha, const hiopVector& xvec, const hiopVector& select);
 
   /**
@@ -217,7 +217,7 @@ public:
   virtual void axzpy ( double alpha, const hiopVector& x, const hiopVector& z );
   /// @brief this += alpha * x / z
   virtual void axdzpy( double alpha, const hiopVector& x, const hiopVector& z );
-  /// @brief this += alpha * x / z on entries 'i' for which select[i]==1.
+  /// @brief this += alpha * x / z on entries `i` for which select[i]==1.
   virtual void axdzpy_w_pattern( double alpha, const hiopVector& x, const hiopVector& z, const hiopVector& select );
   /// @brief Add c to the elements of this
   virtual void addConstant( double c );
@@ -298,7 +298,7 @@ public:
   /// @brief check if all values are finite /well-defined floats. Returns false if nan or infs are present.
   virtual bool isfinite_local() const;
 
-  /// @brief prints up to max_elems (by default all), on rank 'rank' (by default on all)
+  /// @brief prints up to max_elems (by default all), on rank `rank` (by default on all)
   virtual void print(FILE* file=nullptr, const char* message=nullptr,int max_elems=-1, int rank=-1) const;
   /// @brief allocates a vector that mirrors this, but doesn't copy the values
   virtual hiopVector* alloc_clone() const;
@@ -318,12 +318,12 @@ private:
   virtual void copyFromDev() const;
   friend class tests::VectorTestsCuda;
 public:
-  /// @brief get number of values that are less than the given value 'val'. TODO: add unit test
+  /// @brief get number of values that are less than the given value `val`. TODO: add unit test
   virtual size_type numOfElemsLessThan(const double &val) const;
-  /// @brief get number of values whose absolute value are less than the given value 'val'. TODO: add unit test
+  /// @brief get number of values whose absolute value are less than the given value `val`. TODO: add unit test
   virtual size_type numOfElemsAbsLessThan(const double &val) const;  
 
-  /// @brief set int array 'arr', starting at `start` and ending at `end`, to the values in `arr_src` from 'start_src`
+  /// @brief set int array `arr`, starting at `start` and ending at `end`, to the values in `arr_src` from `start_src`
   /// TODO: add unit test
   virtual void set_array_from_to(hiopInterfaceBase::NonlinearityType* arr, 
                                  const int start, 

--- a/src/LinAlg/hiopVectorInt.hpp
+++ b/src/LinAlg/hiopVectorInt.hpp
@@ -86,8 +86,19 @@ public:
   
   virtual void copy_from(const index_type* v_local) = 0;
 
+  /** Copy array content of `hiopVectorIntSeq` into `this`. Host-device 
+   * communication occurs when `this` is a device vector.
+   *
+   * @pre Sizes must match.
+   */
   virtual void copy_from_vectorseq(const hiopVectorIntSeq& src) = 0;
-  virtual void copy_to_vectorseq(hiopVectorIntSeq& src) const = 0;
+
+  /** Copy array content of `this` into `hiopVectorIntSeq`. Host-device 
+   * communication occurs when `this` is a device vector.
+   *
+   * @pre Sizes must match.
+   */
+  virtual void copy_to_vectorseq(hiopVectorIntSeq& dest) const = 0;
   
   /// @brief Set all elements to zero.
   virtual void set_to_zero() = 0;

--- a/src/LinAlg/hiopVectorInt.hpp
+++ b/src/LinAlg/hiopVectorInt.hpp
@@ -80,10 +80,7 @@ public:
   virtual const index_type* local_data_const() const = 0;
   virtual index_type* local_data_host() = 0;
   virtual const index_type* local_data_host_const() const = 0;
-
-  virtual void copy_to_dev() = 0;
-  virtual void copy_from_dev() = 0;
-  
+ 
   virtual void copy_from(const index_type* v_local) = 0;
 
   /** Copy array content of `hiopVectorIntSeq` into `this`. Host-device 

--- a/src/LinAlg/hiopVectorInt.hpp
+++ b/src/LinAlg/hiopVectorInt.hpp
@@ -59,6 +59,9 @@
 namespace hiop
 {
 
+// "forward" definitions
+class hiopVectorIntSeq;
+  
 class hiopVectorInt
 {
 protected:
@@ -82,6 +85,9 @@ public:
   virtual void copy_from_dev() = 0;
   
   virtual void copy_from(const index_type* v_local) = 0;
+
+  virtual void copy_from_vectorseq(const hiopVectorIntSeq& src) = 0;
+  virtual void copy_to_vectorseq(hiopVectorIntSeq& src) const = 0;
   
   /// @brief Set all elements to zero.
   virtual void set_to_zero() = 0;

--- a/src/LinAlg/hiopVectorIntCuda.cpp
+++ b/src/LinAlg/hiopVectorIntCuda.cpp
@@ -87,22 +87,6 @@ hiopVectorIntCuda::~hiopVectorIntCuda()
   cudaFree(buf_);
 }
 
-void hiopVectorIntCuda::copy_from_dev()
-{
-  if (buf_ != buf_host_) {
-    cudaError_t cuerr = cudaMemcpy(buf_host_, buf_, (sz_)*sizeof(index_type), cudaMemcpyDeviceToHost);
-    assert(cuerr == cudaSuccess);
-  }
-}
-
-void hiopVectorIntCuda::copy_to_dev()
-{
-  if (buf_ != buf_host_) {
-    cudaError_t cuerr = cudaMemcpy(buf_, buf_host_, (sz_)*sizeof(index_type), cudaMemcpyHostToDevice);
-    assert(cuerr == cudaSuccess);
-  }
-}
-
 void hiopVectorIntCuda::copy_from(const index_type* v_local)
 {
   if(v_local) {

--- a/src/LinAlg/hiopVectorIntCuda.cpp
+++ b/src/LinAlg/hiopVectorIntCuda.cpp
@@ -122,7 +122,7 @@ void hiopVectorIntCuda::copy_to_vectorseq(hiopVectorIntSeq& dest) const
 {
   assert(dest.size() == sz_);
   auto b = dest.exec_space().copy(dest.local_data(), buf_, sz_, exec_space_);
-  //assert(b);
+  assert(b);
 }
   
 void hiopVectorIntCuda::set_to_zero()

--- a/src/LinAlg/hiopVectorIntCuda.cpp
+++ b/src/LinAlg/hiopVectorIntCuda.cpp
@@ -52,14 +52,17 @@
  *
  */
 #include "hiopVectorIntCuda.hpp"
+
+#include "MemBackendCudaImpl.hpp"
 #include "VectorCudaKernels.hpp"
+
 #include <cuda_runtime.h>
+
+#include "hiopVectorIntSeq.hpp"
 #include <cassert>
 
 namespace hiop
 {
-
-
 
 hiopVectorIntCuda::hiopVectorIntCuda(size_type sz, std::string mem_space)
   : hiopVectorInt(sz),
@@ -108,6 +111,20 @@ void hiopVectorIntCuda::copy_from(const index_type* v_local)
   }
 }
 
+void hiopVectorIntCuda::copy_from_vectorseq(const hiopVectorIntSeq& src)
+{
+  assert(src.size() == sz_);
+  auto b = exec_space_.copy(buf_, src.local_data_const(), sz_, src.exec_space());
+  assert(b);
+}
+
+void hiopVectorIntCuda::copy_to_vectorseq(hiopVectorIntSeq& dest) const
+{
+  assert(dest.size() == sz_);
+  auto b = dest.exec_space().copy(dest.local_data(), buf_, sz_, exec_space_);
+  //assert(b);
+}
+  
 void hiopVectorIntCuda::set_to_zero()
 {
   cudaError_t cuerr = cudaMemset(buf_, 0, sz_);

--- a/src/LinAlg/hiopVectorIntCuda.cpp
+++ b/src/LinAlg/hiopVectorIntCuda.cpp
@@ -108,7 +108,7 @@ void hiopVectorIntCuda::copy_to_vectorseq(hiopVectorIntSeq& dest) const
   auto b = dest.exec_space().copy(dest.local_data(), buf_, sz_, exec_space_);
   assert(b);
 }
-  
+
 void hiopVectorIntCuda::set_to_zero()
 {
   cudaError_t cuerr = cudaMemset(buf_, 0, sz_);

--- a/src/LinAlg/hiopVectorIntCuda.hpp
+++ b/src/LinAlg/hiopVectorIntCuda.hpp
@@ -71,20 +71,6 @@ public:
 
   ~hiopVectorIntCuda();
 
-  /**
-   * @brief Copy array data from the device.
-   *
-   * @note This is a no-op if the memory space is _host_ or _uvm_.
-   */
-  void copy_from_dev();
-
-  /**
-   * @brief Copy array data to the device.
-   *
-   * @note This is a no-op if the memory space is _host_ or _uvm_.
-   */
-  void copy_to_dev();
-
   virtual inline index_type* local_data_host() { return buf_host_; }
 
   virtual inline const index_type* local_data_host_const() const { return buf_host_; }

--- a/src/LinAlg/hiopVectorIntCuda.hpp
+++ b/src/LinAlg/hiopVectorIntCuda.hpp
@@ -96,7 +96,7 @@ public:
   virtual void copy_from(const index_type* v_local);
 
   virtual void copy_from_vectorseq(const hiopVectorIntSeq& src);
-  virtual void copy_to_vectorseq(hiopVectorIntSeq& src) const;
+  virtual void copy_to_vectorseq(hiopVectorIntSeq& dest) const;
 
   /// @brief Set all elements to zero.
   virtual void set_to_zero();

--- a/src/LinAlg/hiopVectorIntCuda.hpp
+++ b/src/LinAlg/hiopVectorIntCuda.hpp
@@ -55,18 +55,17 @@
  */
 
 #include "hiopVectorInt.hpp"
+#include "ExecSpace.hpp"
 #include <string>
 
 namespace hiop
 {
 
+// "forward" declarations
+class hiopVectorIntSeq;
+  
 class hiopVectorIntCuda : public hiopVectorInt
 {
-private:
-  index_type *buf_host_;
-  index_type *buf_;
-  std::string mem_space_;
-
 public:
   hiopVectorIntCuda(size_type sz, std::string mem_space="HOST");
 
@@ -96,6 +95,9 @@ public:
   
   virtual void copy_from(const index_type* v_local);
 
+  virtual void copy_from_vectorseq(const hiopVectorIntSeq& src);
+  virtual void copy_to_vectorseq(hiopVectorIntSeq& src) const;
+
   /// @brief Set all elements to zero.
   virtual void set_to_zero();
 
@@ -113,6 +115,21 @@ public:
    *
    */ 
   virtual void linspace(const index_type& i0, const index_type& di);
+
+  ExecSpace<MemBackendCuda, ExecPolicyCuda>& exec_space()
+  {
+    return exec_space_;
+  }
+  const ExecSpace<MemBackendCuda, ExecPolicyCuda>& exec_space() const
+  {
+    return exec_space_;
+  }
+  
+private:
+  ExecSpace<MemBackendCuda, ExecPolicyCuda> exec_space_;
+  index_type *buf_host_;
+  index_type *buf_;
+  std::string mem_space_;
 };
 
 } // namespace hiop

--- a/src/LinAlg/hiopVectorIntRaja.hpp
+++ b/src/LinAlg/hiopVectorIntRaja.hpp
@@ -62,7 +62,13 @@
 
 namespace hiop
 {
-
+//forward declarations of the "friend" testing classes
+namespace tests
+{
+class VectorTestsIntRaja;
+class MatrixTestsRajaSparseTriplet;
+}
+  
 template<class MEMBACKEND, class EXECPOLICYRAJA>
 class hiopVectorIntRaja : public hiopVectorInt
 {
@@ -70,20 +76,6 @@ public:
   hiopVectorIntRaja(size_type sz, std::string mem_space="HOST");
   hiopVectorIntRaja(const hiopVectorIntRaja&) = delete;
   ~hiopVectorIntRaja();
-
-  /**
-   * @brief Copy array data from the device.
-   *
-   * @note This is a no-op if the memory space is _host_ or _uvm_.
-   */
-  void copy_from_dev();
-
-  /**
-   * @brief Copy array data to the device.
-   *
-   * @note This is a no-op if the memory space is _host_ or _uvm_.
-   */
-  void copy_to_dev();
 
   virtual inline index_type* local_data_host() { return buf_host_; }
 
@@ -122,6 +114,22 @@ public:
   {
     return exec_space_;
   }
+private:
+  friend class tests::VectorTestsIntRaja;
+  friend class tests::MatrixTestsRajaSparseTriplet;
+  /**
+   * @brief Copy array data from the device.
+   *
+   * @note This is a no-op if the memory space is _host_ or _uvm_.
+   */
+  void copy_from_dev();
+
+  /**
+   * @brief Copy array data to the device.
+   *
+   * @note This is a no-op if the memory space is _host_ or _uvm_.
+   */
+  void copy_to_dev();
 
 private:
   ExecSpace<MEMBACKEND, EXECPOLICYRAJA> exec_space_;

--- a/src/LinAlg/hiopVectorIntRaja.hpp
+++ b/src/LinAlg/hiopVectorIntRaja.hpp
@@ -95,6 +95,14 @@ public:
   
   virtual void copy_from(const index_type* v_local);
 
+  virtual void copy_from_vectorseq(const hiopVectorIntSeq& src)
+  {
+  }
+  virtual void copy_to_vectorseq(hiopVectorIntSeq& src) const
+  {
+  }
+
+  
   /// @brief Set all elements to zero.
   virtual void set_to_zero();
 

--- a/src/LinAlg/hiopVectorIntRaja.hpp
+++ b/src/LinAlg/hiopVectorIntRaja.hpp
@@ -95,12 +95,9 @@ public:
   
   virtual void copy_from(const index_type* v_local);
 
-  virtual void copy_from_vectorseq(const hiopVectorIntSeq& src)
-  {
-  }
-  virtual void copy_to_vectorseq(hiopVectorIntSeq& src) const
-  {
-  }
+  virtual void copy_from_vectorseq(const hiopVectorIntSeq& src);
+
+  virtual void copy_to_vectorseq(hiopVectorIntSeq& dest) const;
 
   
   /// @brief Set all elements to zero.

--- a/src/LinAlg/hiopVectorIntRaja.hpp
+++ b/src/LinAlg/hiopVectorIntRaja.hpp
@@ -96,7 +96,6 @@ public:
   virtual void copy_from(const index_type* v_local);
 
   virtual void copy_from_vectorseq(const hiopVectorIntSeq& src);
-
   virtual void copy_to_vectorseq(hiopVectorIntSeq& dest) const;
 
   

--- a/src/LinAlg/hiopVectorIntRajaImpl.hpp
+++ b/src/LinAlg/hiopVectorIntRajaImpl.hpp
@@ -55,6 +55,8 @@
 
 #include "hiopVectorIntRaja.hpp"
 
+#include "hiopVectorIntSeq.hpp"
+
 namespace hiop
 {
 
@@ -105,6 +107,21 @@ void hiopVectorIntRaja<MEMBACKEND, RAJAEXECPOL>::copy_to_dev()
   }
 }
 
+template<class MEMBACKEND, class RAJAEXECPOL>
+void hiopVectorIntRaja<MEMBACKEND, RAJAEXECPOL>::copy_from_vectorseq(const hiopVectorIntSeq& src)
+{
+  assert(sz_ == src.size());
+  exec_space_.copy(buf_, src.local_data_const(), sz_, src.exec_space());
+}
+
+template<class MEMBACKEND, class RAJAEXECPOL>
+void hiopVectorIntRaja<MEMBACKEND, RAJAEXECPOL>::copy_to_vectorseq(hiopVectorIntSeq& dest) const
+{
+  assert(sz_ == dest.size());
+  dest.exec_space().copy(dest.local_data(), buf_, sz_, exec_space_);
+}
+
+  
 template<class MEMBACKEND, class RAJAEXECPOL>
 void hiopVectorIntRaja<MEMBACKEND, RAJAEXECPOL>::copy_from(const index_type* v_local)
 {

--- a/src/LinAlg/hiopVectorIntSeq.cpp
+++ b/src/LinAlg/hiopVectorIntSeq.cpp
@@ -79,6 +79,18 @@ void hiopVectorIntSeq::copy_from(const index_type* v_local)
   }
 }
 
+void hiopVectorIntSeq::copy_from_vectorseq(const hiopVectorIntSeq& src)
+{
+  assert(src.sz_ == sz_);
+  exec_space_.copy(buf_, src.buf_, sz_, src.exec_space_);
+}
+  
+void hiopVectorIntSeq::copy_to_vectorseq(hiopVectorIntSeq& src) const
+{
+  assert(src.sz_ == sz_);
+  src.exec_space_.copy(src.buf_, buf_, sz_, exec_space_);
+}
+  
 void hiopVectorIntSeq::set_to_zero()
 {
   for(index_type i=0; i<sz_; ++i) {

--- a/src/LinAlg/hiopVectorIntSeq.hpp
+++ b/src/LinAlg/hiopVectorIntSeq.hpp
@@ -82,6 +82,9 @@ public:
   
   virtual void copy_from(const index_type* v_local);
 
+  virtual void copy_from_vectorseq(const hiopVectorIntSeq& src);
+  virtual void copy_to_vectorseq(hiopVectorIntSeq& src) const;
+  
   /// @brief Set all elements to zero.
   virtual void set_to_zero();
 
@@ -101,6 +104,10 @@ public:
   virtual void linspace(const index_type& i0, const index_type& di);
 
   const ExecSpace<MemBackendCpp, ExecPolicySeq>& exec_space() const
+  {
+    return exec_space_;
+  }  
+  ExecSpace<MemBackendCpp, ExecPolicySeq>& exec_space()
   {
     return exec_space_;
   }  

--- a/src/LinAlg/hiopVectorPar.cpp
+++ b/src/LinAlg/hiopVectorPar.cpp
@@ -148,12 +148,22 @@ void hiopVectorPar::setToConstant_w_patternSelect(double c, const hiopVector& se
     }
   }
 }
-void hiopVectorPar::copyFrom(const hiopVector& v_ )
+void hiopVectorPar::copyFrom(const hiopVector& v_in )
 {
-  const hiopVectorPar& v = dynamic_cast<const hiopVectorPar&>(v_);
+  const hiopVectorPar& v = dynamic_cast<const hiopVectorPar&>(v_in);
+  copy_from_vectorpar(v);
+}
+
+void hiopVectorPar::copy_from_vectorpar(const hiopVectorPar& v)
+{
   assert(n_local_==v.n_local_);
   assert(glob_il_==v.glob_il_); assert(glob_iu_==v.glob_iu_);
   exec_space_.copy(this->data_, v.data_, n_local_, v.exec_space_);
+}
+
+void hiopVectorPar::copy_to_vectorpar(hiopVectorPar& vdest) const
+{
+  vdest.copy_from_vectorpar(*this);
 }
 
 void hiopVectorPar::copyFrom(const double* v_local_data )

--- a/src/LinAlg/hiopVectorPar.hpp
+++ b/src/LinAlg/hiopVectorPar.hpp
@@ -308,10 +308,15 @@ public:
 
   virtual bool is_equal(const hiopVector& vec) const;
 
+  ExecSpace<MemBackendCpp, ExecPolicySeq>& exec_space()
+  {
+    return exec_space_;
+  }
   const ExecSpace<MemBackendCpp, ExecPolicySeq>& exec_space() const
   {
     return exec_space_;
   }
+
 protected:
   ExecSpace<MemBackendCpp, ExecPolicySeq> exec_space_;
   MPI_Comm comm_;

--- a/src/LinAlg/hiopVectorPar.hpp
+++ b/src/LinAlg/hiopVectorPar.hpp
@@ -87,6 +87,13 @@ public:
   virtual void copyFrom(const double* v_local_data); //v should be of length at least n_local_  
   virtual void copy_from_w_pattern(const hiopVector& src, const hiopVector& select);
 
+  /** Copy to `this` the array content of the hiopVectorPar vector passed as argument.
+   *
+   * @pre `this` and source vector should have the same size.
+   * @pre `this` and source vector should have the same MPI distributions (and, 
+   * hence, same number of local elements) when applicable.
+   */
+  virtual void copy_from_vectorpar(const hiopVectorPar& vsrc);
   /**
    * @brief Copy from src the elements specified by the indices in index_in_src. 
    *
@@ -128,6 +135,15 @@ public:
   virtual void startingAtCopyFromStartingAt(int start_idx_dest, const hiopVector& v, int start_idx_src);
 
   virtual void copyTo(double* dest) const;
+
+  /** Copy the array content `this` in the hiopVectorPar passed as argument
+   *
+   * @pre `this` and destination vector should have the same size.
+   * @pre `this` and destination vector should have the same MPI distributions (and, 
+   * hence, same number of local elements) when applicable.
+   */
+  virtual void copy_to_vectorpar(hiopVectorPar& vdest) const;
+  
   virtual void copyToStarting(int start_index_in_src, hiopVector& v) const;
   /// @brief Copy 'this' to v starting at start_index in 'v'.
   virtual void copyToStarting(hiopVector& v, int start_index_in_dest) const;

--- a/src/LinAlg/hiopVectorPar.hpp
+++ b/src/LinAlg/hiopVectorPar.hpp
@@ -287,12 +287,7 @@ public:
   virtual MPI_Comm get_mpi_comm() const { return comm_; }
   virtual inline double* local_data_host() { return local_data(); }
   virtual inline const double* local_data_host_const() const { return local_data_const(); }
-
-  virtual void copyToDev() {}
-  virtual void copyFromDev() {}
-  virtual void copyToDev() const {}
-  virtual void copyFromDev() const {}
-  
+ 
   virtual size_type numOfElemsLessThan(const double &val) const;
   virtual size_type numOfElemsAbsLessThan(const double &val) const;    
 

--- a/src/LinAlg/hiopVectorRaja.hpp
+++ b/src/LinAlg/hiopVectorRaja.hpp
@@ -72,6 +72,15 @@
 
 namespace hiop
 {
+
+//forward declarations of the test classes that are friends to this class
+namespace tests
+{
+class VectorTestsRajaPar;
+class MatrixTestsRajaDense;
+class MatrixTestsRajaSparseTriplet;
+class MatrixTestsRajaSymSparseTriplet;
+}
   
 template<class MEMBACKEND, class EXECPOLICYRAJA>
 class hiopVectorRaja : public hiopVector
@@ -282,10 +291,14 @@ public:
   inline double* local_data() { return data_dev_; }
   inline const double* local_data_const() const { return data_dev_; }
   inline MPI_Comm get_mpi_comm() const { return comm_; }
-
+private:
   void copyToDev();
   void copyFromDev();
-  
+  friend class tests::VectorTestsRajaPar;
+  friend class tests::MatrixTestsRajaDense;
+  friend class tests::MatrixTestsRajaSparseTriplet;
+  friend class tests::MatrixTestsRajaSymSparseTriplet;
+public:
   virtual size_type numOfElemsLessThan(const double &val) const;
   virtual size_type numOfElemsAbsLessThan(const double &val) const;      
 

--- a/src/LinAlg/hiopVectorRaja.hpp
+++ b/src/LinAlg/hiopVectorRaja.hpp
@@ -89,6 +89,11 @@ public:
   virtual void copyFrom(const double* v_local_data); //v should be of length at least n_local
   virtual void copy_from(const hiopVector& src, const hiopVectorInt& index_in_src); 
   virtual void copy_from_w_pattern(const hiopVector& src, const hiopVector& select);
+
+  /// @brief Copy entries from a hiopVectorPar, see method documentation in the parent class.
+  void copy_from_vectorpar(const hiopVectorPar& vsrc);
+  /// @brief Copy entries to a hiopVectorPar, see method documentation in the parent class.
+  void copy_to_vectorpar(hiopVectorPar& vdest) const;
   
   /**
    * @brief Copy from src the elements specified by the indices in index_in_src. 

--- a/src/LinAlg/hiopVectorRajaImpl.hpp
+++ b/src/LinAlg/hiopVectorRajaImpl.hpp
@@ -265,7 +265,7 @@ void hiopVectorRaja<MEM, POL>::copy_from_vectorpar(const hiopVectorPar& v)
 template<class MEM, class POL> 
 void hiopVectorRaja<MEM, POL>::copy_to_vectorpar(hiopVectorPar& v) const
 {
-  assert(n_local_ == v.get_local_size());
+  assert(n_local_ == v.get_local_size());  
   v.exec_space().copy(v.local_data(), data_dev_, n_local_, exec_space_);
 }
   

--- a/src/LinAlg/hiopVectorRajaImpl.hpp
+++ b/src/LinAlg/hiopVectorRajaImpl.hpp
@@ -76,6 +76,8 @@
 
 #include <RAJA/RAJA.hpp>
 
+#include "hiopVectorPar.hpp"
+
 namespace hiop
 {
 // Define type aliases
@@ -253,6 +255,20 @@ void hiopVectorRaja<MEM, POL>::copyFrom(const hiopVector& vec)
   exec_space_.copy(data_dev_, v.data_dev_, n_local_, v.exec_space_);
 }
 
+template<class MEM, class POL> 
+void hiopVectorRaja<MEM, POL>::copy_from_vectorpar(const hiopVectorPar& v)
+{
+  assert(n_local_ == v.get_local_size());
+  exec_space_.copy(data_dev_, v.local_data_const(), n_local_, v.exec_space());
+}
+
+template<class MEM, class POL> 
+void hiopVectorRaja<MEM, POL>::copy_to_vectorpar(hiopVectorPar& v) const
+{
+  assert(n_local_ == v.get_local_size());
+  v.exec_space().copy(v.local_data(), data_dev_, n_local_, exec_space_);
+}
+  
 /**
  * @brief Copy data from local_array to this vector
  * 
@@ -382,7 +398,6 @@ void hiopVectorRaja<MEM, POL>::copy_from_indexes(const double* vv, const hiopVec
     {
       dd[i] = vv[id[i]];
     });
-
 }
 
 

--- a/src/Optimization/hiopKKTLinSysSparseCondensed.cpp
+++ b/src/Optimization/hiopKKTLinSysSparseCondensed.cpp
@@ -176,7 +176,7 @@ bool hiopKKTLinSysCondensedSparse::build_kkt_matrix(const hiopPDPerturbation& pd
       auto Hd_par =  dynamic_cast<hiopVectorPar*>(Hd_);
       assert(Hd_cuda && "incorrect type for vector class");
       assert(Hd_par && "incorrect type for vector class");      
-      Hd_cuda->copy_from_vec_par(*Hd_par);
+      Hd_cuda->copy_from_vectorpar(*Hd_par);
 
       auto Dx_delta_cuda = dynamic_cast<hiopVectorCuda*>(Dx_plus_deltawx_);
       auto deltawx_cuda = dynamic_cast<hiopVectorCuda*>(deltawx_);
@@ -184,8 +184,8 @@ bool hiopKKTLinSysCondensedSparse::build_kkt_matrix(const hiopPDPerturbation& pd
       const hiopVectorPar& deltawx_host = dynamic_cast<const hiopVectorPar&>(delta_wx_in);
       assert(Dx_delta_cuda && Dx_par && "incorrect type for vector class");
 
-      Dx_delta_cuda->copy_from_vec_par(*Dx_par);
-      deltawx_cuda->copy_from_vec_par(deltawx_host);
+      Dx_delta_cuda->copy_from_vectorpar(*Dx_par);
+      deltawx_cuda->copy_from_vectorpar(deltawx_host);
 #else
       assert(false && "compute mode not available under current build: enable CUDA.");
       Hd_copy_->copyFrom(*Hd_);

--- a/src/Optimization/hiopKKTLinSysSparseNormalEqn.cpp
+++ b/src/Optimization/hiopKKTLinSysSparseNormalEqn.cpp
@@ -224,9 +224,9 @@ bool hiopKKTLinSysSparseNormalEqn::build_kkt_matrix(const hiopPDPerturbation& pd
       auto Hd_par =  dynamic_cast<hiopVectorPar*>(Hd_);
       assert(Hx_cuda && "incorrect type for vector class");
       assert(Hx_par && "incorrect type for vector class");      
-      Hess_diag_cuda->copy_from_vec_par(*Hess_diag_par);
-      Hx_cuda->copy_from_vec_par(*Hx_par);
-      Hd_cuda->copy_from_vec_par(*Hd_par);
+      Hess_diag_cuda->copy_from_vectorpar(*Hess_diag_par);
+      Hx_cuda->copy_from_vectorpar(*Hx_par);
+      Hd_cuda->copy_from_vectorpar(*Hd_par);
 
       auto deltawx_cuda = dynamic_cast<hiopVectorCuda*>(deltawx_);
       auto deltawd_cuda = dynamic_cast<hiopVectorCuda*>(deltawd_);
@@ -237,10 +237,10 @@ bool hiopKKTLinSysSparseNormalEqn::build_kkt_matrix(const hiopPDPerturbation& pd
       const hiopVectorPar& deltacc_host = dynamic_cast<const hiopVectorPar&>(*delta_cc_);
       const hiopVectorPar& deltacd_host = dynamic_cast<const hiopVectorPar&>(*delta_cd_);
 
-      deltawx_cuda->copy_from_vec_par(deltawx_host);
-      deltawd_cuda->copy_from_vec_par(deltawd_host);
-      deltacc_cuda->copy_from_vec_par(deltacc_host);
-      deltacd_cuda->copy_from_vec_par(deltacd_host);
+      deltawx_cuda->copy_from_vectorpar(deltawx_host);
+      deltawd_cuda->copy_from_vectorpar(deltawd_host);
+      deltacc_cuda->copy_from_vectorpar(deltacc_host);
+      deltacd_cuda->copy_from_vectorpar(deltacd_host);
 #else
       assert(false && "compute mode not available under current build: enable CUDA.");
 #endif 

--- a/src/Optimization/hiopNlpFormulation.cpp
+++ b/src/Optimization/hiopNlpFormulation.cpp
@@ -463,6 +463,7 @@ bool hiopNlpFormulation::process_bounds(size_type& n_bnds_low,
 
 #if !defined(HIOP_USE_MPI)
   int* vec_distrib_ = nullptr;
+  MPI_Comm comm_ = MPI_COMM_SELF;
 #endif  
   hiopVectorPar xl_tmp(n_vars_, vec_distrib_, comm_);
   hiopVectorPar xu_tmp(n_vars_, vec_distrib_, comm_);

--- a/tests/LinAlg/matrixTestsDense.hpp
+++ b/tests/LinAlg/matrixTestsDense.hpp
@@ -65,6 +65,9 @@
 #include <hiopMatrixDense.hpp>
 #include "testBase.hpp"
 
+//for processing indexes/ints arrays on host
+#include "hiopVectorIntSeq.hpp"
+
 namespace hiop { namespace tests {
 
 /**
@@ -831,13 +834,14 @@ public:
     dst.setToConstant(dst_val);
     src.setToConstant(src_val);
 
-    index_type* rows_idxs_arr = rows_idxs.local_data_host();
+    hiopVectorIntSeq rows_idxs_host(rows_idxs.size());
+    index_type* rows_idxs_arr = rows_idxs_host.local_data();
     for (index_type i = 0; i < num_rows_to_copy; ++i) {
       rows_idxs_arr[i] = i;
     }
     rows_idxs_arr[0] = num_rows_to_copy - 1;
     rows_idxs_arr[num_rows_to_copy - 1] = 0;
-    rows_idxs.copy_to_dev();
+    rows_idxs.copy_from_vectorseq(rows_idxs_host);
 
     setLocalRow(&src, num_rows_to_copy - 1, zero);
 

--- a/tests/LinAlg/vectorTests.hpp
+++ b/tests/LinAlg/vectorTests.hpp
@@ -512,18 +512,12 @@ public:
 
     const real_type c_val = one;
     const real_type d_val = two;
- 
+
     c.setToConstant(c_val);
     d.setToConstant(d_val);
 
-    for(local_ordinal_type i = 0; i < c_size; ++i) {
-      c_map.local_data_host()[i] = i;
-    }
-    for(local_ordinal_type i = 0; i < d_size; ++i) {
-      d_map.local_data_host()[i] = i + c_size;
-    }
-    c_map.copy_to_dev();
-    d_map.copy_to_dev();
+    c_map.linspace(0, 1);
+    d_map.linspace(c_size, 1);
 
     cd.copy_from_two_vec_w_pattern(c, c_map, d, d_map);
 
@@ -561,18 +555,9 @@ public:
     assert(c_size + d_size == cd_size && "size doesn't match");
 
     const real_type cd_val = two;
- 
-    c.setToZero();
-    d.setToZero();
 
-    for(local_ordinal_type i = 0; i < c_size; ++i) {
-      c_map.local_data_host()[i] = i;
-    }
-    for(local_ordinal_type i = 0; i < d_size; ++i) {
-      d_map.local_data_host()[i] = i + c_size;
-    }
-    c_map.copy_to_dev();
-    d_map.copy_to_dev();
+    c_map.linspace(0, 1);
+    d_map.linspace(c_size, 1);
 
     cd.setToConstant(cd_val);
     cd.copy_to_two_vec_w_pattern(c, c_map, d, d_map);

--- a/tests/LinAlg/vectorTestsInt.hpp
+++ b/tests/LinAlg/vectorTestsInt.hpp
@@ -91,13 +91,14 @@ public:
     int fail = 0;
     const int idx = x.size()/2;
     const int x_val = 1;
-    for(int i=0; i<x.size(); i++)
+    for(int i=0; i<x.size(); i++) {
       setLocalElement(&x, i, 0);
+    }
+    setLocalElement(&x, idx, x_val);
 
-    x.local_data_host()[idx] = x_val;
-    x.copy_to_dev();
-    if (getLocalElement(&x, idx) != x_val)
+    if(getLocalElement(&x, idx) != x_val) {
       fail++;
+    }
 
     printMessage(fail, __func__);
     return fail;


### PR DESCRIPTION
- Addresses issue #581 
- (pre)processing bounds and constraints in `hiopNlpFormulation` (currently is done on host) is now exclusively done via `hiopVector` interface, which facilitates the porting of this processing to device (this will be done by a future PR)
- instruments cuda vectors with execution spaces
- provides implementation of a couple of `copy` methods for device-host transfers needed by the cuda vectors