### PR TITLE
Update the comments in `hiopVector` classes

### DIFF
--- a/src/LinAlg/hiopVector.hpp
+++ b/src/LinAlg/hiopVector.hpp
@@ -295,7 +295,7 @@ public:
    */
   /// @brief Copy the entries in 'this' where corresponding 'ix' is nonzero, to v starting at start_index in 'v'.
   virtual void copyToStartingAt_w_pattern(hiopVector& vec,
-                                          int start_index_in_dest,
+                                          index_type start_index_in_dest,
                                           const hiopVector& ix) const = 0;
 
   /**

--- a/src/LinAlg/hiopVector.hpp
+++ b/src/LinAlg/hiopVector.hpp
@@ -67,52 +67,151 @@ public:
   {
   }
   virtual ~hiopVector() {};
-  /// @brief Set all elements to zero.
-  virtual void setToZero() = 0;
-  /// @brief Set all elements to c
-  virtual void setToConstant( double c ) = 0;
-  /// @brief Set all elements to random values uniformly distributed between `minv` and `maxv`.
-  virtual void set_to_random_uniform(double minv, double maxv) = 0;
-  /// @brief Set all elements that are not zero in ix to  c, and the rest to 0
-  virtual void setToConstant_w_patternSelect( double c, const hiopVector& ix)=0;
 
-  // TODO: names of copyTo/FromStarting methods are quite confusing 
-  //maybe startingAtCopyFromStartingAt startingAtCopyToStartingAt ?
-  /// @brief Copy the elements of v
-  virtual void copyFrom(const hiopVector& v ) = 0;
-  virtual void copyFrom(const double* v_local_data) = 0; //v should be of length at least n_local_
+  /**
+   * @brief Set all elements to zero.
+   */
+  virtual void setToZero() = 0;
+
+  /**
+   * @brief Set all elements to zero.
+   *
+   * @param[in] c - constant
+   */
+  virtual void setToConstant( double c ) = 0;
+
+  /**
+   * @brief Set all elements to random values uniformly distributed between `minv` and `maxv`.
+   *
+   * @param[in] minv - the minimun value
+   * @param[in] maxv - the maximun value
+   */
+  virtual void set_to_random_uniform(double minv, double maxv) = 0;
+
+  /**
+   * @brief Set selected elements to `c`, and the rest to 0
+   *
+   * @param[in] c - constant
+   * @param[in] select - pattern selection
+   */
+  virtual void setToConstant_w_patternSelect(double c, const hiopVector& select)=0;
+
+  /**
+   * @brief Copy data from `vec` to this vector
+   *
+   * @param[in] vec - Vector from which to copy into `this`
+   *
+   * @pre `vec` and `this` must have same partitioning.
+   * @post Elements of `this` are overwritten with elements of `vec`
+   */
+  virtual void copyFrom(const hiopVector& vec) = 0;
+
+  /**
+   * @brief Copy data from local_array to this vector
+   *
+   * @param[in] local_array - A raw array from which to copy into `this`
+   *
+   * @pre `local_array` is allocated by same memory backend and in the same 
+   * memory space used by `this`.
+   * @pre `local_array` must be of same size as the data block of `this`.
+   * @post Elements of `this` are overwritten with elements of `local_array`.
+   *
+   * @warning Method has no way to check for the size of `local_array`. May
+   * read past the end of the array.
+   *
+   * @warning Method casts away const from the `local_array`.
+   *
+   * @warning Not tested - not part of the hiopVector interface.
+   */
+  virtual void copyFrom(const double* local_array) = 0;
+
+  /// @
+  /**
+   * @brief Copy data from `vec` to `this` vector with pattern selection
+   *
+   * @param[in] vec - Vector from which to copy into `this`
+   * @param[in] select - indices of the elements to copy
+   *
+   * @pre `vec`, `select` and `this` must have same partitioning.
+   * @post Elements of `this` are overwritten with elements of `vec`
+   */
   virtual void copy_from_w_pattern(const hiopVector& src, const hiopVector& select) = 0;
-  /// @brief Copy the 'n' elements of v starting at 'start_index_in_this' in 'this'
-  virtual void copyFromStarting(int start_index_in_this, const double* v, int n) = 0;
-  /// @brief Copy v in 'this' starting at start_index_in_src in  'this'. */
-  virtual void copyFromStarting(int start_index_in_src, const hiopVector& v) = 0;
-  /// @brief Copy the 'n' elements of v starting at 'start_index_in_v' into 'this'
+
+  /**
+   * @brief Copy `nv` elements from array `v` to this vector starting from `start_index_in_this`
+   *
+   * @param[in] start_index_in_this - position in this where to copy
+   * @param[in] v - a raw array from which to copy into `this`
+   * @param[in] nv - how many elements of `v` to copy
+   *
+   * @pre Size of `v` must be >= nv.
+   * @pre start_index_in_this+nv <= n_local_
+   * @pre `this` is not distributed
+   * @pre `v` should be allocated in the memory space/backend of `this`
+   *
+   * @warning Method casts away const from the `v`.
+   */
+  virtual void copyFromStarting(int start_index_in_this, const double* v, int nv) = 0;
+
+  /**
+   * @brief Copy `vec` to this vector starting from `start_index` in `this`.
+   *
+   * @param[in] start_index - position in `this` where to copy
+   * @param[in] src - the source vector from which to copy into `this`
+   *
+   * @pre Size of `src` must be >= nv.
+   * @pre start_index + src.n_local_ <= n_local_
+   * @pre `this` is not distributed
+   */
+  virtual void copyFromStarting(int start_index, const hiopVector& src) = 0;
+
+
+  /**
+   * @brief Copy `nv` elements from `start_index_in_v` at array `v` to this vector
+   *
+   * @param[in] start_index_in_v - position in v
+   * @param[in] v  - a raw array from which to copy into `this`
+   * @param[in] nv - how many elements of `v` to copy
+   *
+   * @pre Size of `v` must be >= nv.
+   * @pre start_index_in_v+nv <= size of 'v'
+   * @pre `this` is not distributed
+   * @pre `v` should be allocated in the memory space/backend of `this`
+   *
+   * @warning Method casts away const from the `v`.
+   */
   virtual void copy_from_starting_at(const double* v, int start_index_in_v, int n) = 0;
 
   /** Copy to `this` the array content of the hiopVectorPar vector passed as argument.
    *
    * Host-device memory transfer will occur for device implementations.
-   * 
+   *
+   * @param[in] vsrc - the source vector from which to copy into `this`
+   *
    * @pre `this` and source vector should have the same size.
    * @pre `this` and source vector should have the same MPI distributions (and, 
    * hence, same number of local elements) when applicable.
    */
   virtual void copy_from_vectorpar(const hiopVectorPar& vsrc) = 0;
 
-  
   /**
    * @brief Copy from src the elements specified by the indices in index_in_src. 
+   *
+   * @param[in] src - the source vector from which to copy into `this`
+   * @param[in] index_in_src - position in the source vector
    *
    * @pre All vectors must reside in the same memory space. 
    * @pre Size of src must be greater or equal than size of this
    * @pre Size of index_in_src must be equal to size of this
    * @pre Elements of index_in_src must be valid (zero-based) indexes in src
-   *
    */
   virtual void copy_from_indexes(const hiopVector& src, const hiopVectorInt& index_in_src) = 0;
 
   /**
    * @brief Copy from src the elements specified by the indices in index_in_src. 
+   *
+   * @param[in] src - the raw array from which to copy into `this`
+   * @param[in] index_in_src - position in the source vector
    *
    * @pre All vectors and arrays must reside in the same memory space. 
    * @pre Size of src must be greater or equal than size of this
@@ -121,154 +220,478 @@ public:
    *
    */
   virtual void copy_from_indexes(const double* src, const hiopVectorInt& index_in_src) = 0;
-  
+
   /*
    * @brief Copy from 'v' starting at 'start_idx_src' to 'this' starting at 'start_idx_dest'
    *
-   * Elements are copied into 'this' till the end of the 'this' is reached, more exactly a number 
-   * of lenght(this) - start_idx_dest elements.
+   * @param[in] start_idx_dest - position in `this` to where to copy
+   * @param[in] v - the source vector
+   * @param[in] start_idx_src - position in `v` from where to copy
    *
-   * Precondition: The method expects that in 'v' there are at least as many elements starting 
+   * @pre Elements are copied into 'this' till the end of the 'this' is reached, more exactly a number 
+   * of lenght(this) - start_idx_dest elements.
+   * @pre The method expects that in 'v' there are at least as many elements starting 
    * 'start_idx_src' as 'this' has starting at start_idx_dest, or in other words,
    * length(this) - start_idx_dest <= length(v) - start_idx_src
    */
   virtual void startingAtCopyFromStartingAt(int start_idx_dest, const hiopVector& v, int start_idx_src) = 0;
 
-  /// @brief Copy 'this' to double array, which is assumed to be at least of 'n_local_' size.
+  /**
+   * @brief Copy `this` vector local data to `dest` buffer.
+   *
+   * @param[out] dest - destination buffer where to copy vector data to
+   *
+   * @pre Size of `dest` must be >= n_local_
+   * @pre `dest` should be on the same memory space/backend as `this`
+   *
+   * @post `this` is not modified
+   */
   virtual void copyTo(double* dest) const = 0;
 
   /** Copy the array content `this` in the hiopVectorPar passed as argument
    *
+   * @param[out] vdest - destination vector where to copy vector data to
+   *
    * Host-device memory transfer will occur for device implementations.
-   * 
+   *
    * @pre `this` and destination vector should have the same size.
    * @pre `this` and destination vector should have the same MPI distributions (and, 
    * hence, same number of local elements) when applicable.
    */
   virtual void copy_to_vectorpar(hiopVectorPar& vdest) const = 0;
-  
-  /// @brief Copy 'this' to v starting at start_index in 'this'.
-  virtual void copyToStarting(int start_index_in_src, hiopVector& v) const = 0;
-  /// @brief Copy 'this' to v starting at start_index in 'v'.
-  virtual void copyToStarting(hiopVector& v, int start_index_in_dest) const = 0;
+
+  /**
+   * @brief Copy to `vec` elements of `this` vector starting from `start_index`.
+   *
+   * @param[in] start_index - position in `this` from where to copy
+   * @param[out] dst - the destination vector where to copy elements of `this`
+   *
+   * @pre start_index + dst.n_local_ <= n_local_
+   * @pre `this` and `dst` are not distributed
+   */
+  virtual void copyToStarting(int start_index, hiopVector& dst) const = 0;
+
+  /**
+   * @brief Copy elements of `this` vector to `vec` starting at `start_index_in_dest`.
+   *
+   * @param[out] vec - a vector where to copy elements of `this`
+   * @param[in] start_index_in_dest - position in `vec` where to copy
+   *
+   * @pre start_index_in_dest + vec.n_local_ <= n_local_
+   * @pre `this` and `vec` are not distributed
+   */
+  virtual void copyToStarting(hiopVector& vec, int start_index_in_dest) const = 0;
+
+  /**
+   * @brief Copy specified elements of `this` vector to `vec` starting at `start_index_in_dest`
+   *
+   * @param[out] vec - a vector where to copy elements of `this`
+   * @param[in] start_index_in_dest - position in `vec` where to copy
+   * @param[in] ix - a nonzero pattern that implies which elements of `this` to copy
+   *
+   * @pre start_index_in_dest + vec.n_local_ <= n_local_
+   * @pre `this` and `vec` are not distributed
+   * @pre `ix` and `this` must have same partitioning.
+   */
   /// @brief Copy the entries in 'this' where corresponding 'ix' is nonzero, to v starting at start_index in 'v'.
-  virtual void copyToStartingAt_w_pattern(hiopVector& v,
+  virtual void copyToStartingAt_w_pattern(hiopVector& vec,
                                           int start_index_in_dest,
                                           const hiopVector& ix) const = 0;
 
-  /// @brief Copy the entries in `c` and `d` to `this`, according to the mapping in `c_map` and `d_map`
+  /**
+   * @brief copy 'c' and `d` into `this`, according to the map 'c_map` and `d_map`, respectively.
+   * e.g., this[c_map[i]] = c[i];
+   *
+   * @param[in] c - the 1st source vector
+   * @param[in] d - the 2nd source vector
+   * @param[in] c_map - the element mapping bewteen `this` and `c`
+   * @param[in] d_map - the element mapping bewteen `this` and `d`
+   *
+   * @pre the size of `this` = the size of `c` + the size of `d`.
+   * @pre `c_map` \Union `d_map` = {0, ..., size_of_this_vec-1}
+   */
   virtual void copy_from_two_vec_w_pattern(const hiopVector& c, 
                                            const hiopVectorInt& c_map, 
                                            const hiopVector& d, 
                                            const hiopVectorInt& d_map) = 0;
 
-  /// @brief Copy the entries in `this` to `c` and `d`, according to the mapping `c_map` and `d_map`
+  /**
+   * @brief split `this` to `c` and `d`, according to the map 'c_map` and `d_map`, respectively.
+   *
+   * @param[out] c - the 1st destination vector
+   * @param[out] d - the 2nd destination vector
+   * @param[in] c_map - the element mapping bewteen `this` and `c`
+   * @param[in] d_map - the element mapping bewteen `this` and `d`
+   *
+   * @pre the size of `this` = the size of `c` + the size of `d`.
+   * @pre `c_map` \Union `d_map` = {0, ..., size_of_this_vec-1}
+   */
   virtual void copy_to_two_vec_w_pattern(hiopVector& c, 
                                          const hiopVectorInt& c_map, 
                                          hiopVector& d, 
                                          const hiopVectorInt& d_map) const = 0;
 
   /**
-   * copy 'this' (source) starting at 'start_idx_in_src' to 'dest' starting at index 'int start_idx_dest' 
-   * If num_elems>=0, 'num_elems' will be copied; if num_elems<0, elements will be copied till the end of
-   * either source ('this') or destination ('dest') is reached
-   * if 'selec_dest' is given, the values are copy to 'dest' where the corresponding entry in 'selec_dest' is nonzero
+   * @brief Copy elements of `this` vector to `dest` with offsets.
+   *
+   * Copy `this` (source) starting at `start_idx_in_src` to `dest` 
+   * starting at index 'int start_idx_dest'. If num_elems>=0, 'num_elems' will be copied; 
+   *
+   * @param[in] start_idx_in_src - position in `this` from where to copy
+   * @param[out] dest - destination vector to where to copy vector data
+   * @param[in] start_idx_dest - position in `dest` to where to copy
+   * @param[in] num_elems - number of elements to copy
+   *
+   * @pre start_idx_in_src <= n_local_
+   * @pre start_idx_dest   <= dest.n_local_
+   * @pre `this` and `dest` are not distributed
+   * @post If num_elems >= 0, `num_elems` will be copied
+   * @post If num_elems < 0, elements will be copied till the end of
+   * either source (`this`) or `dest` is reached
    */
-  virtual void startingAtCopyToStartingAt(int start_idx_in_src, hiopVector& dest, int start_idx_dest, int num_elems=-1) const = 0;
-  virtual void startingAtCopyToStartingAt_w_pattern(int start_idx_in_src, hiopVector& dest, int start_idx_dest, const hiopVector& selec_dest, int num_elems=-1) const = 0;
+  virtual void startingAtCopyToStartingAt(index_type start_idx_in_src,
+                                          hiopVector& dest,
+                                          index_type start_idx_dest,
+                                          size_type num_elems=-1) const = 0;
 
-  /** @brief Return the two norm */
-  virtual double twonorm() const = 0;
-  /** @brief Return the infinity norm */
-  virtual double infnorm() const = 0;
   /**
-   * @brief Linf norm on single rank
+   * @brief Copy elements of `this` vector to `dest` with offsets.
+   *
+   * Copy `this` (source) starting at `start_idx_in_src` to `dest` 
+   * starting at index 'int start_idx_dest'. If num_elems>=0, 'num_elems' will be copied; 
+   *
+   * @param[in] start_idx_in_src - position in `this` from where to copy
+   * @param[out] dest - destination vector to where to copy vector data
+   * @param[in] start_idx_dest - position in `dest` to where to copy
+   * @param[in] selec_dest - a nonzero pattern that implies which elements of `dest` should be overwritten
+   * @param[in] num_elems - number of elements to copy
+   *
+   * @pre start_idx_in_src <= n_local_
+   * @pre start_idx_dest   <= dest.n_local_
+   * @pre `this` and `dest` are not distributed
+   * @post If num_elems >= 0, `num_elems` will be copied
+   * @post If num_elems < 0, elements will be copied till the end of
+   * either source (`this`) or `dest` is reached
+   */
+  virtual void startingAtCopyToStartingAt_w_pattern(index_type start_idx_in_src,
+                                                    hiopVector& dest,
+                                                    index_type start_idx_dest,
+                                                    const hiopVector& selec_dest,
+                                                    size_type num_elems=-1) const = 0;
+
+  /**
+   * @brief L2 vector norm.
+   *
+   * @post `this` is not modified
+   */
+  virtual double twonorm() const = 0;
+
+  /**
+   * @brief L-infinity (max) vector norm.
+   *
+   * @post `this` is not modified
+   */
+  virtual double infnorm() const = 0;
+
+  /**
+   * @brief Local L-infinity (max) vector norm.
+   *
+   * @pre  `this` is not empty vector
+   * @post `this` is not modified
    */
   virtual double infnorm_local() const = 0;
-  /** @brief Return the one norm */
-  virtual double onenorm() const = 0;
+
   /**
-   * @brief L1 norm on single rank
+   * @brief 1-norm of `this` vector.
+   *
+   * @post `this` is not modified
+   */
+  virtual double onenorm() const = 0;
+
+  /**
+   * @brief Local 1-norm of `this` vector.
+   *
+   * @pre  `this` is not empty vector
+   * @post `this` is not modified
    */
   virtual double onenorm_local() const = 0;
 
-  /** @brief Multiply the components of this by the components of v. */
-  virtual void componentMult( const hiopVector& v ) = 0;
-  /** @brief Divide the components of this hiopVector by the components of v. */
-  virtual void componentDiv ( const hiopVector& v ) = 0;
   /**
-   * @brief Elements of this that corespond to nonzeros in ix are divided by elements of v.
-   * The rest of elements of this are set to zero.
+   * @brief Multiply `this` by `vec` elementwise and store result in `this`.
+   *
+   * @param[in] vec - input vector
+   *
+   * @pre  `this` and `vec` have same partitioning.
+   * @post `vec` is not modified
    */
-  virtual void componentDiv_w_selectPattern( const hiopVector& v, const hiopVector& ix) = 0;
+  virtual void componentMult( const hiopVector& vec ) = 0;
 
-  /** @brief Set each component of this hiopVector to the minimum of itself and the given constant. */
+  /**
+   * @brief Divide `this` vector elemenwise in-place by `vec`. 
+   *
+   * @param[in] vec - input vector
+   *
+   * @pre `this` and `vec` have same partitioning.
+   * @pre vec[i] != 0 forall i
+   * @post `vec` is not modified
+   */
+  virtual void componentDiv ( const hiopVector& vec ) = 0;
+
+  /**
+   * @brief Divide `this` vector elemenwise in-place by `vec`
+   * with pattern selection. 
+   *
+   * @param[in] vec - input vector
+   * @param[in] select - pattern selection
+   *
+   * @pre `this`, `select` and `vec` have same partitioning.
+   * @pre vec[i] != 0 when select[i] = 1
+   * @post `vec` and `select` are not modified
+   */
+  virtual void componentDiv_w_selectPattern(const hiopVector& vec, const hiopVector& select) = 0;
+
+  /**
+   * @brief Set `this` vector elemenwise to the minimum of itself and the given `constant`
+   *
+   * @param[in] constant - input constant
+   */
   virtual void component_min(const double constant) = 0;
-  /** @brief Set each component of this hiopVector to the minimum of itself and the corresponding component of 'v'. */
-  virtual void component_min(const hiopVector& v ) = 0;
-  /** @brief Set each component of this hiopVector to the maximum of itself and the given constant. */
+
+  /**
+   * @brief Set `this` vector elemenwise to the minimum of itself and the corresponding component of 'vec'.
+   *
+   * @param[in] vec - input vector
+   *
+   * @pre `this` and `vec` have same partitioning.
+   * @post `vec` is not modified
+   */
+  virtual void component_min(const hiopVector& vec) = 0;
+
+  /**
+   * @brief Set `this` vector elemenwise to the maximum of itself and the given `constant`
+   *
+   * @param[in] constant - input constant
+   */
   virtual void component_max(const double constant) = 0;
-  /** @brief Set each component of this hiopVector to the maximum of itself and the corresponding component of 'v'. */
+
+  /**
+   * @brief Set `this` vector elemenwise to the maximum of itself and the corresponding component of 'vec'.
+   *
+   * @param[in] vec - input vector
+   *
+   * @pre `this` and `vec` have same partitioning.
+   * @post `vec` is not modified
+   */
   virtual void component_max(const hiopVector& v) = 0;
-  /** @brief Set each component to its absolute value */
+
+  /**
+   * @brief Set each component to its absolute value
+   */
   virtual void component_abs() = 0;
-  /** @brief Apply sign function to each component */
+
+  /**
+   * @brief Apply sign function to each component
+   */
   virtual void component_sgn() = 0;
-  /** @brief compute sqrt of each component */
+
+  /**
+   * @brief compute square root of each element
+   * @pre all the elements are non-negative
+   */
   virtual void component_sqrt() = 0;
 
-  /// @brief Scale each element of this  by the constant alpha
-  virtual void scale(double alpha) = 0;
-  /// @brief this += alpha * x
-  virtual void axpy(double alpha, const hiopVector& x) = 0;
-  /// @brief this += alpha * x, for the entries in 'this' where corresponding 'select' is nonzero.
-  virtual void axpy_w_pattern(double alpha, const hiopVector& x, const hiopVector& select) = 0;
+  /**
+   * @brief Scale `this` vector by `c` 
+   *
+   * @param[in] c - scaling factor
+   */
+  virtual void scale(double c) = 0;
+
+  /**
+   * @brief Implementation of AXPY kernel. this += alpha * x
+   *
+   * @param[in] alpha - scaling factor
+   * @param[in] xvec - vector of doubles to be axpy-ed to this (size equal to size of this)
+   *
+   * @pre `this` and `xvec` have same partitioning.
+   * @post `xvec` is not modified
+   *
+   * @note Consider implementing with BLAS call (<D>AXPY)
+   */
+  virtual void axpy(double alpha, const hiopVector& xvec) = 0;
+
+  /**
+   * @brief Implementation of AXPY kernel, for selected entries. 
+   * this[i] += alpha * x[i] for all i where select[i] == 1.0;
+   *
+   * @param[in] alpha - scaling factor
+   * @param[in] xvec - vector of doubles to be axpy-ed to this (size equal to size of this)
+   * @param[in] select - pattern selection
+   *
+   * @pre `this`, `select` and `xvec` have same partitioning.
+   * @post `xvec` and `select` is not modified
+   *
+   * @note Consider implementing with BLAS call (<D>AXPY)
+   */
+  virtual void axpy_w_pattern(double alpha, const hiopVector& xvec, const hiopVector& select) = 0;
 
   /**
    * @brief Performs axpy, this += alpha*x, on the indexes in this specified by i.
-   * 
-   * @param alpha scaling factor 
-   * @param x vector of doubles to be axpy-ed to this (size equal to size of i and less than or equal to size of this)
-   * @param i vector of indexes in this to which the axpy operation is performed (size equal to size of x and less than 
-   * or equal to size of this)
+   *
+   * @param[in] alpha - scaling factor 
+   * @param[in] xvec - vector of doubles to be axpy-ed to this
+   *  (size equal to size of i and less than or equal to size of this)
+   * @param[in] i - vector of indexes in this to which the axpy operation is performed
+   *  (size equal to size of x and less than or equal to size of this)
    *
    * @pre The entries of i must be valid (zero-based) indexes in this
-   *
    */
-  virtual void axpy(double alpha, const hiopVector& x, const hiopVectorInt& i) = 0;
+  virtual void axpy(double alpha, const hiopVector& xvec, const hiopVectorInt& i) = 0;
   
-  /// @brief this += alpha * x * z
-  virtual void axzpy ( double alpha, const hiopVector& x, const hiopVector& z ) = 0;
-  /// @brief this += alpha * x / z
-  virtual void axdzpy( double alpha, const hiopVector& x, const hiopVector& z ) = 0;
-  /// @brief this += alpha * x / z on entries 'i' for which select[i]==1.
-  virtual void axdzpy_w_pattern( double alpha, const hiopVector& x, const hiopVector& z,
-				 const hiopVector& select ) = 0; 
-  /// @brief Add c to the elements of this
-  virtual void addConstant( double c ) = 0;
-  virtual void addConstant_w_patternSelect(double c, const hiopVector& ix) = 0;
-  /// @brief Return the dot product of this hiopVector with v
-  virtual double dotProductWith( const hiopVector& v ) const = 0;
-  /// @brief Negate all the elements of this
+  /**
+   * @brief this[i] += alpha*x[i]*z[i] forall i
+   *
+   * @param[in] alpha - scaling factor
+   * @param[in] xvec - vector of doubles to be axzpy-ed to this 
+   * @param[in] zvec - vector of doubles to be axzpy-ed to this 
+   *
+   * @pre `this`, `xvec` and `zvec` have same partitioning.
+   * @post `xvec` and `zvec` are not modified
+   */
+  virtual void axzpy (double alpha, const hiopVector& xvec, const hiopVector& zvec) = 0;
+
+  /**
+   * @brief this[i] += alpha*x[i]/z[i] forall i
+   *
+   * @param[in] alpha - scaling factor
+   * @param[in] xvec - vector of doubles to be axdzpy-ed to this 
+   * @param[in] zvec - vector of doubles to be axdzpy-ed to this 
+   *
+   * @pre `this`, `xvec` and `zvec` have same partitioning.
+   * @pre zvec[i] != 0 forall i
+   * @post `xvec` and `zvec` are not modified
+   */
+  virtual void axdzpy(double alpha, const hiopVector& xvec, const hiopVector& zvec) = 0;
+
+  /**
+   * @brief this[i] += alpha*x[i]/z[i] forall i with pattern selection
+   *
+   * @param[in] alpha - scaling factor
+   * @param[in] xvec - vector of doubles to be axdzpy-ed to this 
+   * @param[in] zvec - vector of doubles to be axdzpy-ed to this 
+   * @param[in] select - pattern selection
+   *
+   * @pre `this`, `xvec`, `zvec` and `select` have same partitioning.
+   * @pre zvec[i] != 0 when select[i] = 1
+   * @post `xvec`, `zvec` and `select` are not modified
+   */
+  virtual void axdzpy_w_pattern(double alpha,
+                                const hiopVector& xvec,
+                                const hiopVector& zvec,
+                                const hiopVector& select) = 0;
+
+  /**
+   * @brief this[i] += c forall i
+   *
+   * @param[in] c - a constant that is added to each element of `this`
+   */
+  virtual void addConstant(double c) = 0;
+
+  /**
+   * @brief this[i] += c forall i with pattern selection
+   *
+   * @param[in] c - a constant that is added to each element of `this`
+   * @param[in] select - pattern selection
+   *
+   * @pre `this` and `select` have same partitioning.
+   * @post `select` is not modified
+   */
+  virtual void addConstant_w_patternSelect(double c, const hiopVector& select) = 0;
+
+  /**
+   * @brief scalar (dot) product.
+   *
+   * @param[in] vec - vector which is scalar-multiplied to `this`.
+   *
+   * @pre `vec` has same size and partitioning as `this`.
+   * @post `this` and `vec` are not modified.
+   *
+   * @todo Consider implementing with BLAS call (<D>DOT).
+   */
+  virtual double dotProductWith(const hiopVector& vec) const = 0;
+
+  /**
+   * @brief Negate all vector elements
+   *
+   * @note Consider implementing with BLAS call (<D>SCAL)
+   */
   virtual void negate() = 0;
-  /// @brief Invert (1/x) the elements of this
+
+  /**
+   * @brief Invert vector elements
+   *
+   * @pre this[i] != 0 forall i
+   * @post `this` is overwritten
+   *
+   * @todo Consider having HiOp-wide `small_real` constant defined.
+   */
   virtual void invert() = 0;
-  /// @brief compute log barrier term, that is sum{ln(x_i):i=1,..,n}
+
+  /**
+   * @brief Sum all selected log(this[i])
+   *
+   * @param[in] select - pattern selection
+   *
+   * @pre `this` and `select` have same partitioning.
+   * @pre Selected elements of `this` are > 0.
+   * @post `this` and `select` are not modified
+   *
+   * @warning This is local method only!
+   */
   virtual double logBarrier_local(const hiopVector& select) const = 0;
-  /// @brief adds the gradient of the log barrier, namely this=this+alpha*1/select(x)
-  virtual void addLogBarrierGrad(double alpha, const hiopVector& x, const hiopVector& select)=0;
-  /// @brief compute sum{(x_i):i=1,..,n}
+
+  /**
+   * @brief adds the gradient of the log barrier, namely this[i]=this[i]+alpha*1/select(x[i])
+   *
+   * @param[in] alpha - scaling factor
+   * @param[in] xvec - vector of the gradient of the log barrier
+   * @param[in] select - pattern selection
+   *
+   * @pre `this`, `xvec` and `select` have same partitioning.
+   * @pre xvec[i] != 0 forall i
+   * @post `xvec` and `select` are not modified
+   */
+  virtual void addLogBarrierGrad(double alpha, const hiopVector& xvec, const hiopVector& select) = 0;
+
+  /**
+   * @brief Sum all elements
+   */
   virtual double sum_local() const = 0;
 
   /**
-   * @brief Computes the log barrier's linear damping term of the Filter-IPM method of 
+   * @brief Linear damping term
+   * Computes the log barrier's linear damping term of the Filter-IPM method of 
    * WaectherBiegler (see paper, section 3.7).
    * Essentially compute  kappa_d*mu* \sum { this[i] | ixleft[i]==1 and ixright[i]==0 }
+   *
+   * @param[in] ixleft - pattern selection 1
+   * @param[in] ixright - pattern selection 2
+   * @param[in] mu - constant used in the above equation
+   * @param[in] kappa_d - constant used in the above equation
+   *
+   * @pre `this`, `ixleft` and `ixright` have same partitioning.
+   * @pre `ixleft` and `ixright` elements are 0 or 1 only.
+   * @post `this`, `ixleft` and `ixright` are not modified
+   *
+   * @warning This is local method only!
    */
-  virtual double linearDampingTerm_local(const hiopVector& ixleft, const hiopVector& ixright, 
-					 const double& mu, const double& kappa_d) const=0;
+  virtual double linearDampingTerm_local(const hiopVector& ixleft,
+                                         const hiopVector& ixright,
+                                         const double& mu,
+                                         const double& kappa_d) const = 0;
 
-  /** 
+  /**
+   * @brief add linear damping term
    * Performs `this[i] = alpha*this[i] + sign*ct` where sign=1 when EXACTLY one of 
    * ixleft[i] and ixright[i] is 1.0 and sign=0 otherwise. 
    *
@@ -277,85 +700,314 @@ public:
    *
    * This method is used to add gradient contributions from the (linear) damping term used
    * to handle unbounded problems. The damping terms are used for variables that are 
-   * bounded on one side only. 
+   * bounded on one side only.
+   *
+   * @param[in] ixleft - pattern selection 1
+   * @param[in] ixright - pattern selection 2
+   * @param[in] alpha - constant used in the above equation
+   * @param[in] ct - constant used in the above equation
    */
   virtual void addLinearDampingTerm(const hiopVector& ixleft,
                                     const hiopVector& ixright,
                                     const double& alpha,
                                     const double& ct) = 0;
 
-  /// @brief True if all elements of this are positive.
+  /**
+   * @brief Check if all elements of the vector are positive
+   *
+   * @post `this` is not modified
+   */
   virtual int allPositive() = 0;
-  /// @brief True if elements corresponding to nonzeros in w are all positive
-  virtual int allPositive_w_patternSelect(const hiopVector& w) = 0;
-  /// @brief Return the minimum value in this vector
+
+  /**
+   * @brief Checks if selected elements of `this` are positive.
+   *
+   * @param[in] select - pattern selection
+   *
+   * @pre `this` and `select` have same partitioning.
+   * @pre Elements of `select` are either 0 or 1.
+   * @post `select` is not modified
+   */
+  virtual int allPositive_w_patternSelect(const hiopVector& select) = 0;
+
+  /**
+   * @brief Return the minimum value in `this` vector
+   */
   virtual double min() const = 0;
+
+  /**
+   * @brief Return the minimum value in selected elements of `this` vector
+   *
+   * @param[in] select - pattern selection
+   *
+   * @pre `this` and `select` have same partitioning.
+   * @pre Elements of `select` are either 0 or 1.
+   * @post `select` is not modified
+   */
   virtual double min_w_pattern(const hiopVector& select) const = 0;
-  /// @brief Return the minimum value in this vector, and the index at which it occurs.
-  virtual void min( double& m, int& index ) const = 0;
-  /// @brief Project the vector into the bounds, used for shifting the ini pt in the bounds
-  virtual bool projectIntoBounds_local(const hiopVector& xl, const hiopVector& ixl, 
-				       const hiopVector& xu, const hiopVector& ixu,
-				       double kappa1, double kappa2) = 0;
-  /// @brief max{a\in(0,1]| x+ad >=(1-tau)x}
-  virtual double fractionToTheBdry_local(const hiopVector& dx, const double& tau) const = 0;
-  virtual double fractionToTheBdry_w_pattern_local(const hiopVector& dx,
+
+  /**
+   * @brief Return the minimum value in this vector, and the index at which it occurs
+   *
+   * @param[out] minval - minimum value in `this` vector
+   * @param[out] index - the index at which the minimum occurs.
+   */
+  virtual void min(double& minval, int& index) const = 0;
+
+  /**
+   * @brief Project solution (`this`) into bounds
+   * This method is used to shift the initial point into the lower/upper bounds
+   *
+   * @param[in] xlo - lower bounds
+   * @param[in] ixl - indices for the lower bounds
+   * @param[in] xup - upper bounds
+   * @param[in] ixu - indices for the upper bounds
+   * @param[in] kappa1 - user parameter which is used to control the projection
+   * @param[in] kappa2 - user parameter which is used to control the projection
+   *
+   * @pre `this`, `xlo`, `ixl`, `xup` and `ixu` have same partitioning.
+   * @pre `ixl` and `ixu` elements are 0 or 1 only.
+   * @post `xlo`, `ixl`, `xup` and `ixu` are not modified
+   *
+   * @warning This is local method only!
+   */
+  virtual bool projectIntoBounds_local(const hiopVector& xlo, 
+                                       const hiopVector& ixl,
+                                       const hiopVector& xup,
+                                       const hiopVector& ixu,
+                                       double kappa1,
+                                       double kappa2) = 0;
+
+  /**
+   * @brief max{a\in(0,1]| x+dvec >=(1-tau)x}, where x is `this`
+   *
+   * @param[in] dvec - vector used in the above equation
+   * @param[in] tau - user parameter
+   *
+   * @pre `this` and `dvec` have same partitioning.
+   * @post `this` and `dvec` are not modified
+   *
+   * @warning This is local method only!
+   */
+  virtual double fractionToTheBdry_local(const hiopVector& dvec, const double& tau) const = 0;
+
+  /**
+   * @brief max{a\in(0,1]| x+dvec >=(1-tau)x} with pattern select
+   *
+   * @param[in] dvec - vector used in the above equation
+   * @param[in] tau - user parameter
+   * @param[in] select - pattern selection
+   *
+   * @pre `this`, `select` and `dvec` have same partitioning.
+   * @pre Elements of `select` are either 0 or 1.
+   * @post `this`, `select` and `dvec` are not modified
+   *
+   * @warning This is local method only!
+   */
+  virtual double fractionToTheBdry_w_pattern_local(const hiopVector& dvec,
                                                    const double& tau,
-                                                   const hiopVector& ix) const = 0;
-  /// @brief Entries corresponding to zeros in ix are set to zero
-  virtual void selectPattern(const hiopVector& ix) = 0;
+                                                   const hiopVector& select) const = 0;
+
+  /**
+   * @brief Set elements of `this` to zero based on `select`.
+   *
+   * @param[in] select - pattern selection
+   *
+   * @pre `this` and `select` have same partitioning.
+   * @pre Elements of `select` are either 0 or 1.
+   * @post `select` is not modified
+   */
+  virtual void selectPattern(const hiopVector& select) = 0;
   /// @brief checks whether entries in this matches pattern in ix
-  virtual bool matchesPattern(const hiopVector& ix) = 0;
 
-  /// @brief dual adjustment -> see hiopIterate::adjustDuals_primalLogHessian
-  virtual void adjustDuals_plh(const hiopVector& x, const hiopVector& ix, const double& mu, const double& kappa) = 0;
+  /**
+   * @brief Checks if `this` matches nonzero pattern of `select`.
+   *
+   * @param[in] select - pattern selection
+   *
+   * @pre `this` and `select` have same partitioning.
+   * @pre Elements of `select` are either 0 or 1.
+   * @post `select` is not modified
+   */
+  virtual bool matchesPattern(const hiopVector& select) = 0;
 
-  /// @brief True if all elements of this are zero. TODO: add unit test
+  /**
+   * @brief Adjusts duals.
+   *
+   * @param[in] xvec - vector used in the computation
+   * @param[in] ixvec - indices used in the computation
+   * @param[in] mu - constant
+   * @param[in] kappa - user parameter
+   *
+   * @pre `this`, `xvec` and `ixvec` have same partitioning.
+   * @pre Elements of `ixvec` are either 0 or 1.
+   * @post `xvec` and `ixvec` are not modified
+   *
+   * @note Implementation probably inefficient.
+   */  
+  virtual void adjustDuals_plh(const hiopVector& xvec, 
+                               const hiopVector& ixvec,
+                               const double& mu,
+                               const double& kappa) = 0;
+
+  /**
+   * @brief Check if all elements of the vector are zero
+   *
+   * @post `this` is not modified
+   * @todo: add unit test, or should we remove this function?
+   */
   virtual bool is_zero() const = 0;
-  /// @brief check for nans in the local vector
+
+  /**
+   * @brief Returns true if any element of `this` is NaN.
+   *
+   * @post `this` is not modified
+   *
+   * @warning This is local method only!
+   */
   virtual bool isnan_local() const = 0;
+
+  /**
+   * @brief Returns true if any element of `this` is Inf.
+   *
+   * @post `this` is not modified
+   *
+   * @warning This is local method only!
+   */
   /// @brief check for infs in the local vector
   virtual bool isinf_local() const = 0;
-  /// @brief check if all values are finite /well-defined floats. Returns false if nan or infs are present.
+
+  /**
+   * @brief Returns true if all elements of `this` are finite.
+   *
+   * @post `this` is not modified
+   *
+   * @warning This is local method only!
+   */
   virtual bool isfinite_local() const = 0;
   
-  /// @brief prints up to max_elems (by default all), on rank 'rank' (by default on all)
-  virtual void print(FILE* file=nullptr, const char* message=nullptr,int max_elems=-1, int rank=-1) const = 0;
-  /// @brief allocates a vector that mirrors this, but doesn't copy the values
+  /**
+   * @brief Prints vector data to a file in Matlab format.
+   *
+   * @pre Vector data was moved from the memory space to the host mirror.
+   */
+  virtual void print(FILE* file=nullptr, const char* message=nullptr, int max_elems=-1, int rank=-1) const = 0;
+
+  /**
+   * @brief allocates a vector that mirrors this, but doesn't copy the values
+   */
   virtual hiopVector* alloc_clone() const = 0;
-  /// @brief allocates a vector that mirrors this, and copies the values
+
+  /**
+   * @brief allocates a vector that mirrors this, and copies the values
+   */
   virtual hiopVector* new_copy () const = 0;
+
+  /**
+   * @brief return the global size of `this` vector
+   */
   virtual size_type get_size() const { return n_; }
+
+  /**
+   * @brief return the size of the local part of `this` vector
+   */
   virtual size_type get_local_size() const = 0;
+
+  /**
+   * @brief accessor to the local data of `this` vector
+   */
   virtual double* local_data() = 0;
+
+  /**
+   * @brief accessor to the local data of `this` vector
+   */
   virtual const double* local_data_const() const = 0;
+
+  /**
+   * @brief accessor to the local data of `this` vector
+   */
   virtual double* local_data_host() = 0;
+
+  /**
+   * @brief accessor to the local data of `this` vector
+   */
   virtual const double* local_data_host_const() const = 0;
   
-  /// @brief get number of values that are less than the given value 'val'. TODO: add unit test
+  /**
+   * @brief get the number of values that are less than the given tolerance 'val'.
+   *
+   * @param[in] val - tolerance
+   *
+   * @post `val` is not modified
+   * @todo: add unit test
+   */
   virtual size_type numOfElemsLessThan(const double &val) const = 0;
-  /// @brief get number of values whose absolute value are less than the given value 'val'. TODO: add unit test
+
+  /**
+   * @brief get the number of values whose absolute value are less than the given tolerance 'val'.
+   *
+   * @param[in] val - tolerance
+   *
+   * @post `val` is not modified
+   * @todo: add unit test
+   */
   virtual size_type numOfElemsAbsLessThan(const double &val) const = 0;  
 
-  /// @brief set int array 'arr', starting at `start` and ending at `end`, to the values in `arr_src` from 'start_src`
-  /// TODO: add unit test
+  /**
+   * @brief set enum-type array 'arr', starting at `start` and ending at `end`, 
+   * to the values in array `arr_src` from 'start_src`
+   *
+   * @param[out] arr - array of used to define hiopInterfaceBase::NonlinearityType
+   * @param[in] start - the first position to update `arr`
+   * @param[in] end - the last position to update `arr`
+   * @param[in] arr_src - the source array of type hiopInterfaceBase::NonlinearityType
+   * @param[in] start_src - the first position of `arr_src` to be copied from
+   *
+   * @pre the size of `arr_src` >= start - end + start_src
+   * @pre the size of `arr` >= start - end
+   * @post `arr` is modified
+   * @post `arr_src` is not modified
+   * @todo: add unit test
+   */
   virtual void set_array_from_to(hiopInterfaceBase::NonlinearityType* arr, 
                                  const int start, 
                                  const int end, 
                                  const hiopInterfaceBase::NonlinearityType* arr_src,
                                  const int start_src) const = 0;
+
+  /**
+   * @brief set enum-type array 'arr', starting at `start` and ending at `end`, 
+   * to the values in array `arr_src` from 'start_src`
+   *
+   * @param[out] arr - array of used to define hiopInterfaceBase::NonlinearityType
+   * @param[in] start - the first position to update `arr`
+   * @param[in] end - the last position to update `arr`
+   * @param[in] arr_src - constant of type hiopInterfaceBase::NonlinearityType
+   *
+   * @pre the size of `arr` >= start - end
+   * @post `arr` is modified
+   * @post `arr_src` is not modified
+   * @todo: add unit test
+   */
   virtual void set_array_from_to(hiopInterfaceBase::NonlinearityType* arr, 
                                  const int start, 
                                  const int end, 
                                  const hiopInterfaceBase::NonlinearityType arr_src) const = 0;
 
-  /// @brief check if `this` vector is identical to `vec`
+  /**
+   * @brief check if `this` vector is identical to `vec`
+   *
+   * @param[in] vec - vector used to be compared with `this`
+   * @todo: add unit test, or should we remove this function?
+   */
   virtual bool is_equal(const hiopVector& vec) const = 0;
 
 protected:
   size_type n_; //we assume sequential data
 protected:
-  /// for internal use only; derived classes may use copy constructor and always allocate data_
+  /**
+   * @brief for internal use only; derived classes may use copy constructor and always allocate data_
+   */
   hiopVector(const hiopVector& v)
     : n_(v.n_)
   {

--- a/src/LinAlg/hiopVectorCuda.cpp
+++ b/src/LinAlg/hiopVectorCuda.cpp
@@ -379,10 +379,10 @@ void hiopVectorCuda::copy_to_two_vec_w_pattern(hiopVector& c,
 }
 
 /// @brief Copy `this` (source) starting at `start_idx_in_src` to `dest` starting at index `int start_idx_dest` 
-void hiopVectorCuda::startingAtCopyToStartingAt(int start_idx_in_src, 
+void hiopVectorCuda::startingAtCopyToStartingAt(index_type start_idx_in_src,
                                                 hiopVector& dest, 
-                                                int start_idx_dest, 
-                                                int num_elems /* = -1 */) const
+                                                index_type start_idx_dest,
+                                                size_type num_elems  /* = -1 */) const
 {
 #ifdef HIOP_DEEPCHECKS
   assert(n_local_==n_ && "only for local/non-distributed vectors");

--- a/src/LinAlg/hiopVectorHip.cpp
+++ b/src/LinAlg/hiopVectorHip.cpp
@@ -382,10 +382,10 @@ void hiopVectorHip::copy_to_two_vec_w_pattern(hiopVector& c,
 }
 
 /// @brief Copy 'this' (source) starting at 'start_idx_in_src' to 'dest' starting at index 'int start_idx_dest' 
-void hiopVectorHip::startingAtCopyToStartingAt(int start_idx_in_src, 
+void hiopVectorHip::startingAtCopyToStartingAt(index_type start_idx_in_src,
                                                 hiopVector& dest, 
-                                                int start_idx_dest, 
-                                                int num_elems /* = -1 */) const
+                                                index_type start_idx_dest,
+                                                size_type num_elems  /* = -1 */) const
 {
 #ifdef HIOP_DEEPCHECKS
   assert(n_local_==n_ && "only for local/non-distributed vectors");

--- a/src/LinAlg/hiopVectorHip.cpp
+++ b/src/LinAlg/hiopVectorHip.cpp
@@ -383,9 +383,9 @@ void hiopVectorHip::copy_to_two_vec_w_pattern(hiopVector& c,
 
 /// @brief Copy 'this' (source) starting at 'start_idx_in_src' to 'dest' starting at index 'int start_idx_dest' 
 void hiopVectorHip::startingAtCopyToStartingAt(index_type start_idx_in_src,
-                                                hiopVector& dest, 
-                                                index_type start_idx_dest,
-                                                size_type num_elems  /* = -1 */) const
+                                               hiopVector& dest, 
+                                               index_type start_idx_dest,
+                                               size_type num_elems  /* = -1 */) const
 {
 #ifdef HIOP_DEEPCHECKS
   assert(n_local_==n_ && "only for local/non-distributed vectors");

--- a/src/LinAlg/hiopVectorHip.hpp
+++ b/src/LinAlg/hiopVectorHip.hpp
@@ -94,8 +94,8 @@ public:
   virtual void setToConstant_w_patternSelect(double c, const hiopVector& select);
 
   /// @brief Copy the elements of v
-  virtual void copyFrom(const hiopVector& v );
-  virtual void copyFrom(const double* v_local_data);
+  virtual void copyFrom(const hiopVector& vec);
+  virtual void copyFrom(const double* local_array);
   /// @brief Copy from vec the elements specified by the indices in select
   virtual void copy_from_w_pattern(const hiopVector& src, const hiopVector& select);
   /// @brief Copy the 'n' elements of v starting at 'start_index_in_dest' in 'this'
@@ -121,11 +121,11 @@ public:
   /// @brief Copy 'this' to double array, which is assumed to be at least of 'n_local_' size.
   virtual void copyTo(double* dest) const;
   /// @brief Copy 'this' to dst starting at start_index in 'this'.
-  virtual void copyToStarting(int start_index_in_src, hiopVector& v) const;
+  virtual void copyToStarting(int start_index, hiopVector& dst) const;
   /// @brief Copy 'this' to dst starting at start_index in 'dst'.
   virtual void copyToStarting(hiopVector& dst, int start_index_in_dest) const;
   /// @brief Copy the entries in 'this' where corresponding 'ix' is nonzero, to v starting at start_index in 'v'.
-  virtual void copyToStartingAt_w_pattern(hiopVector& v, int start_index_in_dest, const hiopVector& ix) const;
+  virtual void copyToStartingAt_w_pattern(hiopVector& vec, int start_index_in_dest, const hiopVector& ix) const;
 
   /// @brief Copy the entries in `c` and `d` to `this`, according to the mapping in `c_map` and `d_map`
   virtual void copy_from_two_vec_w_pattern(const hiopVector& c, 
@@ -181,7 +181,7 @@ public:
   /** @brief Set each component of this hiopVector to the minimum of itself and the given constant. */
   virtual void component_min(const double constant);
   /** @brief Set each component of this hiopVector to the minimum of itself and the corresponding component of 'v'. */
-  virtual void component_min(const hiopVector& v );
+  virtual void component_min(const hiopVector& vec);
   /** @brief Set each component of this hiopVector to the maximum of itself and the given constant. */
   virtual void component_max(const double constant);
   /** @brief Set each component of this hiopVector to the maximum of itself and the corresponding component of 'v'. */
@@ -196,7 +196,7 @@ public:
   /// @brief Scale each element of this  by the constant alpha
   virtual void scale(double alpha);
   /// @brief this += alpha * x
-  virtual void axpy(double alpha, const hiopVector& x);
+  virtual void axpy(double alpha, const hiopVector& xvec);
   /// @brief this += alpha * x, for the entries in 'this' where corresponding 'select' is nonzero.
   virtual void axpy_w_pattern(double alpha, const hiopVector& xvec, const hiopVector& select);
 
@@ -211,19 +211,22 @@ public:
    * @pre The entries of i must be valid (zero-based) indexes in this
    *
    */
-  virtual void axpy(double alpha, const hiopVector& x, const hiopVectorInt& i);
+  virtual void axpy(double alpha, const hiopVector& xvec, const hiopVectorInt& i);
 
   /// @brief this += alpha * x * z
-  virtual void axzpy ( double alpha, const hiopVector& x, const hiopVector& z );
+  virtual void axzpy (double alpha, const hiopVector& xvec, const hiopVector& zvec);
   /// @brief this += alpha * x / z
-  virtual void axdzpy( double alpha, const hiopVector& x, const hiopVector& z );
+  virtual void axdzpy(double alpha, const hiopVector& xvec, const hiopVector& zvec);
   /// @brief this += alpha * x / z on entries 'i' for which select[i]==1.
-  virtual void axdzpy_w_pattern( double alpha, const hiopVector& x, const hiopVector& z, const hiopVector& select );
+  virtual void axdzpy_w_pattern(double alpha,
+                                const hiopVector& xvec,
+                                const hiopVector& zvec,
+                                const hiopVector& select);
   /// @brief Add c to the elements of this
-  virtual void addConstant( double c );
-  virtual void addConstant_w_patternSelect(double c, const hiopVector& ix);
+  virtual void addConstant(double c);
+  virtual void addConstant_w_patternSelect(double c, const hiopVector& select);
   /// @brief Return the dot product of this hiopVector with v
-  virtual double dotProductWith( const hiopVector& v ) const;
+  virtual double dotProductWith(const hiopVector& vec) const;
   /// @brief Negate all the elements of this
   virtual void negate();
   /// @brief Invert (1/x) the elements of this
@@ -231,7 +234,7 @@ public:
   /// @brief compute log barrier term, that is sum{ln(x_i):i=1,..,n}
   virtual double logBarrier_local(const hiopVector& select) const;
   /// @brief adds the gradient of the log barrier, namely this=this+alpha*1/select(x)
-  virtual void addLogBarrierGrad(double alpha, const hiopVector& x, const hiopVector& select);
+  virtual void addLogBarrierGrad(double alpha, const hiopVector& xvec, const hiopVector& select);
   /// @brief compute sum{(x_i):i=1,..,n}
   virtual double sum_local() const;
 
@@ -264,12 +267,12 @@ public:
   /// @brief True if all elements of this are positive.
   virtual int allPositive();
   /// @brief True if elements corresponding to nonzeros in w are all positive
-  virtual int allPositive_w_patternSelect(const hiopVector& w);
+  virtual int allPositive_w_patternSelect(const hiopVector& select);
   /// @brief Return the minimum value in this vector
   virtual double min() const;
   virtual double min_w_pattern(const hiopVector& select) const;
   /// @brief Return the minimum value in this vector, and the index at which it occurs.
-  virtual void min( double& m, int& index ) const;
+  virtual void min(double& minval, int& index) const;
   /// @brief Project the vector into the bounds, used for shifting the ini pt in the bounds
   virtual bool projectIntoBounds_local(const hiopVector& xl,
                                        const hiopVector& ixl,
@@ -278,16 +281,19 @@ public:
                                        double kappa1,
                                        double kappa2);
   /// @brief max{a\in(0,1]| x+ad >=(1-tau)x}
-  virtual double fractionToTheBdry_local(const hiopVector& dx, const double& tau) const;
-  virtual double fractionToTheBdry_w_pattern_local(const hiopVector& dx,
+  virtual double fractionToTheBdry_local(const hiopVector& dvec, const double& tau) const;
+  virtual double fractionToTheBdry_w_pattern_local(const hiopVector& dvec,
                                                    const double& tau,
-                                                   const hiopVector& ix) const;
+                                                   const hiopVector& select) const;
   /// @brief Entries corresponding to zeros in ix are set to zero
-  virtual void selectPattern(const hiopVector& ix);
+  virtual void selectPattern(const hiopVector& select);
   /// @brief checks whether entries in this matches pattern in ix
-  virtual bool matchesPattern(const hiopVector& ix);
+  virtual bool matchesPattern(const hiopVector& select);
   /// @brief dual adjustment -> see hiopIterate::adjustDuals_primalLogHessian
-  virtual void adjustDuals_plh(const hiopVector& x, const hiopVector& ix, const double& mu, const double& kappa);
+  virtual void adjustDuals_plh(const hiopVector& xvec, 
+                               const hiopVector& ixvec,
+                               const double& mu,
+                               const double& kappa);
 
   /// @brief True if all elements of this are zero. TODO: add unit test
   virtual bool is_zero() const;

--- a/src/LinAlg/hiopVectorPar.cpp
+++ b/src/LinAlg/hiopVectorPar.cpp
@@ -368,7 +368,10 @@ void hiopVectorPar::copy_to_two_vec_w_pattern(hiopVector& c,
  * If num_elems>=0, 'num_elems' will be copied; if num_elems<0, elements will be copied till the end of
  * either source ('this') or destination ('dest') is reached */
 void hiopVectorPar::
-startingAtCopyToStartingAt(int start_idx_in_src, hiopVector& dest_, int start_idx_dest, int num_elems/*=-1*/) const
+startingAtCopyToStartingAt(index_type start_idx_in_src,
+                           hiopVector& dest_,
+                           index_type start_idx_dest,
+                           size_type num_elems/*=-1*/) const
 {
 #ifdef HIOP_DEEPCHECKS
   assert(n_local_==n_ && "only for local/non-distributed vectors");
@@ -706,7 +709,7 @@ void hiopVectorPar::axzpy(double alpha, const hiopVector& x_, const hiopVector& 
   }
 }
 
-void hiopVectorPar::axdzpy( double alpha, const hiopVector& x_, const hiopVector& z_)
+void hiopVectorPar::axdzpy(double alpha, const hiopVector& x_, const hiopVector& z_)
 {
   if(alpha==0.) return;
   const hiopVectorPar& vx = dynamic_cast<const hiopVectorPar&>(x_);
@@ -737,7 +740,7 @@ void hiopVectorPar::axdzpy( double alpha, const hiopVector& x_, const hiopVector
   }
 }
 
-void hiopVectorPar::axdzpy_w_pattern( double alpha, const hiopVector& x_, const hiopVector& z_, const hiopVector& select)
+void hiopVectorPar::axdzpy_w_pattern(double alpha, const hiopVector& x_, const hiopVector& z_, const hiopVector& select)
 {
   const hiopVectorPar& vx = dynamic_cast<const hiopVectorPar&>(x_);
   const hiopVectorPar& vz = dynamic_cast<const hiopVectorPar&>(z_);
@@ -763,7 +766,7 @@ void hiopVectorPar::axdzpy_w_pattern( double alpha, const hiopVector& x_, const 
 }
 
 
-void hiopVectorPar::addConstant( double c )
+void hiopVectorPar::addConstant(double c)
 {
   for(size_type i=0; i<n_local_; i++) data_[i]+=c;
 }

--- a/src/LinAlg/hiopVectorPar.hpp
+++ b/src/LinAlg/hiopVectorPar.hpp
@@ -103,7 +103,7 @@ public:
   virtual void copyToStarting(int start_index, hiopVector& dst) const;
   virtual void copyToStarting(hiopVector& vec, int start_index_in_dest) const;
   virtual void copyToStartingAt_w_pattern(hiopVector& vec,
-                                          int start_index_in_dest,
+                                          index_type start_index_in_dest,
                                           const hiopVector& ix) const;
 
   virtual void copy_from_two_vec_w_pattern(const hiopVector& c, 
@@ -132,7 +132,7 @@ public:
   virtual double infnorm() const;
   virtual double infnorm_local() const;
   virtual double onenorm() const;
-  virtual double onenorm_local() const; 
+  virtual double onenorm_local() const;
   virtual void componentMult( const hiopVector& v );
   virtual void componentDiv ( const hiopVector& v );
   virtual void componentDiv_w_selectPattern( const hiopVector& v, const hiopVector& ix);
@@ -145,37 +145,19 @@ public:
   virtual void component_sqrt();
 
   virtual void scale( double alpha );
-  /// @brief this += alpha * x
   virtual void axpy  ( double alpha, const hiopVector& x );
-  /// @brief this += alpha * x, for the entries in 'this' where corresponding 'select' is nonzero.
   virtual void axpy_w_pattern(double alpha, const hiopVector& xvec, const hiopVector& select);
-
-  /**
-   * @brief Performs axpy, this += alpha*x, on the indexes in this specified by i.
-   * 
-   * @param alpha scaling factor 
-   * @param x vector of doubles to be axpy-ed to this (size equal to size of i and less than or equal to size of this)
-   * @param i vector of indexes in this to which the axpy operation is performed (size equal to size of x and less than 
-   * or equal to size of this)
-   *
-   * @pre The entries of i must be valid (zero-based) indexes in this
-   *
-   */
   virtual void axpy(double alpha, const hiopVector& xvec, const hiopVectorInt& i);
-  
-  /// @brief this += alpha * x * z
   virtual void axzpy (double alpha, const hiopVector& xvec, const hiopVector& zvec);
-  /// @brief this += alpha * x / z
   virtual void axdzpy(double alpha, const hiopVector& xvec, const hiopVector& zvec);
   virtual void axdzpy_w_pattern(double alpha,
                                 const hiopVector& xvec,
                                 const hiopVector& zvec,
-                                const hiopVector& select); 
-  /// @brief Add c to the elements of this
+                                const hiopVector& select);
   virtual void addConstant(double c);
   virtual void addConstant_w_patternSelect(double c, const hiopVector& select);
   virtual double min() const;
-  virtual double min_w_pattern(const hiopVector& select) const;  
+  virtual double min_w_pattern(const hiopVector& select) const;
   virtual void min(double& minval, int& index) const;
   virtual void negate();
   virtual void invert();
@@ -232,7 +214,7 @@ public:
   virtual inline const double* local_data_host_const() const { return local_data_const(); }
  
   virtual size_type numOfElemsLessThan(const double &val) const;
-  virtual size_type numOfElemsAbsLessThan(const double &val) const;    
+  virtual size_type numOfElemsAbsLessThan(const double &val) const;
 
   virtual void set_array_from_to(hiopInterfaceBase::NonlinearityType* arr, 
                                  const int start, 

--- a/src/LinAlg/hiopVectorPar.hpp
+++ b/src/LinAlg/hiopVectorPar.hpp
@@ -83,106 +83,52 @@ public:
   virtual void set_to_random_uniform(double minv, double maxv);
   virtual void setToConstant_w_patternSelect(double c, const hiopVector& select);
 
-  virtual void copyFrom(const hiopVector& v );
-  virtual void copyFrom(const double* v_local_data); //v should be of length at least n_local_  
+  virtual void copyFrom(const hiopVector& vec);
+  virtual void copyFrom(const double* local_array);
   virtual void copy_from_w_pattern(const hiopVector& src, const hiopVector& select);
 
-  /** Copy to `this` the array content of the hiopVectorPar vector passed as argument.
-   *
-   * @pre `this` and source vector should have the same size.
-   * @pre `this` and source vector should have the same MPI distributions (and, 
-   * hence, same number of local elements) when applicable.
-   */
   virtual void copy_from_vectorpar(const hiopVectorPar& vsrc);
-  /**
-   * @brief Copy from src the elements specified by the indices in index_in_src. 
-   *
-   * @pre All vectors must reside in the same memory space. 
-   * @pre Size of src must be greater or equal than size of this
-   * @pre Size of index_in_src must be equal to size of this
-   * @pre Elements of index_in_src must be valid (zero-based) indexes in src
-   *
-   */
   virtual void copy_from_indexes(const hiopVector& src, const hiopVectorInt& index_in_src);
-  /**
-   * @brief Copy from src the elements specified by the indices in index_in_src. 
-   *
-   * @pre All vectors and arrays must reside in the same memory space. 
-   * @pre Size of src must be greater or equal than size of this
-   * @pre Size of index_in_src must be equal to size of this
-   * @pre Elements of index_in_src must be valid (zero-based) indexes in src
-   *
-   */
   virtual void copy_from_indexes(const double* src, const hiopVectorInt& index_in_src);
-  
-  /// @brief Copy the 'n' elements of v starting at 'start_index_in_this' in 'this'
-  virtual void copyFromStarting(int start_index_in_this, const double* v, int n);
-  virtual void copyFromStarting(int start_index_in_src, const hiopVector& v);
-  /// @brief Copy the 'n' elements of v starting at 'start_index_in_v' into 'this'
+
+  virtual void copyFromStarting(int start_index_in_this, const double* v, int nv);
+  virtual void copyFromStarting(int start_index, const hiopVector& src);
   virtual void copy_from_starting_at(const double* v, int start_index_in_v, int n);
-  
-    
-  /*
-   * @brief Copy from 'v' starting at 'start_idx_src' to 'this' starting at 'start_idx_dest'
-   *
-   * Elements are copied into 'this' till the end of the 'this' is reached, more exactly a number 
-   * of lenght(this) - start_idx_dest elements are copied.
-   *
-   * Precondition: The method expects that in 'v' there are at least as many elements starting 
-   * 'start_idx_src' as 'this' has starting at 'start_idx_dest', or in other words,
-   * length(this) - start_idx_dest <= length(v) - start_idx_src
-   */
+
   virtual void startingAtCopyFromStartingAt(int start_idx_dest, const hiopVector& v, int start_idx_src);
 
   virtual void copyTo(double* dest) const;
-
-  /** Copy the array content `this` in the hiopVectorPar passed as argument
-   *
-   * @pre `this` and destination vector should have the same size.
-   * @pre `this` and destination vector should have the same MPI distributions (and, 
-   * hence, same number of local elements) when applicable.
-   */
   virtual void copy_to_vectorpar(hiopVectorPar& vdest) const;
-  
-  virtual void copyToStarting(int start_index_in_src, hiopVector& v) const;
-  /// @brief Copy 'this' to v starting at start_index in 'v'.
-  virtual void copyToStarting(hiopVector& v, int start_index_in_dest) const;
-  /// @brief Copy the entries in 'this' where corresponding 'ix' is nonzero, to v starting at start_index in 'v'.
-  virtual void copyToStartingAt_w_pattern(hiopVector& v,
+
+  virtual void copyToStarting(int start_index, hiopVector& dst) const;
+  virtual void copyToStarting(hiopVector& vec, int start_index_in_dest) const;
+  virtual void copyToStartingAt_w_pattern(hiopVector& vec,
                                           int start_index_in_dest,
                                           const hiopVector& ix) const;
 
-  /// @brief Copy the entries in `c` and `d` to `this`, according to the mapping in `c_map` and `d_map`
   virtual void copy_from_two_vec_w_pattern(const hiopVector& c, 
                                            const hiopVectorInt& c_map, 
                                            const hiopVector& d, 
                                            const hiopVectorInt& d_map);
 
-  /// @brief Copy the entries in `this` to `c` and `d`, according to the mapping `c_map` and `d_map`
   virtual void copy_to_two_vec_w_pattern(hiopVector& c, 
                                          const hiopVectorInt& c_map, 
                                          hiopVector& d, 
                                          const hiopVectorInt& d_map) const;
 
-  /**
-   * @brief copy 'this' (source) starting at 'start_idx_in_src' to 'dest' starting at index 'start_idx_dest' 
-   *
-   * If num_elems>=0, 'num_elems' will be copied; if num_elems<0, elements will be copied till the end of
-   * either source ('this') or destination ('dest') is reached
-   * if 'selec_dest' is given, the values are copy to 'dest' where the corresponding entry in 'selec_dest' is nonzero
-   */
-  virtual void startingAtCopyToStartingAt(int start_idx_in_src,
-					  hiopVector& dest,
-					  int start_idx_dest,
-					  int num_elems=-1) const;
-  
-  virtual void startingAtCopyToStartingAt_w_pattern(int start_idx_in_src,
-                                                    hiopVector& dest, int start_idx_dest,
+  virtual void startingAtCopyToStartingAt(index_type start_idx_in_src,
+                                          hiopVector& dest,
+                                          index_type start_idx_dest,
+                                          size_type num_elems=-1) const;
+
+  virtual void startingAtCopyToStartingAt_w_pattern(index_type start_idx_in_src,
+                                                    hiopVector& dest,
+                                                    index_type start_idx_dest,
                                                     const hiopVector& selec_dest,
-                                                    int num_elems=-1) const;
+                                                    size_type num_elems=-1) const;
 
   virtual double twonorm() const;
-  virtual double dotProductWith( const hiopVector& v ) const;
+  virtual double dotProductWith(const hiopVector& vec) const;
   virtual double infnorm() const;
   virtual double infnorm_local() const;
   virtual double onenorm() const;
@@ -191,7 +137,7 @@ public:
   virtual void componentDiv ( const hiopVector& v );
   virtual void componentDiv_w_selectPattern( const hiopVector& v, const hiopVector& ix);
   virtual void component_min(const double constant);
-  virtual void component_min(const hiopVector& v);
+  virtual void component_min(const hiopVector& vec);
   virtual void component_max(const double constant);
   virtual void component_max(const hiopVector& v);
   virtual void component_abs();
@@ -202,7 +148,7 @@ public:
   /// @brief this += alpha * x
   virtual void axpy  ( double alpha, const hiopVector& x );
   /// @brief this += alpha * x, for the entries in 'this' where corresponding 'select' is nonzero.
-  virtual void axpy_w_pattern(double alpha, const hiopVector& x, const hiopVector& select);
+  virtual void axpy_w_pattern(double alpha, const hiopVector& xvec, const hiopVector& select);
 
   /**
    * @brief Performs axpy, this += alpha*x, on the indexes in this specified by i.
@@ -215,63 +161,60 @@ public:
    * @pre The entries of i must be valid (zero-based) indexes in this
    *
    */
-  virtual void axpy(double alpha, const hiopVector& x, const hiopVectorInt& i);
+  virtual void axpy(double alpha, const hiopVector& xvec, const hiopVectorInt& i);
   
   /// @brief this += alpha * x * z
-  virtual void axzpy ( double alpha, const hiopVector& x, const hiopVector& z );
+  virtual void axzpy (double alpha, const hiopVector& xvec, const hiopVector& zvec);
   /// @brief this += alpha * x / z
-  virtual void axdzpy( double alpha, const hiopVector& x, const hiopVector& z );
-  virtual void axdzpy_w_pattern( double alpha, const hiopVector& x, const hiopVector& z, const hiopVector& select ); 
+  virtual void axdzpy(double alpha, const hiopVector& xvec, const hiopVector& zvec);
+  virtual void axdzpy_w_pattern(double alpha,
+                                const hiopVector& xvec,
+                                const hiopVector& zvec,
+                                const hiopVector& select); 
   /// @brief Add c to the elements of this
-  virtual void addConstant( double c );
-  virtual void addConstant_w_patternSelect(double c, const hiopVector& ix);
+  virtual void addConstant(double c);
+  virtual void addConstant_w_patternSelect(double c, const hiopVector& select);
   virtual double min() const;
   virtual double min_w_pattern(const hiopVector& select) const;  
-  virtual void min( double& m, int& index ) const;
+  virtual void min(double& minval, int& index) const;
   virtual void negate();
   virtual void invert();
   virtual double logBarrier_local(const hiopVector& select) const;
   virtual double sum_local() const;
-  virtual void addLogBarrierGrad(double alpha, const hiopVector& x, const hiopVector& select);
+  virtual void addLogBarrierGrad(double alpha, const hiopVector& xvec, const hiopVector& select);
 
-  virtual double linearDampingTerm_local(const hiopVector& ixl_select, const hiopVector& ixu_select, 
-					 const double& mu, const double& kappa_d) const;
+  virtual double linearDampingTerm_local(const hiopVector& ixleft,
+                                         const hiopVector& ixright,
+                                         const double& mu,
+                                         const double& kappa_d) const;
 
-  /** 
-   * Performs `this[i] = alpha*this[i] + sign*ct` where sign=1 when EXACTLY one of 
-   * ixleft[i] and ixright[i] is 1.0 and sign=0 otherwise. 
-   *
-   * Supports distributed/MPI vectors, but performs only elementwise operations and do not
-   * require communication.
-   *
-   * This method is used to add gradient contributions from the (linear) damping term used
-   * to handle unbounded problems. The damping terms are used for variables that are 
-   * bounded on one side only. 
-   */
   virtual void addLinearDampingTerm(const hiopVector& ixleft,
                                     const hiopVector& ixright,
                                     const double& alpha,
                                     const double& ct);
 
   virtual int allPositive();
-  virtual int allPositive_w_patternSelect(const hiopVector& w);
-  virtual bool projectIntoBounds_local(const hiopVector& xl, const hiopVector& ixl, 
-				       const hiopVector& xu, const hiopVector& ixu,
-				       double kappa1, double kappa2);
-  virtual double fractionToTheBdry_local(const hiopVector& dx, const double& tau) const;
-  virtual double fractionToTheBdry_w_pattern_local(const hiopVector& dx,
-						   const double& tau,
-						   const hiopVector& ix) const;
-  virtual void selectPattern(const hiopVector& ix);
-  virtual bool matchesPattern(const hiopVector& ix);
+  virtual int allPositive_w_patternSelect(const hiopVector& select);
+  virtual bool projectIntoBounds_local(const hiopVector& xl, 
+                                       const hiopVector& ixl,
+                                       const hiopVector& xu,
+                                       const hiopVector& ixu,
+                                       double kappa1,
+                                       double kappa2);
+  virtual double fractionToTheBdry_local(const hiopVector& dvec, const double& tau) const;
+  virtual double fractionToTheBdry_w_pattern_local(const hiopVector& dvec,
+                                                   const double& tau,
+                                                   const hiopVector& ix) const;
+  virtual void selectPattern(const hiopVector& select);
+  virtual bool matchesPattern(const hiopVector& select);
 
   virtual hiopVector* alloc_clone() const;
   virtual hiopVector* new_copy () const;
 
   virtual void adjustDuals_plh(const hiopVector& x,
-			       const hiopVector& ix,
-			       const double& mu,
-			       const double& kappa);
+                               const hiopVector& ix,
+                               const double& mu,
+                               const double& kappa);
 
   virtual bool is_zero() const;
   virtual bool isnan_local() const;
@@ -303,10 +246,17 @@ public:
 
   virtual bool is_equal(const hiopVector& vec) const;
 
+  /**
+   * @brief accessor to the execution policy
+   */
   ExecSpace<MemBackendCpp, ExecPolicySeq>& exec_space()
   {
     return exec_space_;
   }
+
+  /**
+   * @brief accessor to the execution policy
+   */
   const ExecSpace<MemBackendCpp, ExecPolicySeq>& exec_space() const
   {
     return exec_space_;

--- a/src/LinAlg/hiopVectorPar.hpp
+++ b/src/LinAlg/hiopVectorPar.hpp
@@ -87,25 +87,70 @@ public:
   virtual void copyFrom(const double* local_array);
   virtual void copy_from_w_pattern(const hiopVector& src, const hiopVector& select);
 
+  /** Copy to `this` the array content of the hiopVectorPar vector passed as argument.
+   *
+   * @pre `this` and source vector should have the same size.
+   * @pre `this` and source vector should have the same MPI distributions (and, 
+   * hence, same number of local elements) when applicable.
+   */
   virtual void copy_from_vectorpar(const hiopVectorPar& vsrc);
+  /**
+   * @brief Copy from src the elements specified by the indices in index_in_src. 
+   *
+   * @pre All vectors must reside in the same memory space. 
+   * @pre Size of src must be greater or equal than size of this
+   * @pre Size of index_in_src must be equal to size of this
+   * @pre Elements of index_in_src must be valid (zero-based) indexes in src
+   *
+   */
   virtual void copy_from_indexes(const hiopVector& src, const hiopVectorInt& index_in_src);
+  /**
+   * @brief Copy from src the elements specified by the indices in index_in_src. 
+   *
+   * @pre All vectors and arrays must reside in the same memory space. 
+   * @pre Size of src must be greater or equal than size of this
+   * @pre Size of index_in_src must be equal to size of this
+   * @pre Elements of index_in_src must be valid (zero-based) indexes in src
+   *
+   */
   virtual void copy_from_indexes(const double* src, const hiopVectorInt& index_in_src);
 
+  /// @brief Copy the 'n' elements of v starting at 'start_index_in_this' in 'this'
   virtual void copyFromStarting(int start_index_in_this, const double* v, int nv);
   virtual void copyFromStarting(int start_index, const hiopVector& src);
   virtual void copy_from_starting_at(const double* v, int start_index_in_v, int n);
 
+  /*
+   * @brief Copy from 'v' starting at 'start_idx_src' to 'this' starting at 'start_idx_dest'
+   *
+   * Elements are copied into 'this' till the end of the 'this' is reached, more exactly a number 
+   * of lenght(this) - start_idx_dest elements are copied.
+   *
+   * Precondition: The method expects that in 'v' there are at least as many elements starting 
+   * 'start_idx_src' as 'this' has starting at 'start_idx_dest', or in other words,
+   * length(this) - start_idx_dest <= length(v) - start_idx_src
+   */
   virtual void startingAtCopyFromStartingAt(int start_idx_dest, const hiopVector& v, int start_idx_src);
 
   virtual void copyTo(double* dest) const;
+
+  /** Copy the array content `this` in the hiopVectorPar passed as argument
+   *
+   * @pre `this` and destination vector should have the same size.
+   * @pre `this` and destination vector should have the same MPI distributions (and, 
+   * hence, same number of local elements) when applicable.
+   */
   virtual void copy_to_vectorpar(hiopVectorPar& vdest) const;
 
   virtual void copyToStarting(int start_index, hiopVector& dst) const;
+  /// @brief Copy 'this' to v starting at start_index in 'v'.
   virtual void copyToStarting(hiopVector& vec, int start_index_in_dest) const;
+  /// @brief Copy the entries in 'this' where corresponding 'ix' is nonzero, to v starting at start_index in 'v'.
   virtual void copyToStartingAt_w_pattern(hiopVector& vec,
                                           index_type start_index_in_dest,
                                           const hiopVector& ix) const;
 
+  /// @brief Copy the entries in `c` and `d` to `this`, according to the mapping in `c_map` and `d_map`
   virtual void copy_from_two_vec_w_pattern(const hiopVector& c, 
                                            const hiopVectorInt& c_map, 
                                            const hiopVector& d, 
@@ -116,6 +161,13 @@ public:
                                          hiopVector& d, 
                                          const hiopVectorInt& d_map) const;
 
+  /**
+   * @brief copy 'this' (source) starting at 'start_idx_in_src' to 'dest' starting at index 'start_idx_dest' 
+   *
+   * If num_elems>=0, 'num_elems' will be copied; if num_elems<0, elements will be copied till the end of
+   * either source ('this') or destination ('dest') is reached
+   * if 'selec_dest' is given, the values are copy to 'dest' where the corresponding entry in 'selec_dest' is nonzero
+   */
   virtual void startingAtCopyToStartingAt(index_type start_idx_in_src,
                                           hiopVector& dest,
                                           index_type start_idx_dest,
@@ -145,15 +197,33 @@ public:
   virtual void component_sqrt();
 
   virtual void scale( double alpha );
+  /// @brief this += alpha * x
   virtual void axpy  ( double alpha, const hiopVector& x );
+  /// @brief this += alpha * x, for the entries in 'this' where corresponding 'select' is nonzero.
   virtual void axpy_w_pattern(double alpha, const hiopVector& xvec, const hiopVector& select);
+
+  /**
+   * @brief Performs axpy, this += alpha*x, on the indexes in this specified by i.
+   * 
+   * @param alpha scaling factor 
+   * @param x vector of doubles to be axpy-ed to this (size equal to size of i and less than or equal to size of this)
+   * @param i vector of indexes in this to which the axpy operation is performed (size equal to size of x and less than 
+   * or equal to size of this)
+   *
+   * @pre The entries of i must be valid (zero-based) indexes in this
+   *
+   */
   virtual void axpy(double alpha, const hiopVector& xvec, const hiopVectorInt& i);
+
+  /// @brief this += alpha * x * z
   virtual void axzpy (double alpha, const hiopVector& xvec, const hiopVector& zvec);
+  /// @brief this += alpha * x / z
   virtual void axdzpy(double alpha, const hiopVector& xvec, const hiopVector& zvec);
   virtual void axdzpy_w_pattern(double alpha,
                                 const hiopVector& xvec,
                                 const hiopVector& zvec,
                                 const hiopVector& select);
+  /// @brief Add c to the elements of this
   virtual void addConstant(double c);
   virtual void addConstant_w_patternSelect(double c, const hiopVector& select);
   virtual double min() const;
@@ -170,6 +240,17 @@ public:
                                          const double& mu,
                                          const double& kappa_d) const;
 
+  /** 
+   * Performs `this[i] = alpha*this[i] + sign*ct` where sign=1 when EXACTLY one of 
+   * ixleft[i] and ixright[i] is 1.0 and sign=0 otherwise. 
+   *
+   * Supports distributed/MPI vectors, but performs only elementwise operations and do not
+   * require communication.
+   *
+   * This method is used to add gradient contributions from the (linear) damping term used
+   * to handle unbounded problems. The damping terms are used for variables that are 
+   * bounded on one side only. 
+   */
   virtual void addLinearDampingTerm(const hiopVector& ixleft,
                                     const hiopVector& ixright,
                                     const double& alpha,
@@ -214,7 +295,7 @@ public:
   virtual inline const double* local_data_host_const() const { return local_data_const(); }
  
   virtual size_type numOfElemsLessThan(const double &val) const;
-  virtual size_type numOfElemsAbsLessThan(const double &val) const;
+  virtual size_type numOfElemsAbsLessThan(const double &val) const; 
 
   virtual void set_array_from_to(hiopInterfaceBase::NonlinearityType* arr, 
                                  const int start, 

--- a/src/LinAlg/hiopVectorRaja.hpp
+++ b/src/LinAlg/hiopVectorRaja.hpp
@@ -94,9 +94,8 @@ public:
   virtual void setToConstant( double c );
   virtual void set_to_random_uniform(double minv, double maxv);
   virtual void setToConstant_w_patternSelect(double c, const hiopVector& select);
-  virtual void copyFrom(const hiopVector& v );
-  virtual void copyFrom(const double* v_local_data); //v should be of length at least n_local
-  virtual void copy_from(const hiopVector& src, const hiopVectorInt& index_in_src); 
+  virtual void copyFrom(const hiopVector& vec);
+  virtual void copyFrom(const double* local_array); //v should be of length at least n_local
   virtual void copy_from_w_pattern(const hiopVector& src, const hiopVector& select);
 
   /// @brief Copy entries from a hiopVectorPar, see method documentation in the parent class.
@@ -136,30 +135,19 @@ public:
    */
   virtual void copy_from_indexes(const double* src, const hiopVectorInt& index_in_src);
 
-  /**
-   * @brief Copy from src the elements specified by the indices in index_in_src. 
-   *
-   * @pre All vectors and arrays must reside in the same memory space. 
-   * @pre Size of src must be greater or equal than size of this
-   * @pre Size of index_in_src must be equal to size of this
-   * @pre Elements of index_in_src must be valid (zero-based) indexes in src
-   *
-   */
-  virtual void copy_from(const double* src, const hiopVectorInt& index_in_src);
-  
   /** Copy the 'n' elements of v starting at 'start_index_in_this' in 'this' */
-  virtual void copyFromStarting(int start_index_in_this, const double* v, int n);
-  virtual void copyFromStarting(int start_index_in_src, const hiopVector& v);
+  virtual void copyFromStarting(int start_index_in_this, const double* v, int nv);
+  virtual void copyFromStarting(int start_index, const hiopVector& src);
   /// @brief Copy the 'n' elements of v starting at 'start_index_in_v' into 'this'
   virtual void copy_from_starting_at(const double* v, int start_index_in_v, int n);
   /* copy 'dest' starting at 'start_idx_dest' to 'this' starting at 'start_idx_src' */
   virtual void startingAtCopyFromStartingAt(int start_idx_src, const hiopVector& v, int start_idx_dest);
 
   virtual void copyTo(double* dest) const;
-  virtual void copyToStarting(int start_index_in_src, hiopVector& v) const;
+  virtual void copyToStarting(int start_index, hiopVector& dst) const;
   /* Copy 'this' to v starting at start_index in 'v'. */
-  virtual void copyToStarting(hiopVector& v, int start_index_in_dest) const;
-  virtual void copyToStartingAt_w_pattern(hiopVector& v,
+  virtual void copyToStarting(hiopVector& vec, int start_index_in_dest) const;
+  virtual void copyToStartingAt_w_pattern(hiopVector& vec,
                                           int start_index_in_dest,
                                           const hiopVector& ix) const;
 
@@ -180,7 +168,8 @@ public:
    * either source ('this') or destination ('dest') is reached
    * if 'selec_dest' is given, the values are copy to 'dest' where the corresponding entry in 'selec_dest' is nonzero */
   virtual void startingAtCopyToStartingAt(index_type start_idx_in_src,
-                                          hiopVector& dest, index_type start_idx_dest,
+                                          hiopVector& dest,
+                                          index_type start_idx_dest,
                                           size_type num_elems=-1) const;
   virtual void startingAtCopyToStartingAt_w_pattern(index_type start_idx_in_src,
                                                     hiopVector& dest,
@@ -189,7 +178,7 @@ public:
                                                     size_type num_elems=-1) const;
 
   virtual double twonorm() const;
-  virtual double dotProductWith( const hiopVector& v ) const;
+  virtual double dotProductWith(const hiopVector& vec) const;
   virtual double infnorm() const;
   virtual double infnorm_local() const;
   virtual double onenorm() const;
@@ -198,7 +187,7 @@ public:
   virtual void componentDiv ( const hiopVector& v );
   virtual void componentDiv_w_selectPattern( const hiopVector& v, const hiopVector& ix);
   virtual void component_min(const double constant);
-  virtual void component_min(const hiopVector& v);
+  virtual void component_min(const hiopVector& vec);
   virtual void component_max(const double constant);
   virtual void component_max(const hiopVector& v);
   virtual void component_abs();
@@ -208,7 +197,7 @@ public:
   /** this += alpha * x */
   virtual void axpy  ( double alpha, const hiopVector& x );
   /// @brief this += alpha * x, for the entries in 'this' where corresponding 'select' is nonzero.
-  virtual void axpy_w_pattern(double alpha, const hiopVector& x, const hiopVector& select);
+  virtual void axpy_w_pattern(double alpha, const hiopVector& xvec, const hiopVector& select);
 
   /**
    * @brief Performs axpy, this += alpha*x, on the indexes in this specified by i.
@@ -221,25 +210,28 @@ public:
    * @pre The entries of i must be valid (zero-based) indexes in this
    *
    */
-  virtual void axpy(double alpha, const hiopVector& x, const hiopVectorInt& i);
+  virtual void axpy(double alpha, const hiopVector& xvec, const hiopVectorInt& i);
   
   
   /** this += alpha * x * z */
-  virtual void axzpy ( double alpha, const hiopVector& x, const hiopVector& z );
+  virtual void axzpy (double alpha, const hiopVector& xvec, const hiopVector& zvec);
   /** this += alpha * x / z */
-  virtual void axdzpy( double alpha, const hiopVector& x, const hiopVector& z );
-  virtual void axdzpy_w_pattern( double alpha, const hiopVector& x, const hiopVector& z, const hiopVector& select ); 
+  virtual void axdzpy(double alpha, const hiopVector& xvec, const hiopVector& zvec);
+  virtual void axdzpy_w_pattern(double alpha,
+                                const hiopVector& xvec,
+                                const hiopVector& zvec,
+                                const hiopVector& select); 
   /** Add c to the elements of this */
-  virtual void addConstant( double c );
-  virtual void addConstant_w_patternSelect(double c, const hiopVector& ix);
+  virtual void addConstant(double c);
+  virtual void addConstant_w_patternSelect(double c, const hiopVector& select);
   virtual double min() const;
-  virtual void min( double& m, int& index ) const;
+  virtual void min(double& minval, int& index) const;
   virtual double min_w_pattern(const hiopVector& select) const;  
   virtual void negate();
   virtual void invert();
   virtual double logBarrier_local(const hiopVector& select) const;
   virtual double sum_local() const;
-  virtual void addLogBarrierGrad(double alpha, const hiopVector& x, const hiopVector& select);
+  virtual void addLogBarrierGrad(double alpha, const hiopVector& xvec, const hiopVector& select);
 
   virtual double linearDampingTerm_local(const hiopVector& ixl_select, const hiopVector& ixu_select, 
                                          const double& mu, const double& kappa_d) const;
@@ -262,19 +254,25 @@ public:
                                     const double& ct);
 
   virtual int allPositive();
-  virtual int allPositive_w_patternSelect(const hiopVector& w);
-  virtual bool projectIntoBounds_local(const hiopVector& xl, const hiopVector& ixl, 
-                                       const hiopVector& xu, const hiopVector& ixu,
-                                       double kappa1, double kappa2);
-  virtual double fractionToTheBdry_local(const hiopVector& dx, const double& tau) const;
-  virtual double fractionToTheBdry_w_pattern_local(const hiopVector& dx, const double& tau, const hiopVector& ix) const;
-  virtual void selectPattern(const hiopVector& ix);
-  virtual bool matchesPattern(const hiopVector& ix);
+  virtual int allPositive_w_patternSelect(const hiopVector& select);
+  virtual bool projectIntoBounds_local(const hiopVector& xlo, 
+                                       const hiopVector& ixl,
+                                       const hiopVector& xup,
+                                       const hiopVector& ixu,
+                                       double kappa1,
+                                       double kappa2);
+  virtual double fractionToTheBdry_local(const hiopVector& dvec, const double& tau) const;
+  virtual double fractionToTheBdry_w_pattern_local(const hiopVector& dvec, const double& tau, const hiopVector& ix) const;
+  virtual void selectPattern(const hiopVector& select);
+  virtual bool matchesPattern(const hiopVector& select);
 
   virtual hiopVector* alloc_clone() const;
   virtual hiopVector* new_copy () const;
 
-  virtual void adjustDuals_plh(const hiopVector& x, const hiopVector& ix, const double& mu, const double& kappa);
+  virtual void adjustDuals_plh(const hiopVector& xvec, 
+                               const hiopVector& ixvec,
+                               const double& mu,
+                               const double& kappa);
 
   virtual bool is_zero() const;
   virtual bool isnan_local() const;

--- a/src/LinAlg/hiopVectorRaja.hpp
+++ b/src/LinAlg/hiopVectorRaja.hpp
@@ -148,7 +148,7 @@ public:
   /* Copy 'this' to v starting at start_index in 'v'. */
   virtual void copyToStarting(hiopVector& vec, int start_index_in_dest) const;
   virtual void copyToStartingAt_w_pattern(hiopVector& vec,
-                                          int start_index_in_dest,
+                                          index_type start_index_in_dest,
                                           const hiopVector& ix) const;
 
   /// @brief Copy the entries in `c` and `d` to `this`, according to the mapping in `c_map` and `d_map`

--- a/src/LinAlg/hiopVectorRajaImpl.hpp
+++ b/src/LinAlg/hiopVectorRajaImpl.hpp
@@ -714,26 +714,26 @@ void hiopVectorRaja<MEM, POL>::startingAtCopyToStartingAt(index_type start_idx_i
   assert(n_local_==n_ && "only for local/non-distributed vectors");
 #endif  
 
-  hiopVectorRaja& dest = dynamic_cast<hiopVectorRaja<MEM, POL>&>(destination);
+  hiopVectorRaja& dest_raja = dynamic_cast<hiopVectorRaja<MEM, POL>&>(dest);
 
   assert(start_idx_in_src >= 0 && start_idx_in_src <= this->n_local_);
-  assert(start_idx_dest   >= 0 && start_idx_dest   <= dest.n_local_);
+  assert(start_idx_dest   >= 0 && start_idx_dest   <= dest_raja.n_local_);
 
 #ifndef NDEBUG  
-  if(start_idx_dest==dest.n_local_ || start_idx_in_src==this->n_local_) assert((num_elems==-1 || num_elems==0));
+  if(start_idx_dest==dest_raja.n_local_ || start_idx_in_src==this->n_local_) assert((num_elems==-1 || num_elems==0));
 #endif
 
   if(num_elems<0)
   {
-    num_elems = std::min(this->n_local_ - start_idx_in_src, dest.n_local_ - start_idx_dest);
+    num_elems = std::min(this->n_local_ - start_idx_in_src, dest_raja.n_local_ - start_idx_dest);
   } 
   else
   {
     assert(num_elems+start_idx_in_src <= this->n_local_);
-    assert(num_elems+start_idx_dest   <= dest.n_local_);
+    assert(num_elems+start_idx_dest   <= dest_raja.n_local_);
     //make sure everything stays within bounds (in release)
     num_elems = std::min(num_elems, (int)this->n_local_-start_idx_in_src);
-    num_elems = std::min(num_elems, (int)dest.n_local_-start_idx_dest);
+    num_elems = std::min(num_elems, (int)dest_raja.n_local_-start_idx_dest);
   }
 
   if(num_elems == 0)
@@ -741,7 +741,7 @@ void hiopVectorRaja<MEM, POL>::startingAtCopyToStartingAt(index_type start_idx_i
 
   //rm.copy(dest.data_dev_ + start_idx_dest, this->data_dev_ + start_idx_in_src, num_elems*sizeof(double));
   //TODO: fix pointer arithmetic on host
-  dest.exec_space_.copy(dest.data_dev_+start_idx_dest, data_dev_+start_idx_in_src, num_elems, exec_space_);
+  dest_raja.exec_space_.copy(dest_raja.data_dev_+start_idx_dest, data_dev_+start_idx_in_src, num_elems, exec_space_);
 }
 
 template<class MEM, class POL>


### PR DESCRIPTION
1. Update the doxygen-style comments in `hiopVector.hpp` (the abstract class).
2. remove duplicated function `copy_from(const hiopVector& vec, const hiopVectorInt& index_in_src)`
    (keep `copy_from_indexes(const hiopVector& src, const hiopVectorInt& index_in_src);`)
3. keep consistence of the variable names in the header files.

CLOSE #576 