### PR TITLE
fix issue #577

### DIFF
--- a/src/LinAlg/LinAlgFactory.cpp
+++ b/src/LinAlg/LinAlgFactory.cpp
@@ -146,8 +146,7 @@ hiopVector* LinearAlgebraFactory::create_vector(const ExecSpaceInfo& hi, //const
 #else  // non RAJA
     assert(false && "requested execution space not available because Hiop was not"
            "built with RAJA support");
-    return new hiopVectorPar(glob_n, col_part, comm);
-#endif
+#endif // #ifdef HIOP_USE_RAJA
     } else { //else for if(hi.exec_backend_ == "RAJA")
       if(mem_space_upper == "CUDA") {
 #ifdef HIOP_USE_CUDA
@@ -155,7 +154,6 @@ hiopVector* LinearAlgebraFactory::create_vector(const ExecSpaceInfo& hi, //const
 #else //ifdef HIOP_USE_CUDA
         assert(false && "requested memory space not available because Hiop was not"
                "built with CUDA support");
-        return new hiop::hiopVectorPar(glob_n, col_part, comm);
 #endif //ifdef HIOP_USE_CUDA
       } else {
         if(mem_space_upper == "HIP") {
@@ -164,15 +162,15 @@ hiopVector* LinearAlgebraFactory::create_vector(const ExecSpaceInfo& hi, //const
 #else //ifdef HIOP_USE_HIP
           assert(false && "requested memory space not available because HiOp was not"
                 "built with HIP support");
-          return new hiop::hiopVectorPar(glob_n, col_part, comm);
 #endif //ifdef HIOP_USE_HIP
         } else {
           assert(false && "to be implemented");
-          return nullptr;
         }
       }
     }
   }
+  assert(false && "should not reach here");
+  return nullptr;
 }
 
 /**
@@ -228,7 +226,6 @@ hiopVectorInt* LinearAlgebraFactory::create_vector_int(const ExecSpaceInfo& hi,
 #else  // non RAJA
     assert(false && "requested execution space not available because Hiop was not"
            "built with RAJA support");
-    return new hiopVectorIntSeq(n);
 #endif
     } else { //else for if(hi.exec_backend_ == "RAJA")
       if(ms == "CUDA") {
@@ -237,7 +234,6 @@ hiopVectorInt* LinearAlgebraFactory::create_vector_int(const ExecSpaceInfo& hi,
 #else //ifdef HIOP_USE_CUDA
         assert(false && "requested memory space not available because Hiop was not"
                "built with CUDA support");
-        return new hiop::hiopVectorIntSeq(n);
 #endif //ifdef HIOP_USE_CUDA
       } else {
         if(ms == "HIP") {
@@ -246,15 +242,15 @@ hiopVectorInt* LinearAlgebraFactory::create_vector_int(const ExecSpaceInfo& hi,
 #else //ifdef HIOP_USE_HIP
           assert(false && "requested memory space not available because HiOp was not"
                 "built with HIP support");
-          return new hiop::hiopVectorIntSeq(n);
 #endif //ifdef HIOP_USE_CUDA
         } else {
           assert(false && "to be implemented");
-          return nullptr;
         }
       }
     }
   }
+  assert(false && "should not reach here");
+  return nullptr;
 }
 
 /**
@@ -316,7 +312,6 @@ hiopMatrixDense* LinearAlgebraFactory::create_matrix_dense(const ExecSpaceInfo& 
                                                                                                m_max_alloc);
 #else
           assert(false && "cuda memory backend not available because HiOp was not built with CUDA");
-          return nullptr;
 #endif //HIOP_USE_CUDA
           
         } else if(hi.mem_backend_ == "HIP") {
@@ -330,7 +325,6 @@ hiopMatrixDense* LinearAlgebraFactory::create_matrix_dense(const ExecSpaceInfo& 
                                                                                              m_max_alloc);
 #else
           assert(false && "cuda memory backend not available because HiOp was not built with HIP");
-          return nullptr;
 #endif //HIOP_USE_HIP
           
         } else {
@@ -348,7 +342,6 @@ hiopMatrixDense* LinearAlgebraFactory::create_matrix_dense(const ExecSpaceInfo& 
                                                                                              m_max_alloc);
 #else
           assert(false && "cuda memory backend not available because HiOp was not built with RAJA-OMP");
-          return nullptr;
 #endif //!defined(HIOP_USE_CUDA) && !defined(HIOP_USE_HIP)
           
         }
@@ -371,17 +364,16 @@ hiopMatrixDense* LinearAlgebraFactory::create_matrix_dense(const ExecSpaceInfo& 
                                                                                                m_max_alloc);
 #else
           assert(false && "requested memory space not available because Hiop was not built with CUDA");
-          return nullptr;
 #endif //HIOP_USE_CUDA
       } else if(mem_space_upper == "HIP") {
         assert(false && "to be implemented");
-        return nullptr;
       } else {
         assert(false && "to be implemented");
-        return nullptr;
       }
     } // end of else for if(hi.exec_backend_ == "RAJA")
   } // end of else if(mem_space_upper == "DEFAULT") 
+  assert(false && "should not reach here");
+  return nullptr;
 }
 
 /**
@@ -402,9 +394,10 @@ hiopMatrixSparse* LinearAlgebraFactory::create_matrix_sparse(const std::string& 
 #else
     assert(false && "requested memory space not available because Hiop was not"
            "built with RAJA support");
-    return new hiopMatrixSparseTriplet(rows, cols, nnz);
 #endif
   }
+  assert(false && "should not reach here");
+  return nullptr;
 }
 
 hiopMatrixSparseCSR* LinearAlgebraFactory::create_matrix_sparse_csr(const std::string& mem_space)
@@ -417,9 +410,10 @@ hiopMatrixSparseCSR* LinearAlgebraFactory::create_matrix_sparse_csr(const std::s
     return new hiopMatrixSparseCSRCUDA();
 #else
     assert(false && "requested memory space not available because Hiop was not built with CUDA support");
-    return new hiopMatrixSparseCSRSeq();
 #endif
   }
+  assert(false && "should not reach here");
+  return nullptr;
 }
   
 hiopMatrixSparseCSR*  LinearAlgebraFactory::create_matrix_sparse_csr(const std::string& mem_space,
@@ -435,10 +429,10 @@ hiopMatrixSparseCSR*  LinearAlgebraFactory::create_matrix_sparse_csr(const std::
     return new hiopMatrixSparseCSRCUDA(rows, cols, nnz);
 #else
     assert(false && "requested memory space not available because Hiop was not built with CUDA support");
-    return new hiopMatrixSparseCSRSeq(rows, cols, nnz);
 #endif
   }
-
+  assert(false && "should not reach here");
+  return nullptr;
 }
 
 
@@ -459,9 +453,10 @@ hiopMatrixSparse* LinearAlgebraFactory::create_matrix_sym_sparse(const std::stri
 #else
     assert(false && "requested memory space not available because Hiop was not"
            "built with RAJA support");
-    return new hiopMatrixSymSparseTriplet(size, nnz);
 #endif
   }
+  assert(false && "should not reach here");
+  return nullptr;
 }
 
 /**
@@ -482,9 +477,10 @@ double* LinearAlgebraFactory::create_raw_array(const std::string& mem_space, siz
 #else
     assert(false && "requested memory space not available because Hiop was not"
            "built with RAJA support");
-    return new double[n];
 #endif
   }
+  assert(false && "should not reach here");
+  return nullptr;
 }
 
 /**


### PR DESCRIPTION
In `LinAlgFactory.cpp`, we have some return functions after assertions that can only be triggered under `NDEBUG` builds. 
For example, see the following code:
```
     assert(false && "requested memory space not available because Hiop was not"
                      "built with CUDA support");
      return new hiopVectorPar(glob_n, col_part, comm)
```

Instead of returning the sequential CPU implementation, e.g., `hiopVectorPar`, this PR returns `nullptr` when `hiop` is configured unexpectedly.

CLOSE #577 