### PR TITLE
PNNL GitLab Pipeline Status posts to GitHub

### DIFF
--- a/.github/workflows/push_mirror.yml
+++ b/.github/workflows/push_mirror.yml
@@ -1,9 +1,9 @@
-name: Mirroring
+name: Push Mirror
 
 on: [push, delete]
 
 jobs:
-  to_gitlab:
+  PNNL_GitLab:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/push_mirror.yml
+++ b/.github/workflows/push_mirror.yml
@@ -22,19 +22,3 @@ jobs:
           pipeline_id=$(echo $response | jq '.id' | sed 's/"//g')
           echo "PIPELINE_ID=${pipeline_id}" >> $GITHUB_ENV
           exit $exit_code
-      - name: Watch Pipeline Results
-        run: |
-          sudo apt install jq
-          while :; do
-            response=$(curl --header "PRIVATE-TOKEN: ${{ secrets.PNNL_GITLAB_CI_PAT }}" "https://gitlab.pnnl.gov/api/v4/projects/769/pipelines/${PIPELINE_ID}")
-            status=$(echo $response | jq '.status' | sed -e 's/"//g')
-            echo
-            echo "Full response: ${response}"
-            echo
-            echo "-- Got pipeline status: $status"
-            echo
-            bash_code=$(echo $status | perl -ne 'if (/failed/){print"exit 1";exit;} elsif (/success/){print"exit 0";exit;}')
-            eval "$bash_code"
-            sleep 60 
-          done
-

--- a/.gitlab/pnnl-ci.yml
+++ b/.gitlab/pnnl-ci.yml
@@ -107,9 +107,12 @@ pnnl_cleanup:
     ls -hal $WORKDIR
 
 .report-status:
+  extends:
+    - .pnnl_tags
   variables:
     STATUS_PROJECT: LLNL/hiop
     STATUS_NAME: PNNL CI
+    GIT_STRATEGY: none
   script:
     # For complete details on the GitHub API please see:
     # https://developer.github.com/v3/repos/statuses

--- a/.gitlab/pnnl-ci.yml
+++ b/.gitlab/pnnl-ci.yml
@@ -113,6 +113,9 @@ pnnl_cleanup:
   script:
     # For complete details on the GitHub API please see:
     # https://developer.github.com/v3/repos/statuses
+    # TODO:
+    #   - Create access token with `repo:status scope` in HiOp to be able to post to GitHub commit status
+    #   - Add PNNL GitLab CI/CD variable with environment scope (same environment name as below) containing GitHub authorization token
     - curl -X POST -H @${GITHUB_CURL_HEADERS} https://api.github.com/repos/${STATUS_PROJECT}/statuses/${CI_COMMIT_SHA}?state=${CI_JOB_NAME}\&context=${STATUS_NAME}\&target_url=${CI_PIPELINE_URL}
   environment:
     name: reporting-github

--- a/.gitlab/pnnl-ci.yml
+++ b/.gitlab/pnnl-ci.yml
@@ -105,3 +105,32 @@ pnnl_cleanup:
     export WORKDIR="$HOME/gitlab/"
     find $WORKDIR -type d -mindepth 1 -mmin +360 -prune -print -exec rm -rf {} \; || true
     ls -hal $WORKDIR
+
+.report-status:
+  variables:
+    STATUS_PROJECT: LLNL/hiop
+    STATUS_NAME: PNNL CI
+  script:
+    # For complete details on the GitHub API please see:
+    # https://developer.github.com/v3/repos/statuses
+    - curl -X POST -H @${GITHUB_CURL_HEADERS} https://api.github.com/repos/${STATUS_PROJECT}/statuses/${CI_COMMIT_SHA}?state=${CI_JOB_NAME}\&context=${STATUS_NAME}\&target_url=${CI_PIPELINE_URL}
+  environment:
+    name: reporting-github
+  dependencies: []
+
+pending:
+  stage: .pre
+  extends:
+    - .report-status
+
+success:
+  stage: .post
+  extends:
+    - .report-status
+
+failed:
+  stage: .post
+  extends:
+    - .report-status
+  rules:
+    - when: on_failure


### PR DESCRIPTION
This moves the fetching of PNNL CI's pipeline status from being done through a stalling GitHub action, to an asynchronous post to GitHub's API from PNNL GitLab.

I can also go ahead and add this same configuration to ORNL if you want, but I figured doing one of them at a time would make it go smoothly. The modification to the ORNL mirror will temporarily break CI until the PR is merged FYI.