### PR TITLE
Fix PNNL pipeline status/memory issue

### DIFF
--- a/.gitlab/pnnl-ci.yml
+++ b/.gitlab/pnnl-ci.yml
@@ -130,7 +130,7 @@ pnnl_cleanup:
       -X POST \
       -H @${GITHUB_CURL_HEADERS} \
       https://api.github.com/repos/${STATUS_PROJECT}/statuses/${CI_COMMIT_SHA} \
-      -d '{"state":"${CI_JOB_NAME}","target_url":"${CI_PIPELINE_URL}","context"="${STATUS_NAME}"}'
+      -d "{\"state\":\"${CI_JOB_NAME}\",\"target_url\":\"${CI_PIPELINE_URL}\",\"context\"=\"${STATUS_NAME}\"}"
   environment:
     name: reporting-github
 

--- a/.gitlab/pnnl-ci.yml
+++ b/.gitlab/pnnl-ci.yml
@@ -125,6 +125,7 @@ pnnl_cleanup:
     GIT_STRATEGY: none
   script:
     - |
+      set -x
       curl -L \
       -X POST \
       -H @${GITHUB_CURL_HEADERS} \

--- a/.gitlab/pnnl-ci.yml
+++ b/.gitlab/pnnl-ci.yml
@@ -124,9 +124,12 @@ pnnl_cleanup:
     STATUS_NAME: PNNL_GitLab
     GIT_STRATEGY: none
   script:
-    - curl --version
-    - echo curl -X POST -H @${GITHUB_CURL_HEADERS} https://api.github.com/repos/${STATUS_PROJECT}/statuses/${CI_COMMIT_SHA}?state=${CI_JOB_NAME}\&context=${STATUS_NAME}\&target_url=${CI_PIPELINE_URL}
-    - curl -X POST -H @${GITHUB_CURL_HEADERS} https://api.github.com/repos/${STATUS_PROJECT}/statuses/${CI_COMMIT_SHA}?state=${CI_JOB_NAME}\&context=${STATUS_NAME}\&target_url=${CI_PIPELINE_URL}
+    - |
+      curl -L \
+      -X POST \
+      -H @${GITHUB_CURL_HEADERS} \
+      https://api.github.com/repos/${STATUS_PROJECT}/statuses/${CI_COMMIT_SHA} \
+      -d '{"state":"${CI_JOB_NAME}","target_url":"${CI_PIPELINE_URL}","context"="${STATUS_NAME}"}'
   environment:
     name: reporting-github
 

--- a/.gitlab/pnnl-ci.yml
+++ b/.gitlab/pnnl-ci.yml
@@ -130,7 +130,7 @@ pnnl_cleanup:
       -X POST \
       -H @${GITHUB_CURL_HEADERS} \
       https://api.github.com/repos/${STATUS_PROJECT}/statuses/${CI_COMMIT_SHA} \
-      -d "{\"state\":\"${CI_JOB_NAME}\",\"target_url\":\"${CI_PIPELINE_URL}\",\"context\"=\"${STATUS_NAME}\"}"
+      -d "{\"state\":\"${CI_JOB_NAME}\",\"target_url\":\"${CI_PIPELINE_URL}\",\"context\":\"${STATUS_NAME}\"}"
   environment:
     name: reporting-github
 

--- a/.gitlab/pnnl-ci.yml
+++ b/.gitlab/pnnl-ci.yml
@@ -124,6 +124,8 @@ pnnl_cleanup:
     STATUS_NAME: PNNL_GitLab
     GIT_STRATEGY: none
   script:
+    - curl --version
+    - echo curl -X POST -H @${GITHUB_CURL_HEADERS} https://api.github.com/repos/${STATUS_PROJECT}/statuses/${CI_COMMIT_SHA}?state=${CI_JOB_NAME}\&context=${STATUS_NAME}\&target_url=${CI_PIPELINE_URL}
     - curl -X POST -H @${GITHUB_CURL_HEADERS} https://api.github.com/repos/${STATUS_PROJECT}/statuses/${CI_COMMIT_SHA}?state=${CI_JOB_NAME}\&context=${STATUS_NAME}\&target_url=${CI_PIPELINE_URL}
   environment:
     name: reporting-github

--- a/.gitlab/pnnl-ci.yml
+++ b/.gitlab/pnnl-ci.yml
@@ -13,6 +13,7 @@ variables:
     - marianas
 
 .pnnl_nohpc_tags:
+  # Use curl base image as ubuntu base is missing it
   image: curlimages/curl
   tags:
     - basic
@@ -108,7 +109,7 @@ pnnl_cleanup:
   variables:
     GIT_STRATEGY: none
   script:
-  # clears directory of files more than 6 hours/360 minutes old
+  # clears directory of files more than 2 hours/120 minutes old
   - |
     set -xv
     export WORKDIR="$HOME/gitlab/"
@@ -123,16 +124,9 @@ pnnl_cleanup:
     STATUS_NAME: PNNL_GitLab
     GIT_STRATEGY: none
   script:
-    # For complete details on the GitHub API please see:
-    # https://developer.github.com/v3/repos/statuses
-    # TODO:
-    #   - Create access token with `repo:status scope` in HiOp to be able to post to GitHub commit status
-    #   - Add PNNL GitLab CI/CD variable with environment scope (same environment name as below) containing GitHub authorization token
-    - set -x
     - curl -X POST -H @${GITHUB_CURL_HEADERS} https://api.github.com/repos/${STATUS_PROJECT}/statuses/${CI_COMMIT_SHA}?state=${CI_JOB_NAME}\&context=${STATUS_NAME}\&target_url=${CI_PIPELINE_URL}
   environment:
     name: reporting-github
-  dependencies: []
 
 pending:
   stage: .pre

--- a/.gitlab/pnnl-ci.yml
+++ b/.gitlab/pnnl-ci.yml
@@ -13,6 +13,7 @@ variables:
     - marianas
 
 .pnnl_nohpc_tags:
+  image: curlimages/curl
   tags:
     - basic
     - exasgd

--- a/.gitlab/pnnl-ci.yml
+++ b/.gitlab/pnnl-ci.yml
@@ -9,7 +9,15 @@ variables:
     - k8s
     - ikp
     - exasgd
+    - deception
     - marianas
+
+.pnnl_nohpc_tags:
+  tags:
+    - basic
+    - exasgd
+    - ikp
+    - k8s
 
 .newell:
   variables:
@@ -103,12 +111,12 @@ pnnl_cleanup:
   - |
     set -xv
     export WORKDIR="$HOME/gitlab/"
-    find $WORKDIR -type d -mindepth 1 -mmin +360 -prune -print -exec rm -rf {} \; || true
+    find $WORKDIR -type d -mindepth 1 -mmin +120 -prune -print -exec rm -rf {} \; || true
     ls -hal $WORKDIR
 
 .report-status:
   extends:
-    - .pnnl_tags
+    - .pnnl_nohpc_tags
   variables:
     STATUS_PROJECT: LLNL/hiop
     STATUS_NAME: PNNL_GitLab


### PR DESCRIPTION
This PR actually allows for the PNNL pipeline status to post to GitHub, with actions and secrets configured correctly.