### PR TITLE
Use failure not failed in PNNL commit status posting

### DIFF
--- a/.gitlab/pnnl-ci.yml
+++ b/.gitlab/pnnl-ci.yml
@@ -144,7 +144,7 @@ success:
   extends:
     - .report-status
 
-failed:
+failure:
   stage: .post
   extends:
     - .report-status


### PR DESCRIPTION
The incorrect stage name causes the status of a failed pipeline run not to actually post to GitHub.