### PR TITLE
Fix Assignment Typo in hiopMatrixSparseCsrCuda.cpp

### DIFF
--- a/src/LinAlg/hiopMatrixSparseCsrCuda.cpp
+++ b/src/LinAlg/hiopMatrixSparseCsrCuda.cpp
@@ -154,7 +154,7 @@ hiopMatrixSparseCSRCUDA::~hiopMatrixSparseCSRCUDA()
   cusparseStatus_t st = cusparseDestroyMatDescr(mat_descr_);
   assert(st == CUSPARSE_STATUS_SUCCESS);
 
-  st == cusparseSpGEMM_destroyDescr(gemm_sp_descr_);
+  st = cusparseSpGEMM_destroyDescr(gemm_sp_descr_);
   assert(st == CUSPARSE_STATUS_SUCCESS);
 }
 


### PR DESCRIPTION
This PR patches a type on line 157 of hiopMatrixSparseCsrCuda.cpp. The typo was an extra equals sign in a variable assignment which caused the assignment to act as a comparison instead.

Issue: #611