### PR TITLE
Use constraint violation in checkTermination

### DIFF
--- a/src/Optimization/hiopAlgFilterIPM.hpp
+++ b/src/Optimization/hiopAlgFilterIPM.hpp
@@ -167,7 +167,8 @@ protected:
                                    double& logoptim,
                                    double& logfeas,
                                    double& logcomplem,
-                                   double& logoverall);
+                                   double& logoverall,
+                                   double& cons_violation);
 
   virtual double thetaLogBarrier(const hiopIterate& it, const hiopResidual& resid, const double& mu);
 
@@ -242,6 +243,7 @@ protected:
   double _err_nlp_optim0,_err_nlp_feas0,_err_nlp_complem0;//initial errors, not scaled by sd, sc, and sc
   double _err_log_optim, _err_log_feas, _err_log_complem;//not scaled by sd, sc, and sc
   double _err_nlp, _err_log; //max of the above (scaled)
+  double _err_cons_violation; // constraint violation (Note: this is slightly different from _err_nlp_feas)
   double onenorm_pr_curr_; //one norm of the constraint infeasibility
 
   //class for updating the duals multipliers
@@ -277,6 +279,9 @@ protected:
   double theta_mu;      //exponent for a Mehtrotra-style decrease of mu
   double eps_tol;       //abs tolerance for the NLP error
   double eps_rtol;      //rel tolerance for the NLP error
+  double dual_tol_;     //abs tolerance for the dual infeasibility
+  double cons_tol_;     //abs tolerance for the constraint violation
+  double comp_tol_;     //abs tolerance for the complementary conditions
   double tau_min;       //min value for the fraction-to-the-boundary parameter: tau_k=max{tau_min,1-\mu_k}
   double kappa_eps;     //tolerance for the barrier problem, relative to mu: error<=kappa_eps*mu
   double kappa1,kappa2; //params for default starting point

--- a/src/Optimization/hiopResidual.hpp
+++ b/src/Optimization/hiopResidual.hpp
@@ -94,10 +94,19 @@ public:
                           const hiopLogBarProblem& logprob);
 
   /* Return the Nlp and Log-bar errors computed at the previous update call. */
-  inline void getNlpErrors(double& optim, double& feas, double& comple) const
-  { optim=nrmInf_nlp_optim; feas=nrmInf_nlp_feasib; comple=nrmInf_nlp_complem;};
+  inline void getNlpErrors(double& optim, double& feas, double& comple, double& cons_violation) const
+  { 
+    optim = nrmInf_nlp_optim;
+    feas = nrmInf_nlp_feasib;
+    comple = nrmInf_nlp_complem;
+    cons_violation = nrmInf_cons_violation;
+  };
   inline void getBarrierErrors(double& optim, double& feas, double& comple) const
-  { optim=nrmInf_bar_optim; feas=nrmInf_bar_feasib; comple=nrmInf_bar_complem;};
+  { 
+    optim = nrmInf_bar_optim;
+    feas = nrmInf_bar_feasib;
+    comple = nrmInf_bar_complem;
+  };
   /* get the previously computed Infeasibility */
   inline double getInfeasInfNorm() const {
     return nrmInf_nlp_feasib;
@@ -167,7 +176,7 @@ private:
    *  for the barrier subproblem
    */
   double nrmInf_bar_optim, nrmInf_bar_feasib, nrmInf_bar_complem;
-  
+
   /** storage for the one norm of [ryc,ryd]. This is the one norm of constraint violations.
   */ 
   double nrmOne_nlp_feasib;
@@ -175,6 +184,8 @@ private:
   double nrmOne_nlp_optim;
   double nrmOne_bar_optim;
   
+  /** inf norm of constraint violation */
+  double nrmInf_cons_violation;
 
   // and associated info from problem formulation
   hiopNlpFormulation * nlp;

--- a/src/Utils/hiopOptions.cpp
+++ b/src/Utils/hiopOptions.cpp
@@ -576,6 +576,25 @@ void hiopOptionsNLP::register_options()
                       "Exponential reduction coefficient for mu (default 1.5) (eqn (7) in Filt-IPM paper)");
   register_num_option("eta_phi", 1e-8, 0, 0.01, "Parameter of (suff. decrease) in Armijo Rule");
   register_num_option("tolerance", 1e-8, 1e-14, 1e-1, "Absolute error tolerance for the NLP (default 1e-8)");
+
+  register_num_option("cons_tol",
+                      1e-4,
+                      1e-16,
+                      1e+10,
+                      "Absolute error tolerance for the constraint violation (default 1e-4)");
+
+  register_num_option("dual_tol",
+                      1.0,
+                      1e-16,
+                      1e+10,
+                      "Absolute error tolerance for the dual infeasibility (default 1.0)");
+
+  register_num_option("comp_tol",
+                      1e-4,
+                      1e-16,
+                      1e+10,
+                      "Absolute error tolerance for the complementary conditions (default 1e-4)");
+
   register_num_option("rel_tolerance",
                       0.,
                       0.,
@@ -1235,6 +1254,36 @@ void hiopOptionsNLP::ensure_consistence()
                  "There is no reason to set 'acceptable_tolerance' tighter than 'tolerance'. "
                  "Will set the two to 'tolerance'.\n");
       set_val("acceptable_tolerance", eps_tol);
+    }
+  }
+
+  double dual_tol = GetNumeric("dual_tol");
+  if(dual_tol < eps_tol) {
+    if(is_user_defined("dual_tol")) {
+      log_printf(hovWarning,
+                 "There is no reason to set 'dual_tol' tighter than 'tolerance'. "
+                 "Will set the two to 'tolerance'.\n");
+      set_val("dual_tol", eps_tol);
+    }
+  }
+
+  double cons_tol = GetNumeric("cons_tol");
+  if(cons_tol < eps_tol) {
+    if(is_user_defined("cons_tol")) {
+      log_printf(hovWarning,
+                 "There is no reason to set 'cons_tol' tighter than 'tolerance'. "
+                 "Will set the two to 'tolerance'.\n");
+      set_val("cons_tol", eps_tol);
+    }
+  }
+
+  double comp_tol = GetNumeric("comp_tol");
+  if(comp_tol < eps_tol) {
+    if(is_user_defined("comp_tol")) {
+      log_printf(hovWarning,
+                 "There is no reason to set 'comp_tol' tighter than 'tolerance'. "
+                 "Will set the two to 'tolerance'.\n");
+      set_val("comp_tol", eps_tol);
     }
   }
 


### PR DESCRIPTION
address issue #608 
Use real constraint violation, instead of primal infeasibilities, to check convergence.

CLOSE #608 