### PR TITLE
Use bicg ir in the dense solver

### DIFF
--- a/src/Drivers/Dense/CMakeLists.txt
+++ b/src/Drivers/Dense/CMakeLists.txt
@@ -42,6 +42,8 @@ add_test(NAME NlpDenseCons2_UN_5K COMMAND  ${RUNCMD} "$<TARGET_FILE:NlpDenseCons
 add_test(NAME NlpDenseCons3_5H    COMMAND  ${RUNCMD} "$<TARGET_FILE:NlpDenseConsEx3.exe>"   "500" "-selfcheck")
 add_test(NAME NlpDenseCons3_5K    COMMAND  ${RUNCMD} "$<TARGET_FILE:NlpDenseConsEx3.exe>"  "5000" "-selfcheck")
 add_test(NAME NlpDenseCons3_50K   COMMAND  ${RUNCMD} "$<TARGET_FILE:NlpDenseConsEx3.exe>" "50000" "-selfcheck")
+add_test(NAME NlpDenseCons4       COMMAND  ${RUNCMD} "$<TARGET_FILE:NlpDenseConsEx4.exe>" "-selfcheck")
+
 if(HIOP_USE_MPI)
   add_test(NAME NlpDenseCons3_50K_mpi COMMAND ${MPICMD} -n 2 "$<TARGET_FILE:NlpDenseConsEx3.exe>" "50000" "-selfcheck")
 endif(HIOP_USE_MPI)

--- a/src/Drivers/Dense/NlpDenseConsEx2Driver.cpp
+++ b/src/Drivers/Dense/NlpDenseConsEx2Driver.cpp
@@ -30,6 +30,8 @@ static bool parse_arguments(int argc, char **argv, size_type& n, bool& self_chec
     {
       if(std::string(argv[2]) == "-unconstrained") {
         no_con = true;
+      } else if(std::string(argv[2]) == "-selfcheck") {
+        self_check = true;
       }
     }
   case 2: //1 argument

--- a/src/LinAlg/hiopVectorPar.cpp
+++ b/src/LinAlg/hiopVectorPar.cpp
@@ -246,13 +246,13 @@ void hiopVectorPar::startingAtCopyFromStartingAt(int start_idx_dest,
                                                  int start_idx_src)
 {
   size_type howManyToCopyDest = this->n_local_ - start_idx_dest;
+  const hiopVectorPar& v = dynamic_cast<const hiopVectorPar&>(v_in);
 
 #ifdef HIOP_DEEPCHECKS
   assert(n_local_==n_ && "only for local/non-distributed vectors");
   assert(v.n_local_==v.n_ && "only for local/non-distributed vectors");
 #endif
   assert((start_idx_dest>=0 && start_idx_dest<this->n_local_) || this->n_local_==0);
-  const hiopVectorPar& v = dynamic_cast<const hiopVectorPar&>(v_in);
   assert((start_idx_src>=0 && start_idx_src<v.n_local_) || v.n_local_==0 || v.n_local_==start_idx_src);
   size_type howManyToCopySrc = v.n_local_-start_idx_src;
 

--- a/src/LinAlg/hiopVectorPar.cpp
+++ b/src/LinAlg/hiopVectorPar.cpp
@@ -245,12 +245,14 @@ void hiopVectorPar::startingAtCopyFromStartingAt(int start_idx_dest,
                                                  const hiopVector& v_in,
                                                  int start_idx_src)
 {
-  const hiopVectorPar& v = dynamic_cast<const hiopVectorPar&>(v_in);
   size_type howManyToCopyDest = this->n_local_ - start_idx_dest;
 
-//  assert(n_local_==n_ && "only for local/non-distributed vectors");
-//  assert(v.n_local_==v.n_ && "only for local/non-distributed vectors");
+#ifdef HIOP_DEEPCHECKS
+  assert(n_local_==n_ && "only for local/non-distributed vectors");
+  assert(v.n_local_==v.n_ && "only for local/non-distributed vectors");
+#endif
   assert((start_idx_dest>=0 && start_idx_dest<this->n_local_) || this->n_local_==0);
+  const hiopVectorPar& v = dynamic_cast<const hiopVectorPar&>(v_in);
   assert((start_idx_src>=0 && start_idx_src<v.n_local_) || v.n_local_==0 || v.n_local_==start_idx_src);
   size_type howManyToCopySrc = v.n_local_-start_idx_src;
 
@@ -270,14 +272,18 @@ void hiopVectorPar::startingAtCopyFromStartingAt(int start_idx_dest,
 void hiopVectorPar::copyToStarting(int start_index, hiopVector& v_) const
 {
   hiopVectorPar& v = dynamic_cast<hiopVectorPar&>(v_);
-//  assert(n_local_==n_ && "are you sure you want to call this?");
+#ifdef HIOP_DEEPCHECKS
+  assert(n_local_==n_ && "are you sure you want to call this?");
+#endif
   assert(start_index+v.n_local_ <= n_local_);
   v.exec_space_.copy(v.data_, data_+start_index, v.n_local_, exec_space_);
 }
 /* Copy 'this' to v starting at start_index in 'v'. */
 void hiopVectorPar::copyToStarting(hiopVector& v_, int start_index/*_in_dest*/) const
 {
-//  assert(n_local_==n_ && "only for local/non-distributed vectors");
+#ifdef HIOP_DEEPCHECKS
+  assert(n_local_==n_ && "only for local/non-distributed vectors");
+#endif
   hiopVectorPar& v = dynamic_cast<hiopVectorPar&>(v_);
   assert(start_index+n_local_ <= v.n_local_);
   v.exec_space_.copy(v.data_+start_index, data_, n_local_, exec_space_); 

--- a/src/LinAlg/hiopVectorPar.cpp
+++ b/src/LinAlg/hiopVectorPar.cpp
@@ -242,16 +242,15 @@ void hiopVectorPar::copy_from_starting_at(const double* v, int start_index_in_v,
 }
 
 void hiopVectorPar::startingAtCopyFromStartingAt(int start_idx_dest, 
-						 const hiopVector& v_in, 
-						 int start_idx_src)
+                                                 const hiopVector& v_in,
+                                                 int start_idx_src)
 {
-  size_type howManyToCopyDest = this->n_local_ - start_idx_dest;
-  
-#ifdef HIOP_DEEPCHECKS
-  assert(n_local_==n_ && "only for local/non-distributed vectors");
-#endif
-  assert((start_idx_dest>=0 && start_idx_dest<this->n_local_) || this->n_local_==0);
   const hiopVectorPar& v = dynamic_cast<const hiopVectorPar&>(v_in);
+  size_type howManyToCopyDest = this->n_local_ - start_idx_dest;
+
+//  assert(n_local_==n_ && "only for local/non-distributed vectors");
+//  assert(v.n_local_==v.n_ && "only for local/non-distributed vectors");
+  assert((start_idx_dest>=0 && start_idx_dest<this->n_local_) || this->n_local_==0);
   assert((start_idx_src>=0 && start_idx_src<v.n_local_) || v.n_local_==0 || v.n_local_==start_idx_src);
   size_type howManyToCopySrc = v.n_local_-start_idx_src;
 
@@ -271,18 +270,14 @@ void hiopVectorPar::startingAtCopyFromStartingAt(int start_idx_dest,
 void hiopVectorPar::copyToStarting(int start_index, hiopVector& v_) const
 {
   hiopVectorPar& v = dynamic_cast<hiopVectorPar&>(v_);
-#ifdef HIOP_DEEPCHECKS
-  assert(n_local_==n_ && "are you sure you want to call this?");
-#endif
+//  assert(n_local_==n_ && "are you sure you want to call this?");
   assert(start_index+v.n_local_ <= n_local_);
   v.exec_space_.copy(v.data_, data_+start_index, v.n_local_, exec_space_);
 }
 /* Copy 'this' to v starting at start_index in 'v'. */
 void hiopVectorPar::copyToStarting(hiopVector& v_, int start_index/*_in_dest*/) const
 {
-#ifdef HIOP_DEEPCHECKS
-  assert(n_local_==n_ && "only for local/non-distributed vectors");
-#endif
+//  assert(n_local_==n_ && "only for local/non-distributed vectors");
   hiopVectorPar& v = dynamic_cast<hiopVectorPar&>(v_);
   assert(start_index+n_local_ <= v.n_local_);
   v.exec_space_.copy(v.data_+start_index, data_, n_local_, exec_space_); 

--- a/src/Optimization/hiopHessianLowRank.cpp
+++ b/src/Optimization/hiopHessianLowRank.cpp
@@ -920,7 +920,7 @@ void hiopHessianLowRank::timesVecCmn(double beta, hiopVector& y, double alpha, c
   //we have B+=B-B*s*B*s'/(s'*B*s)+yy'/(y'*s)
   //B0 is sigma*I. There is an additional diagonal log-barrier term _Dx
 
-  bool print=FOOTPRINT_INTERVAL_RESET;
+  bool print=false;
   if(print) {
     nlp->log->printf(hovMatrices, "---hiopHessianLowRank::timesVec \n");
     nlp->log->write("S=", *St, hovMatrices);

--- a/src/Optimization/hiopHessianLowRank.hpp
+++ b/src/Optimization/hiopHessianLowRank.hpp
@@ -109,19 +109,19 @@ public:
   virtual void symMatTimesInverseTimesMatTrans(double beta, hiopMatrixDense& W_, 
 					       double alpha, const hiopMatrixDense& X);
 #ifdef HIOP_DEEPCHECKS
+  /* same as above but without the Dx term in H */
+  virtual void timesVec_noLogBarrierTerm(double beta, hiopVector& y, double alpha, const hiopVector&x);
+  virtual void print(FILE* f, hiopOutVerbosity v, const char* msg) const;
+#endif
+
   /* computes the product of the Hessian with a vector: y=beta*y+alpha*H*x.
    * The function is supposed to use the underlying ***recursive*** definition of the 
    * quasi-Newton Hessian and is used for checking/testing/error calculation.
    */
   virtual void timesVec(double beta, hiopVector& y, double alpha, const hiopVector&x);
 
-  /* same as above but without the Dx term in H */
-  virtual void timesVec_noLogBarrierTerm(double beta, hiopVector& y, double alpha, const hiopVector&x);
   /* code shared by the above two methods*/
-  virtual void timesVecCmn(double beta, hiopVector& y, double alpha, const hiopVector&x, bool addLogBarTerm);
-
-  virtual void print(FILE* f, hiopOutVerbosity v, const char* msg) const;
-#endif
+  virtual void timesVecCmn(double beta, hiopVector& y, double alpha, const hiopVector&x, bool addLogBarTerm = false) const;
 
 protected:
   int l_max; //max memory size
@@ -133,11 +133,9 @@ protected:
   hiopNlpDenseConstraints* nlp;
 private:
   hiopVector* DhInv; //(B0+Dk)^{-1}
-#ifdef HIOP_DEEPCHECKS
-  // needed in timesVec (for residual checking in solveCompressed, only HIOP_DEEPCHECKS mode).
+  // needed in timesVec (for residual checking in solveCompressed.
   // can be recomputed from DhInv decided to store it instead to avoid round-off errors
-  hiopVector* _Dx; 
-#endif
+  hiopVector* _Dx;
   bool matrixChanged;
   //these are matrices from the compact representation; they are updated at each iteration.
   // more exactly Bk=B0-[B0*St' Yt']*[St*B0*St'  L]*[St*B0]
@@ -244,10 +242,8 @@ public:
     assert(false && "not provided because it is not needed");
   }
 
-  void timesVec(double beta, hiopVector& y, double alpha, const hiopVector&x) const
-  {
-    assert(false && "not provided because it is not needed");
-  }
+  void timesVec(double beta, hiopVector& y, double alpha, const hiopVector&x) const;
+
   /** y = beta * y + alpha * this^T * x */
   virtual void transTimesVec(double beta,   hiopVector& y,
 			     double alpha,  const hiopVector& x ) const

--- a/src/Optimization/hiopKKTLinSys.cpp
+++ b/src/Optimization/hiopKKTLinSys.cpp
@@ -927,7 +927,6 @@ bool hiopKKTLinSys::compute_directions_w_IR(const hiopResidual* resid, hiopItera
   const size_type nyc = resid->ryc->get_local_size();
   const size_type nyd = resid->ryd->get_local_size();
   size_type dim_rhs = 5*nx + 5*nd + nyc + nyd;
-  
   /***********************************************************************
    * solve the compressed system as a preconditioner
    * (be aware that rx_tilde is reused/modified inside this function)

--- a/src/Optimization/hiopKKTLinSysDense.hpp
+++ b/src/Optimization/hiopKKTLinSysDense.hpp
@@ -174,7 +174,8 @@ public:
     hiopLinSolverSymDense* linSys = dynamic_cast<hiopLinSolverSymDense*> (linSys_);
     assert(linSys && "fail to get an object for correct linear system");
 
-    int nx=rx.get_size(), nyc=ryc.get_size(), nyd=ryd.get_size();
+    int nx=rx.get_local_size(), nyc=ryc.get_local_size(), nyd=ryd.get_local_size();
+
     if(rhsXYcYd == nullptr) {
       rhsXYcYd = LinearAlgebraFactory::create_vector(nlp_->options->GetString("mem_space"),
                                                      nx+nyc+nyd);

--- a/src/Optimization/hiopKKTLinSysDense.hpp
+++ b/src/Optimization/hiopKKTLinSysDense.hpp
@@ -174,8 +174,7 @@ public:
     hiopLinSolverSymDense* linSys = dynamic_cast<hiopLinSolverSymDense*> (linSys_);
     assert(linSys && "fail to get an object for correct linear system");
 
-    int nx=rx.get_local_size(), nyc=ryc.get_local_size(), nyd=ryd.get_local_size();
-
+    int nx=rx.get_size(), nyc=ryc.get_size(), nyd=ryd.get_size();
     if(rhsXYcYd == nullptr) {
       rhsXYcYd = LinearAlgebraFactory::create_vector(nlp_->options->GetString("mem_space"),
                                                      nx+nyc+nyd);

--- a/src/Utils/hiopOptions.cpp
+++ b/src/Utils/hiopOptions.cpp
@@ -1314,18 +1314,6 @@ void hiopOptionsNLP::ensure_consistence()
       }
       set_val("duals_update_type", "linear");
     }
-  } else {
-    size_type ir_outer_maxit = GetInteger("ir_outer_maxit");
-    if( 0 != ir_outer_maxit) {
-      //warn only if these are defined by the user (option file or via SetXXX methods)
-      if(is_user_defined("ir_outer_maxit")) {
-        log_printf(hovWarning,
-                   "The option 'ir_outer_maxit=%d' is not valid with 'Hessian=quasinewton_approx'. "
-                   "Will use 'ir_outer_maxit=0'.\n",
-                   ir_outer_maxit);
-      }
-      set_val("ir_outer_maxit", 0);
-    }
   }
 
   //


### PR DESCRIPTION
Add outer iterative refinement into the dense solver.

Serial code, i.e., not mpi support. 
Compound vector may be required.

See #616 