### PR TITLE
Add MPI unit test for DenseEx4

### DIFF
--- a/src/Drivers/Dense/CMakeLists.txt
+++ b/src/Drivers/Dense/CMakeLists.txt
@@ -42,10 +42,13 @@ add_test(NAME NlpDenseCons2_UN_5K COMMAND  ${RUNCMD} "$<TARGET_FILE:NlpDenseCons
 add_test(NAME NlpDenseCons3_5H    COMMAND  ${RUNCMD} "$<TARGET_FILE:NlpDenseConsEx3.exe>"   "500" "-selfcheck")
 add_test(NAME NlpDenseCons3_5K    COMMAND  ${RUNCMD} "$<TARGET_FILE:NlpDenseConsEx3.exe>"  "5000" "-selfcheck")
 add_test(NAME NlpDenseCons3_50K   COMMAND  ${RUNCMD} "$<TARGET_FILE:NlpDenseConsEx3.exe>" "50000" "-selfcheck")
-add_test(NAME NlpDenseCons4       COMMAND  ${RUNCMD} "$<TARGET_FILE:NlpDenseConsEx4.exe>" "-selfcheck")
-
 if(HIOP_USE_MPI)
   add_test(NAME NlpDenseCons3_50K_mpi COMMAND ${MPICMD} -n 2 "$<TARGET_FILE:NlpDenseConsEx3.exe>" "50000" "-selfcheck")
+endif(HIOP_USE_MPI)
+
+add_test(NAME NlpDenseCons4       COMMAND  ${RUNCMD} "$<TARGET_FILE:NlpDenseConsEx4.exe>" "-selfcheck")
+if(HIOP_USE_MPI)
+  add_test(NAME NlpDenseCons4_mpi COMMAND ${MPICMD} -n 2 "$<TARGET_FILE:NlpDenseConsEx4.exe>" "-selfcheck")
 endif(HIOP_USE_MPI)
 
 if(HIOP_WITH_VALGRIND_TESTS)

--- a/src/Drivers/Dense/NlpDenseConsEx4.cpp
+++ b/src/Drivers/Dense/NlpDenseConsEx4.cpp
@@ -254,31 +254,51 @@ bool DenseConsEx4::eval_Jac_cons(const size_type& n,
 
     assert(itcon*n_local+n_local <= n_local*num_cons);
 
-    //Jacobian of constraint 1 is all zero
+    //Jacobian of constraint 1
     if(idx_cons[itcon]==0) {
-      Jac[itcon*n_local+0] = idx_local2global(n,0)==0?(-0.12*x[0]):0.;
-      Jac[itcon*n_local+1] = idx_local2global(n,1)==1?1.:0.;
+      for(int i = 0; i < n_local; ++i) {
+        if(idx_local2global(n,i)==0) {
+          Jac[itcon*n_local+i] = -0.12*x[i];
+        } else if (idx_local2global(n,i)==1) {
+          Jac[itcon*n_local+i] = 1.0;
+        }
+      }
       continue;
     }
     
-    //Jacobian of constraint 2 is all ones except the first entry, which is 2
+    //Jacobian of constraint 2
     if(idx_cons[itcon]==1) {
-      Jac[itcon*n_local+0] = idx_local2global(n,0)==0?(0.1*x[0]):0.;
-      Jac[itcon*n_local+1] = idx_local2global(n,1)==1?1.:0.;
+      for(int i = 0; i < n_local; ++i) {
+        if(idx_local2global(n,i)==0) {
+          Jac[itcon*n_local+i] = 0.1*x[i];
+        } else if (idx_local2global(n,i)==1) {
+          Jac[itcon*n_local+i] = 1.0;
+        }
+      }
       continue;
     }
     
     //Jacobian of constraint 3
     if(idx_cons[itcon]==2) {
-      Jac[itcon*n_local+0] = idx_local2global(n,0)==0?0.:0.;
-      Jac[itcon*n_local+1] = idx_local2global(n,1)==1?(2.*x[1]):0.;
+      for(int i = 0; i < n_local; ++i) {
+        if(idx_local2global(n,i)==0) {
+          Jac[itcon*n_local+i] = 0.0;
+        } else if (idx_local2global(n,i)==1) {
+          Jac[itcon*n_local+i] = 2.*x[i];
+        }
+      }
       continue;
     }
     
     //Jacobian of constraint  4
     if(idx_cons[itcon]==3) {
-      Jac[itcon*n_local+0] = idx_local2global(n,0)==0?(2.*x[0]):0.;
-      Jac[itcon*n_local+1] = idx_local2global(n,1)==1?0.:0.;
+      for(int i = 0; i < n_local; ++i) {
+        if(idx_local2global(n,i)==0) {
+          Jac[itcon*n_local+i] = 2.*x[i];
+        } else if (idx_local2global(n,i)==1) {
+          Jac[itcon*n_local+i] = 0.0;
+        }
+      }
     }
   }
   return true;

--- a/src/Drivers/Dense/NlpDenseConsEx4Driver.cpp
+++ b/src/Drivers/Dense/NlpDenseConsEx4Driver.cpp
@@ -69,6 +69,10 @@ int main(int argc, char **argv)
   hiopSolveStatus status = solver.run();
 
   double obj_value = solver.getObjective();
+
+#ifdef HIOP_USE_MPI
+  MPI_Finalize();
+#endif
   
   if(status<0) {
     if(rank==0) printf("solver returned negative solve status: %d (with objective is %18.12e)\n", status, obj_value);
@@ -85,10 +89,6 @@ int main(int argc, char **argv)
       printf("Optimal objective: %22.14e. Solver status: %d\n", obj_value, status);
     }
   }
-
-#ifdef HIOP_USE_MPI
-  MPI_Finalize();
-#endif
 
   return 0;
 }


### PR DESCRIPTION
Allow using MPI in the example `hiopDenseEx4` and add a new unit test for that.