### PR TITLE
Add more options to control NLP scaling

### DIFF
--- a/doc/src/sections/solver_options.tex
+++ b/doc/src/sections/solver_options.tex
@@ -404,6 +404,15 @@ This option takes double values in $[0, 10^{20}]$ and has a default value $10^{-
 \noindent \textbf{scaling\_max\_grad}: the user's NLP will be rescaled if the inf-norm of the gradient at the starting point is larger than the value of this option. Double values in $[10^{-20}, 10^{20}]$. Default value: $100$.
 \medskip
 
+\noindent \textbf{scaling_max_obj_grad}: if a positive value is given, the objective of user's NLP will be scaled so that the inf-norm of its gradient is equal to the given value. This value overwrites the value given by ``scaling\_max\_grad''. Double values in $[0, 10^{20}]$. Default value: $0$.
+\medskip
+
+\noindent \textbf{scaling_max_con_grad}: if a positive value is given, each constraint of user's NLP will be scaled so that the inf-norm of its gradient is equal to the given value. This value overwrites the value given by ``scaling\_max\_grad''. Double values in $[0, 10^{20}]$. Default value: $0$.
+\medskip
+
+\noindent \textbf{scaling\_min\_grad}: If a positive value is given, it is used as the lower bound for the scaling factors. This option has a priority, i.e., the final scaling factor computed must greater or equal to this value, even thought it may violate the values given in ``scaling\_max\_grad'', ``scaling\_max\_obj\_grad'' and ``scaling\_max\_con\_grad''. Double values in $[0, 10^{20}]$. Default value: $10^{-8}$.
+\medskip
+
 \noindent \textbf{eq\_relax\_factor}: perturbation of the equalities to allow posing them as inequalities. This factor is relative to the maximum between the magnitude of the equalities rhs and 1.0. Used only by `hiopNlpSparseIneq' formulation class. Double values in $[10^{-15}, 1]$. Default value: $10^{-8}$.
 \medskip
 

--- a/doc/src/sections/solver_options.tex
+++ b/doc/src/sections/solver_options.tex
@@ -404,13 +404,13 @@ This option takes double values in $[0, 10^{20}]$ and has a default value $10^{-
 \noindent \textbf{scaling\_max\_grad}: the user's NLP will be rescaled if the inf-norm of the gradient at the starting point is larger than the value of this option. After rescaling, the inf-norm of the gradient will equal the value of this option. Double values in $[10^{-20}, 10^{20}]$. Default value: $100$.
 \medskip
 
-\noindent \textbf{scaling_max_obj_grad}: if a positive value is given, the objective of user's NLP will be scaled so that the inf-norm of its gradient is equal to the value of this option. This option takes precedence over ``scaling\_max\_grad''. Double values in $[0, 10^{20}]$. Default value: $0$.
+\noindent \textbf{scaling\_max\_obj\_grad}: if a positive value is given, the objective of user's NLP will be scaled so that the inf-norm of its gradient is equal to the value of this option. This option takes precedence over ``scaling\_max\_grad''. Double values in $[0, 10^{20}]$. Default value: $0$.
 \medskip
 
-\noindent \textbf{scaling_max_con_grad}: if a positive value is given, each constraint of user's NLP will be scaled so that the inf-norm of its gradient is equal to the value of this. This option takes precedence over ``scaling\_max\_grad''. Double values in $[0, 10^{20}]$. Default value: $0$.
+\noindent \textbf{scaling\_max\_con\_grad}: if a positive value is given, each constraint of user's NLP will be scaled so that the inf-norm of its gradient is equal to the value of this. This option takes precedence over ``scaling\_max\_grad''. Double values in $[0, 10^{20}]$. Default value: $0$.
 \medskip
 
-\noindent \textbf{scaling\_min\_grad}: A positive value for this option will be used as a lower bound for (and will overwrite) the scaling factors computed as instructed by options ``scaling\_max\_grad'', ``scaling\_max\_obj\_grad'' and ``scaling\_max\_con\_grad''. Double values in $[0, 10^{20}]$. Default value: $10^{-8}$.
+\noindent \textbf{scaling\_min\_grad}: a positive value for this option will be used as a lower bound for (and will overwrite) the scaling factors computed as instructed by options ``scaling\_max\_grad'', ``scaling\_max\_obj\_grad'' and ``scaling\_max\_con\_grad''. Double values in $[0, 10^{20}]$. Default value: $10^{-8}$.
 \medskip
 
 \noindent \textbf{eq\_relax\_factor}: perturbation of the equalities to allow posing them as inequalities. This factor is relative to the maximum between the magnitude of the equalities rhs and 1.0. Used only by `hiopNlpSparseIneq' formulation class. Double values in $[10^{-15}, 1]$. Default value: $10^{-8}$.

--- a/doc/src/sections/solver_options.tex
+++ b/doc/src/sections/solver_options.tex
@@ -401,16 +401,16 @@ This option takes double values in $[0, 10^{20}]$ and has a default value $10^{-
 \end{itemize}
 \medskip
 
-\noindent \textbf{scaling\_max\_grad}: the user's NLP will be rescaled if the inf-norm of the gradient at the starting point is larger than the value of this option. Double values in $[10^{-20}, 10^{20}]$. Default value: $100$.
+\noindent \textbf{scaling\_max\_grad}: the user's NLP will be rescaled if the inf-norm of the gradient at the starting point is larger than the value of this option. After rescaling, the inf-norm of the gradient will equal the value of this option. Double values in $[10^{-20}, 10^{20}]$. Default value: $100$.
 \medskip
 
-\noindent \textbf{scaling_max_obj_grad}: if a positive value is given, the objective of user's NLP will be scaled so that the inf-norm of its gradient is equal to the given value. This value overwrites the value given by ``scaling\_max\_grad''. Double values in $[0, 10^{20}]$. Default value: $0$.
+\noindent \textbf{scaling_max_obj_grad}: if a positive value is given, the objective of user's NLP will be scaled so that the inf-norm of its gradient is equal to the value of this option. This option takes precedence over ``scaling\_max\_grad''. Double values in $[0, 10^{20}]$. Default value: $0$.
 \medskip
 
-\noindent \textbf{scaling_max_con_grad}: if a positive value is given, each constraint of user's NLP will be scaled so that the inf-norm of its gradient is equal to the given value. This value overwrites the value given by ``scaling\_max\_grad''. Double values in $[0, 10^{20}]$. Default value: $0$.
+\noindent \textbf{scaling_max_con_grad}: if a positive value is given, each constraint of user's NLP will be scaled so that the inf-norm of its gradient is equal to the value of this. This option takes precedence over ``scaling\_max\_grad''. Double values in $[0, 10^{20}]$. Default value: $0$.
 \medskip
 
-\noindent \textbf{scaling\_min\_grad}: If a positive value is given, it is used as the lower bound for the scaling factors. This option has a priority, i.e., the final scaling factor computed must greater or equal to this value, even thought it may violate the values given in ``scaling\_max\_grad'', ``scaling\_max\_obj\_grad'' and ``scaling\_max\_con\_grad''. Double values in $[0, 10^{20}]$. Default value: $10^{-8}$.
+\noindent \textbf{scaling\_min\_grad}: A positive value for this option will be used as a lower bound for (and will overwrite) the scaling factors computed as instructed by options ``scaling\_max\_grad'', ``scaling\_max\_obj\_grad'' and ``scaling\_max\_con\_grad''. Double values in $[0, 10^{20}]$. Default value: $10^{-8}$.
 \medskip
 
 \noindent \textbf{eq\_relax\_factor}: perturbation of the equalities to allow posing them as inequalities. This factor is relative to the maximum between the magnitude of the equalities rhs and 1.0. Used only by `hiopNlpSparseIneq' formulation class. Double values in $[10^{-15}, 1]$. Default value: $10^{-8}$.

--- a/src/Optimization/hiopNlpFormulation.cpp
+++ b/src/Optimization/hiopNlpFormulation.cpp
@@ -681,23 +681,32 @@ bool hiopNlpFormulation::apply_scaling(hiopVector& c, hiopVector& d, hiopVector&
   }
   
   const double max_grad = options->GetNumeric("scaling_max_grad");
+  const double max_obj_grad = options->GetNumeric("scaling_max_obj_grad");
+  const double max_con_grad = options->GetNumeric("scaling_max_con_grad");
+  double obj_grad_target = max_grad;
+  double con_grad_target = max_grad;
+  if(max_obj_grad > 0) {
+    obj_grad_target = max_obj_grad;
+  }
+  if(max_con_grad > 0) {
+    con_grad_target = max_con_grad;
+  }
 
-  if(gradf.infnorm() < max_grad &&
-     Jac_c.max_abs_value() < max_grad &&
-     Jac_d.max_abs_value() < max_grad)
+  if(gradf.infnorm() < obj_grad_target       &&
+     Jac_c.max_abs_value() < con_grad_target &&
+     Jac_d.max_abs_value() < con_grad_target)
   {
     return false;
   }
   
   nlp_scaling_ = new hiopNLPObjGradScaling(this,
-                                          max_grad,
-                                          c,
-                                          d,
-                                          gradf,
-                                          Jac_c,
-                                          Jac_d,
-                                          *cons_eq_mapping_,
-                                          *cons_ineq_mapping_);
+                                           c,
+                                           d,
+                                           gradf,
+                                           Jac_c,
+                                           Jac_d,
+                                           *cons_eq_mapping_,
+                                           *cons_ineq_mapping_);
   
   c_rhs_ = nlp_scaling_->apply_to_cons_eq(*c_rhs_, n_cons_eq_);
   dl_ = nlp_scaling_->apply_to_cons_ineq(*dl_, n_cons_ineq_);

--- a/src/Optimization/hiopNlpTransforms.cpp
+++ b/src/Optimization/hiopNlpTransforms.cpp
@@ -416,7 +416,6 @@ relax_from_ori(const double& bound_relax_perturb, hiopVector& xl, hiopVector& xu
 * For class hiopNLPObjGradScaling
 */
 hiopNLPObjGradScaling::hiopNLPObjGradScaling(hiopNlpFormulation* nlp,
-                                             const double& max_grad, 
                                              hiopVector& c, 
                                              hiopVector& d, 
                                              hiopVector& gradf,
@@ -429,9 +428,24 @@ hiopNLPObjGradScaling::hiopNLPObjGradScaling(hiopNlpFormulation* nlp,
     scale_factor_obj(1.),
     n_eq(c.get_size()), n_ineq(d.get_size())
 {
-  scale_factor_obj = max_grad/gradf.infnorm();
-  if(scale_factor_obj>1.) {
-    scale_factor_obj=1.;
+  const double max_grad = nlp_->options->GetNumeric("scaling_max_grad");
+  const double min_grad = nlp_->options->GetNumeric("scaling_min_grad");
+  const double max_obj_grad = nlp_->options->GetNumeric("scaling_max_obj_grad");
+  const double max_con_grad = nlp_->options->GetNumeric("scaling_max_con_grad");
+
+  const double gradf_infnorm = gradf.infnorm();  
+  scale_factor_obj = 1.;
+  if(max_obj_grad == 0.) {
+    if(gradf_infnorm > max_grad) {
+      scale_factor_obj = max_grad / gradf.infnorm();
+    }
+  } else {
+    if(gradf_infnorm > 0.) {
+      scale_factor_obj = max_obj_grad / gradf.infnorm();
+    }
+  }
+  if(scale_factor_obj < min_grad) {
+    scale_factor_obj = min_grad;
   }
   
   scale_factor_c = c.new_copy();
@@ -455,6 +469,30 @@ hiopNLPObjGradScaling::hiopNLPObjGradScaling(hiopNlpFormulation* nlp,
 
   scale_factor_cd->copy_from_two_vec_w_pattern(*scale_factor_c, cons_eq_mapping, *scale_factor_d, cons_ineq_mapping);
 
+  Jac_c.row_max_abs_value(*scale_factor_c);
+  Jac_d.row_max_abs_value(*scale_factor_d);
+  if(max_con_grad == 0.) {
+    if(scale_factor_c->infnorm() > max_grad){
+      scale_factor_c->scale(1./max_grad);
+      scale_factor_c->component_max(1.0);
+      scale_factor_c->invert();               
+    } else {
+      scale_factor_c->setToConstant(1.0);
+    }
+    
+    if(scale_factor_d->infnorm() > max_grad){
+      scale_factor_d->scale(1./max_grad);
+      scale_factor_d->component_max(1.0);
+      scale_factor_d->invert();               
+    } else {
+      scale_factor_d->setToConstant(1.0);
+    }
+  } else {
+    scale_factor_c->setToConstant(max_con_grad / scale_factor_c->infnorm());
+    scale_factor_d->setToConstant(max_con_grad / scale_factor_d->infnorm());
+  }
+  scale_factor_c->component_max(min_grad);
+  scale_factor_d->component_max(min_grad);
 }
 
 hiopNLPObjGradScaling::~hiopNLPObjGradScaling()

--- a/src/Optimization/hiopNlpTransforms.cpp
+++ b/src/Optimization/hiopNlpTransforms.cpp
@@ -444,7 +444,7 @@ hiopNLPObjGradScaling::hiopNLPObjGradScaling(hiopNlpFormulation* nlp,
       scale_factor_obj = max_obj_grad / gradf.infnorm();
     }
   }
-  if(scale_factor_obj < min_grad) {
+  if(min_grad > 0.0 && scale_factor_obj < min_grad) {
     scale_factor_obj = min_grad;
   }
   
@@ -491,8 +491,10 @@ hiopNLPObjGradScaling::hiopNLPObjGradScaling(hiopNlpFormulation* nlp,
     scale_factor_c->setToConstant(max_con_grad / scale_factor_c->infnorm());
     scale_factor_d->setToConstant(max_con_grad / scale_factor_d->infnorm());
   }
-  scale_factor_c->component_max(min_grad);
-  scale_factor_d->component_max(min_grad);
+  if(min_grad > 0.0) {
+    scale_factor_c->component_max(min_grad);
+    scale_factor_d->component_max(min_grad);
+  }
 }
 
 hiopNLPObjGradScaling::~hiopNLPObjGradScaling()

--- a/src/Optimization/hiopNlpTransforms.hpp
+++ b/src/Optimization/hiopNlpTransforms.hpp
@@ -352,7 +352,6 @@ class hiopNLPObjGradScaling : public hiopNlpTransformation
 {
 public:
   hiopNLPObjGradScaling(hiopNlpFormulation* nlp,
-                        const double& max_grad, 
                         hiopVector& c, 
                         hiopVector& d, 
                         hiopVector& gradf,

--- a/src/Utils/hiopOptions.cpp
+++ b/src/Utils/hiopOptions.cpp
@@ -773,7 +773,7 @@ void hiopOptionsNLP::register_options()
                         1e+20,
                         "If a positive value is given, the objective of user's NLP will be scaled so that the "
                         "inf-norm of its gradient is equal to the value of this option. This option takes "
-                        "precedence over scaling_max_grad.")
+                        "precedence over scaling_max_grad.");
 
     register_num_option("scaling_max_con_grad",
                         0.0,

--- a/src/Utils/hiopOptions.cpp
+++ b/src/Utils/hiopOptions.cpp
@@ -766,6 +766,31 @@ void hiopOptionsNLP::register_options()
                         1e+20,
                         "The user's NLP will be rescaled if the inf-norm of the gradient at the starting point is "
                         "larger than the value of this option (default 100)");
+
+    register_num_option("scaling_max_obj_grad",
+                        0.0,
+                        0.0,
+                        1e+20,
+                        "If a positive value is given, the objective of user's NLP will be scaled "
+                        "so that the inf-norm of its gradient is equal to the given value. This value "
+                        "overwrites the value given by scaling_max_grad.");
+
+    register_num_option("scaling_max_con_grad",
+                        0.0,
+                        0.0,
+                        1e+20,
+                        "If a positive value is given, the constraints of user's NLP will be scaled "
+                        "so that the inf-norm of its gradient is equal to the given value. This value "
+                        "overwrites the value given by scaling_max_grad.");
+
+    register_num_option("scaling_min_grad",
+                        1e-8,
+                        0.0,
+                        1e+20,
+                        "If a positive value is given, it is used as the lower bound for the scaling factors. "
+                        "This option has a priority, i.e., the final scaling factor computed must greater or "
+                        "equal to this value, even thought it may violate the values given in scaling_max_grad, "
+                        "scaling_max_obj_grad and scaling_max_con_grad");
   }
 
   // outer iterative refinement

--- a/src/Utils/hiopOptions.cpp
+++ b/src/Utils/hiopOptions.cpp
@@ -771,26 +771,24 @@ void hiopOptionsNLP::register_options()
                         0.0,
                         0.0,
                         1e+20,
-                        "If a positive value is given, the objective of user's NLP will be scaled "
-                        "so that the inf-norm of its gradient is equal to the given value. This value "
-                        "overwrites the value given by scaling_max_grad.");
+                        "If a positive value is given, the objective of user's NLP will be scaled so that the "
+                        "inf-norm of its gradient is equal to the value of this option. This option takes "
+                        "precedence over scaling_max_grad.")
 
     register_num_option("scaling_max_con_grad",
                         0.0,
                         0.0,
                         1e+20,
-                        "If a positive value is given, the constraints of user's NLP will be scaled "
-                        "so that the inf-norm of its gradient is equal to the given value. This value "
-                        "overwrites the value given by scaling_max_grad.");
+                        "If a positive value is given, each constraint of user's NLP will be scaled so that the "
+                        "inf-norm of its gradient is equal to the value of this option. This option takes "
+                        "precedence over scaling_max_grad.");
 
     register_num_option("scaling_min_grad",
                         1e-8,
                         0.0,
                         1e+20,
-                        "If a positive value is given, it is used as the lower bound for the scaling factors. "
-                        "This option has a priority, i.e., the final scaling factor computed must greater or "
-                        "equal to this value, even thought it may violate the values given in scaling_max_grad, "
-                        "scaling_max_obj_grad and scaling_max_con_grad");
+                        "a positive value for this option will be used as a lower bound for (and will overwrite) "
+                        "the scaling factors computed as instructed by options scaling_max_grad, scaling_max_obj_grad and scaling_max_con_grad.");
   }
 
   // outer iterative refinement


### PR DESCRIPTION
In this PR, the following user parameters are introduced:

`scaling_max_obj_grad`: If a positive value is given, the objective of user's NLP will be scaled so that the inf-norm of its gradient is equal to the given value. This value overwrites the value given by `scaling_max_grad`. Default value is 0

`scaling_max_con_grad`: If a positive value is given, the constraints of user's NLP will be scaled so that the inf-norm of its gradient is equal to the given value. This value overwrites the value given by `scaling_max_grad`. Default value is 0

`scaling_min_grad`: If a positive value is given, it is used as the lower bound for the scaling factors. This option has a priority, i.e., the final scaling factor computed must greater or equal to this value, even thought it may violate the values given in `scaling_max_grad`, `scaling_max_obj_grad` and `scaling_max_con_grad`. Default value is 1e-8

CLOSE #648 