### PR TITLE
Fix a bug in copying an empty matrix into a bigger matrix

### DIFF
--- a/src/LinAlg/hiopMatrixRajaSparseTripletImpl.hpp
+++ b/src/LinAlg/hiopMatrixRajaSparseTripletImpl.hpp
@@ -1114,6 +1114,10 @@ copyRowsBlockFrom(const hiopMatrix& src_gen,
                   const index_type& rows_dst_idx_st,
                   const size_type& dest_nnz_st)
 {
+  if(n_rows <= 0) {
+    return;
+  }
+
   const hiopMatrixRajaSparseTriplet& src = dynamic_cast<const hiopMatrixRajaSparseTriplet&>(src_gen);
   assert(this->numberOfNonzeros() >= src.numberOfNonzeros());
   assert(this->n() >= src.n());

--- a/tests/LinAlg/matrixTestsRajaSparseTriplet.cpp
+++ b/tests/LinAlg/matrixTestsRajaSparseTriplet.cpp
@@ -355,7 +355,7 @@ void MatrixTestsRajaSparseTriplet::initializeMatrix(
 
   assert(A->numberOfNonzeros() == m * entries_per_row && "Matrix initialized with insufficent number of non-zero entries");
   A->copyFromDev();
-  for(local_ordinal_type row = 0, col = 0, i = 0; row < m; row++, col = 0) 
+  for(local_ordinal_type row = 0, col = 0, i = 0; row < m && i < A->numberOfNonzeros(); row++, col = 0) 
   {
     for(local_ordinal_type j=0; j<entries_per_row-1; i++, j++, col += n / entries_per_row)
     {

--- a/tests/LinAlg/matrixTestsSparse.hpp
+++ b/tests/LinAlg/matrixTestsSparse.hpp
@@ -1034,7 +1034,7 @@ public:
     assert(A.n() >= B.n());
     assert(n_rows + A_rows_st <= A.m());
     assert(n_rows + B_rows_st <= B.m());
-    assert(nnz_A_need_to_copy<A_nnz);
+    assert(nnz_A_need_to_copy<=A_nnz);
     assert(nnz_A_need_to_copy+B_nnz_st<=B_nnz);
 
     const real_type A_val = one;

--- a/tests/LinAlg/matrixTestsSparseTriplet.cpp
+++ b/tests/LinAlg/matrixTestsSparseTriplet.cpp
@@ -314,7 +314,7 @@ void MatrixTestsSparseTriplet::initializeMatrix(
 
   assert(A->numberOfNonzeros() == m * entries_per_row && "Matrix initialized with insufficent number of non-zero entries");
 
-  for(local_ordinal_type row = 0, col = 0, i = 0; row < m; row++, col = 0) 
+  for(local_ordinal_type row = 0, col = 0, i = 0; row < m && i < A->numberOfNonzeros(); row++, col = 0) 
   {
     for(local_ordinal_type j=0; j<entries_per_row-1; i++, j++, col += n / entries_per_row)
     {

--- a/tests/testMatrixSparse.cpp
+++ b/tests/testMatrixSparse.cpp
@@ -217,7 +217,7 @@ int main(int argc, char** argv)
     // Remove testing objects
     delete mxn_sparse;
     delete mxn_empty;
-    delete nullxn_sparse
+    delete nullxn_sparse;
     delete m2xn_sparse;
     delete m3xn3_sparse;
     delete m4xn4_sparse;
@@ -374,7 +374,7 @@ int main(int argc, char** argv)
     // Remove testing objects
     delete mxn_sparse;
     delete mxn_empty;
-    delete nullxn_sparse
+    delete nullxn_sparse;
     delete mxn_sparse_2;
     delete m2xn_sparse;
     delete m3xn3_sparse;

--- a/tests/testMatrixSparse.cpp
+++ b/tests/testMatrixSparse.cpp
@@ -105,7 +105,15 @@ int main(int argc, char** argv)
     hiop::hiopMatrixSparse* mxn_sparse = 
       hiop::LinearAlgebraFactory::create_matrix_sparse(mem_space, M_local, N_local, nnz);
     test.initializeMatrix(mxn_sparse, entries_per_row);
-  
+
+    hiop::hiopMatrixSparse* mxn_empty = 
+      hiop::LinearAlgebraFactory::create_matrix_sparse(mem_space, M_local, N_global, 0);
+    test.initializeMatrix(mxn_empty, 0);
+
+    hiop::hiopMatrixSparse* nullxn_sparse = 
+      hiop::LinearAlgebraFactory::create_matrix_sparse(mem_space, 0, N_global, 0);
+    test.initializeMatrix(nullxn_sparse, 0);
+
     hiop::hiopVectorPar vec_m(M_global);
     hiop::hiopVectorPar vec_n(N_global);
 
@@ -172,7 +180,10 @@ int main(int argc, char** argv)
     // copy the 1st row of mxn_sparse to the last row in m2xn_sparse
     // replace the nonzero index from "nnz-entries_per_row"
     fail += test.copy_rows_block_from(*mxn_sparse, *m2xn_sparse,0, 1, M_global-1, mxn_sparse->numberOfNonzeros()-entries_per_row);
-
+    fail += test.copy_rows_block_from(*mxn_empty, *m2xn_sparse,0, 1, M_global-1, mxn_sparse->numberOfNonzeros());
+    fail += test.copy_rows_block_from(*nullxn_sparse, *m2xn_sparse,0, 0, M_global-1, mxn_sparse->numberOfNonzeros());
+    fail += test.copy_rows_block_from(*nullxn_sparse, *nullxn_sparse,0, 0, 0, nullxn_sparse->numberOfNonzeros());
+  
     // create a bigger matrix, to test copy_submatrix_from and opy_submatrix_from_trans
     hiop::hiopMatrixDenseRowMajor m4xn4_dense(2*M_global+N_global, 2*M_global+N_global);
     local_ordinal_type nnz4 = entries_per_row*(2*M_global+N_global);
@@ -232,7 +243,15 @@ int main(int argc, char** argv)
       hiop::LinearAlgebraFactory::create_matrix_sparse(mem_space, M_local, N_local, nnz);
 
     test.initializeMatrix(mxn_sparse, entries_per_row);
+
+    hiop::hiopMatrixSparse* mxn_empty = 
+      hiop::LinearAlgebraFactory::create_matrix_sparse(mem_space, M_local, N_global, 0);
+    test.initializeMatrix(mxn_empty, 0);
   
+    hiop::hiopMatrixSparse* nullxn_sparse = 
+    hiop::LinearAlgebraFactory::create_matrix_sparse(mem_space, 0, N_global, 0);
+    test.initializeMatrix(nullxn_sparse, 0);
+
     //hiop::hiopVectorRajaPar vec_m(M_global, mem_space);
     hiop::hiopVector* vec_m = hiop::LinearAlgebraFactory::create_vector(mem_space, M_global);
     hiop::hiopVector* vec_m_2 = hiop::LinearAlgebraFactory::create_vector(mem_space, M_global);
@@ -311,7 +330,10 @@ int main(int argc, char** argv)
     // copy the 1st row of mxn_sparse to the last row in m2xn_sparse
     // replace the nonzero index from "nnz-entries_per_row"
     fail += test.copy_rows_block_from(*mxn_sparse, *m2xn_sparse,0, 1, M_global-1, mxn_sparse->numberOfNonzeros()-entries_per_row);
-
+    fail += test.copy_rows_block_from(*mxn_empty, *m2xn_sparse,0, 1, M_global-1, mxn_sparse->numberOfNonzeros());
+    fail += test.copy_rows_block_from(*nullxn_sparse, *m2xn_sparse,0, 0, M_global-1, mxn_sparse->numberOfNonzeros());
+    fail += test.copy_rows_block_from(*nullxn_sparse, *nullxn_sparse,0, 0, 0, nullxn_sparse->numberOfNonzeros());
+    
     // create a bigger matrix, to test copy_submatrix_from and opy_submatrix_from_trans
     //hiop::hiopMatrixRajaDense m4xn4_dense(2*M_global+N_global, 2*M_global+N_global,mem_space);
     hiop::hiopMatrixDense* m4xn4_dense =

--- a/tests/testMatrixSparse.cpp
+++ b/tests/testMatrixSparse.cpp
@@ -216,6 +216,8 @@ int main(int argc, char** argv)
 
     // Remove testing objects
     delete mxn_sparse;
+    delete mxn_empty;
+    delete nullxn_sparse
     delete m2xn_sparse;
     delete m3xn3_sparse;
     delete m4xn4_sparse;
@@ -371,6 +373,8 @@ int main(int argc, char** argv)
 
     // Remove testing objects
     delete mxn_sparse;
+    delete mxn_empty;
+    delete nullxn_sparse
     delete mxn_sparse_2;
     delete m2xn_sparse;
     delete m3xn3_sparse;


### PR DESCRIPTION
There is a bug in RAJA implementation which fails HiOp when we copy an empty matrix into a bigger matrix.

This PR tries to:
1. modify the corresponding unit test to catch this segmentation failure.
2. Avoid copying an empty matrix in the RAJA implementation

CLOSE #665 

@pelesh @cameronrutherford @abhyshr
