### PR TITLE
Update ginkgo interface

### DIFF
--- a/src/Drivers/Sparse/CMakeLists.txt
+++ b/src/Drivers/Sparse/CMakeLists.txt
@@ -18,11 +18,10 @@ add_executable(NlpSparseEx4.exe NlpSparseEx4.cpp NlpSparseEx4Driver.cpp)
 target_link_libraries(NlpSparseEx4.exe HiOp::HiOp)
 
 if(HIOP_USE_RAJA)
-  if(HIOP_USE_GPU AND HIOP_USE_CUDA)
+  if(HIOP_USE_GPU)
     set_source_files_properties(
       NlpSparseRajaEx2.cpp 
       NlpSparseRajaEx2Driver.cpp 
-      PROPERTIES LANGUAGE CUDA
     )
   
     add_executable(NlpSparseRajaEx2.exe  NlpSparseRajaEx2Driver.cpp  NlpSparseRajaEx2.cpp)

--- a/src/Drivers/Sparse/NlpSparseEx1Driver.cpp
+++ b/src/Drivers/Sparse/NlpSparseEx1Driver.cpp
@@ -239,8 +239,12 @@ int main(int argc, char **argv)
     nlp.options->SetStringValue("fact_acceptor", "inertia_free");
     nlp.options->SetIntegerValue("ir_outer_maxit", 0);
     if (use_ginkgo_cuda) {
+        nlp.options->SetStringValue("mem_space", "device");
+        nlp.options->SetStringValue("compute_mode", "gpu");
         nlp.options->SetStringValue("ginkgo_exec", "cuda");
     } else if (use_ginkgo_hip) {
+        nlp.options->SetStringValue("mem_space", "device");
+        nlp.options->SetStringValue("compute_mode", "gpu");
         nlp.options->SetStringValue("ginkgo_exec", "hip");
     } else {
         nlp.options->SetStringValue("ginkgo_exec", "reference");

--- a/src/Drivers/Sparse/NlpSparseEx1Driver.cpp
+++ b/src/Drivers/Sparse/NlpSparseEx1Driver.cpp
@@ -239,11 +239,9 @@ int main(int argc, char **argv)
     nlp.options->SetStringValue("fact_acceptor", "inertia_free");
     nlp.options->SetIntegerValue("ir_outer_maxit", 0);
     if (use_ginkgo_cuda) {
-        nlp.options->SetStringValue("mem_space", "device");
         nlp.options->SetStringValue("compute_mode", "gpu");
         nlp.options->SetStringValue("ginkgo_exec", "cuda");
     } else if (use_ginkgo_hip) {
-        nlp.options->SetStringValue("mem_space", "device");
         nlp.options->SetStringValue("compute_mode", "gpu");
         nlp.options->SetStringValue("ginkgo_exec", "hip");
     } else {

--- a/src/Drivers/Sparse/NlpSparseEx2Driver.cpp
+++ b/src/Drivers/Sparse/NlpSparseEx2Driver.cpp
@@ -248,8 +248,10 @@ int main(int argc, char **argv)
       nlp.options->SetStringValue("linsol_mode", "speculative");
       nlp.options->SetStringValue("linear_solver_sparse", "ginkgo");
       if (use_ginkgo_cuda) {
+          nlp.options->SetStringValue("compute_mode", "gpu");
           nlp.options->SetStringValue("ginkgo_exec", "cuda");
       } else if (use_ginkgo_hip) {
+          nlp.options->SetStringValue("compute_mode", "gpu");
           nlp.options->SetStringValue("ginkgo_exec", "hip");
       } else {
           nlp.options->SetStringValue("ginkgo_exec", "reference");

--- a/src/Drivers/Sparse/NlpSparseEx4Driver.cpp
+++ b/src/Drivers/Sparse/NlpSparseEx4Driver.cpp
@@ -238,8 +238,10 @@ int main(int argc, char **argv)
     nlp.options->SetStringValue("fact_acceptor", "inertia_free");
     nlp.options->SetIntegerValue("ir_outer_maxit", 0);
     if (use_ginkgo_cuda) {
+        nlp.options->SetStringValue("compute_mode", "gpu");
         nlp.options->SetStringValue("ginkgo_exec", "cuda");
     } else if (use_ginkgo_hip) {
+        nlp.options->SetStringValue("compute_mode", "gpu");
         nlp.options->SetStringValue("ginkgo_exec", "hip");
     } else {
         nlp.options->SetStringValue("ginkgo_exec", "reference");

--- a/src/Drivers/Sparse/NlpSparseRajaEx2Driver.cpp
+++ b/src/Drivers/Sparse/NlpSparseRajaEx2Driver.cpp
@@ -256,11 +256,23 @@ int main(int argc, char **argv)
     // only support cusolverLU right now, 2023.02.28
     //lsq initialization of the duals fails for this example since the Jacobian is rank deficient
     //use zero initialization
-    nlp.options->SetStringValue("linear_solver_sparse", "resolve");
     if(use_resolve_cuda_rf) {
+      nlp.options->SetStringValue("linear_solver_sparse", "resolve");
       nlp.options->SetStringValue("resolve_refactorization", "rf");
       nlp.options->SetIntegerValue("ir_inner_maxit", 20);
       nlp.options->SetIntegerValue("ir_outer_maxit", 0);
+    }
+    if (use_ginkgo) {
+      nlp.options->SetStringValue("linear_solver_sparse", "ginkgo");
+      nlp.options->SetIntegerValue("ir_outer_maxit", 0);
+      if (use_ginkgo_cuda) {
+        nlp.options->SetStringValue("ginkgo_exec", "cuda");
+      } else if (use_ginkgo_hip) {
+        nlp.options->SetStringValue("ginkgo_exec", "hip");
+      } else {
+        nlp.options->SetStringValue("ginkgo_exec", "reference");
+        nlp.options->SetStringValue("compute_mode", "cpu");
+      }
     }
     nlp.options->SetStringValue("duals_init", "zero");
     nlp.options->SetStringValue("mem_space", "device");

--- a/src/LinAlg/hiopLinSolverSparseGinkgo.cpp
+++ b/src/LinAlg/hiopLinSolverSparseGinkgo.cpp
@@ -212,13 +212,11 @@ std::shared_ptr<gko::Executor> create_exec(std::string executor_string)
             {"omp", [] { return gko::OmpExecutor::create(); }},
             {"cuda",
              [] {
-                 return gko::CudaExecutor::create(0, gko::ReferenceExecutor::create(),
-                                                  true);
+                 return gko::CudaExecutor::create(0, gko::ReferenceExecutor::create());
              }},
             {"hip",
              [] {
-                 return gko::HipExecutor::create(0, gko::ReferenceExecutor::create(),
-                                                 true);
+                 return gko::HipExecutor::create(0, gko::ReferenceExecutor::create());
              }},
             {"dpcpp",
              [] {
@@ -284,7 +282,6 @@ std::shared_ptr<gko::LinOpFactory> setup_solver_factory(std::shared_ptr<const gk
       index_covert_CSR2Triplet_{nullptr},
       index_covert_extra_Diag2CSR_{nullptr}
   {
-      std::cout << "START" << std::endl;
     if(nlp_->options->GetString("mem_space") == "device") {
       M_host_ = LinearAlgebraFactory::create_matrix_sparse("default", n, n, nnz);
     }
@@ -316,7 +313,6 @@ std::shared_ptr<gko::LinOpFactory> setup_solver_factory(std::shared_ptr<const gk
 
     // If the matrix is on device, copy it to the host mirror
     std::string mem_space = nlp_->options->GetString("mem_space");
-    std::cout << nlp_->options->GetString("ginkgo_exec") << " " << mem_space << std::endl;
     auto M = M_;
     if(mem_space == "device") {
       auto host = exec_->get_master();
@@ -383,7 +379,6 @@ std::shared_ptr<gko::LinOpFactory> setup_solver_factory(std::shared_ptr<const gk
 
   bool hiopLinSolverSymSparseGinkgo::solve ( hiopVector& x_ )
   {
-      std::cout << "SOLVE" << std::endl;
     using vec = gko::matrix::Dense<double>;
     using arr = gko::array<double>;
     auto host = exec_->get_master();

--- a/src/LinAlg/hiopLinSolverSparseGinkgo.hpp
+++ b/src/LinAlg/hiopLinSolverSparseGinkgo.hpp
@@ -96,6 +96,8 @@ private:
 
   static const std::map<std::string, gko::solver::trisolve_algorithm> alg_map_;
 
+  hiopMatrixSparse* M_host_{ nullptr }; ///< Host mirror for the KKT matrix
+
 public:
 
   /** called the very first time a matrix is factored. Allocates space

--- a/src/LinAlg/hiopLinSolverSparseGinkgo.hpp
+++ b/src/LinAlg/hiopLinSolverSparseGinkgo.hpp
@@ -90,6 +90,7 @@ private:
   std::shared_ptr<gko::Executor> exec_;
   std::shared_ptr<gko::matrix::Csr<double, int>> mtx_;
   std::shared_ptr<gko::matrix::Csr<double, int>> host_mtx_;
+  std::shared_ptr<gko::matrix::Dense<double>> dense_b_;
   std::shared_ptr<gko::LinOpFactory> reusable_factory_;
   std::shared_ptr<gko::LinOp> gko_solver_;
   bool iterative_refinement_;

--- a/src/Optimization/hiopKKTLinSysSparse.cpp
+++ b/src/Optimization/hiopKKTLinSysSparse.cpp
@@ -317,9 +317,7 @@ namespace hiop
         if( (nullptr == linSys_ && linear_solver == "auto") || linear_solver == "ginkgo") {
           //ma57, pardiso and strumpack are not available or user requested ginkgo
 #ifdef HIOP_USE_GINKGO              
-          nlp_->log->printf(hovScalars,
-                            "KKT_SPARSE_XYcYd linsys: alloc GINKGO with matrix size %d (%d cons)\n",
-                            n, neq+nineq);
+          linsol_actual = "GINKGO";
           linSys_ = new hiopLinSolverSymSparseGinkgo(n, nnz, nlp_);
 #endif  // HIOP_USE_GINKGO        
         }
@@ -375,6 +373,14 @@ namespace hiop
           linsol_actual = "PARDISO";
           linSys_ = new hiopLinSolverSymSparsePARDISO(n, nnz, nlp_);
 #endif // HIOP_USE_PARDISO
+        }
+        
+        if( (nullptr == linSys_ && linear_solver == "auto") || linear_solver == "ginkgo") {
+          //ma57, pardiso and strumpack are not available or user requested ginkgo
+#ifdef HIOP_USE_GINKGO              
+          linsol_actual = "GINKGO";
+          linSys_ = new hiopLinSolverSymSparseGinkgo(n, nnz, nlp_);
+#endif  // HIOP_USE_GINKGO        
         }
 
         if(linSys_) {
@@ -747,6 +753,14 @@ namespace hiop
 #endif // HIOP_USE_PARDISO          
         }
 
+        if(nullptr == linSys_ && linear_solver == "ginkgo") {
+          //ma57, pardiso and strumpack are not available or user requested ginkgo
+#ifdef HIOP_USE_GINKGO
+          linSys_ = new hiopLinSolverSymSparseGinkgo(n, nnz, nlp_);
+          actual_lin_solver = "GINKGO";        
+#endif  // HIOP_USE_GINKGO        
+        }
+
         if(linSys_) {
           nlp_->log->printf(hovScalars,
                             "KKT_SPARSE_XDYcYd linsys: alloc [%s] size %d (%d cons) (hybrid)\n",
@@ -781,6 +795,14 @@ namespace hiop
           }
 #endif
         } //end resolve
+        
+        if(nullptr == linSys_ && linear_solver == "ginkgo") {
+          //ma57, pardiso and strumpack are not available or user requested ginkgo
+#ifdef HIOP_USE_GINKGO
+          linSys_ = new hiopLinSolverSymSparseGinkgo(n, nnz, nlp_);
+          actual_lin_solver = "GINKGO";        
+#endif  // HIOP_USE_GINKGO        
+        }
       } // end of compute mode gpu
     }
     assert(linSys_&& "KKT_SPARSE_XDYcYd linsys: cannot instantiate backend linear solver");


### PR DESCRIPTION
This PR updates the Ginkgo interface in order to be able to handle data coming from the GPU.
Currently this means:

- in the first solver call: Copying matrices to the CPU, transform to CSR and start factorization preprocessing on the host before moving to the GPU
- if the matrix is updated: copying the matrix values to the CPU, move them to the CSR format and then refactorize on the GPU (this should be all moved to the GPU)
- in the solve: handle vectors on the GPU if possible, if they are on the CPU move them to the GPU for the solve

I would be grateful for some instructions on how to test the `mem_space == device` @pelesh @nkoukpaizan 

Note: I will update the interface further to be based on the most current Ginkgo release (1.7.0)