### PR TITLE
Update CMake file and use vsnprintf to avoid compiling errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 set(CMAKE_CUDA_SEPARABLE_COMPILATION ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-set(CMAKE_CXX_FLAGS "-Wall -Werror")
+set(CMAKE_CXX_FLAGS_DEBUG "-Wall -Werror")
 
 if (POLICY CMP0074)
   cmake_policy(SET CMP0074 NEW)
@@ -105,7 +105,9 @@ if(NOT "${HIOP_EXTRA_LINK_FLAGS}" STREQUAL "")
 endif()
 
 if(HIOP_USE_MPI)
-  find_package(MPI REQUIRED)
+  find_package(MPI REQUIRED COMPONENTS C CXX Fortran)
+
+  #find_package(MPI REQUIRED)
   if(NOT DEFINED MPI_CXX_COMPILER)
     set(CMAKE_CXX_COMPILER ${MPI_CXX_COMPILER})
     set(CMAKE_C_COMPILER ${MPI_C_COMPILER})
@@ -114,7 +116,7 @@ if(HIOP_USE_MPI)
   
   set(CMAKE_Fortran_COMPILER ${MPI_Fortran_COMPILER})
   include_directories(${MPI_Fortran_ADDITIONAL_INCLUDE_DIRS} ${MPI_Fortran_COMPILER_INCLUDE_DIRS} )
-  set (CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -D HIOP_USE_MPI")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -D HIOP_USE_MPI")
   
   target_link_libraries(hiop_tpl INTERFACE MPI::MPI_CXX MPI::MPI_CXX)
   set(HIOP_EXTRA_MPI_FLAGS "" CACHE STRING "Extra arguments to mpiexec when running tests")

--- a/src/Utils/hiopLogger.cpp
+++ b/src/Utils/hiopLogger.cpp
@@ -144,7 +144,7 @@ void hiopLogger::printf(hiopOutVerbosity v, const char* format, ...)
 
   va_list args;
   va_start(args, format);
-  vsprintf(buff_,format, args);
+  vsnprintf(buff_,4096,format, args);
   fprintf(f_,"%s",buff_);
   va_end(args);
 
@@ -155,7 +155,7 @@ void hiopLogger::printf_error(hiopOutVerbosity v, const char* format, ...)
   char buff[4096];
   va_list args;
   va_start (args, format);
-  vsprintf (buff,format, args);
+  vsnprintf(buff,4096,format, args);
   fprintf(stderr,"%s",buff);
   va_end (args);
 };

--- a/src/Utils/hiopOptions.cpp
+++ b/src/Utils/hiopOptions.cpp
@@ -478,7 +478,7 @@ void hiopOptions::log_printf(hiopOutVerbosity v, const char* format, ...)
   char buff[1024];
   va_list args;
   va_start (args, format);
-  vsprintf (buff,format, args);
+  vsnprintf(buff,1024,format, args);
   if(log_) {
     log_->printf(v,buff);
   } else {


### PR DESCRIPTION
1. Compiler flags `-Wall` and `-Werror` are only used in the debug mode; 
2. Change `vsprintf` to `vsnprintf`, otherwise when `-Werror` is given, we got multiple errors such as 
```
/hiop/src/Utils/hiopLogger.cpp:147:3: error: 'vsprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use vsnprintf(3) instead. [-Werror,-Wdeprecated-declarations]
  vsprintf(buff_,format, args);
```

@jaelynlitz @cameronrutherford @cnpetra 