### PR TITLE
Dense matrix needs RAJA when GPU is used

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,6 +228,7 @@ if(HIOP_USE_GPU)
   endif()
 
   if(HIOP_USE_CUDA)
+    set(HIOP_USE_RAJA "ON") #CUDA/HIP requires using RAJA.
     enable_language(CUDA)
     check_language(CUDA)
 
@@ -269,7 +270,6 @@ if(HIOP_USE_GPU)
         "\n* HIOP_USE_HIP"
     )
   endif()
-  set(HIOP_USE_RAJA "ON") #CUDA/HIP requires using RAJA. This dependency will be removed in a future release, after somee necessary implementations.
 endif(HIOP_USE_GPU)
 
 if(HIOP_USE_RAJA)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,16 +222,14 @@ else()
 endif()
 
 if(HIOP_USE_GPU)
+  if(NOT HIOP_USE_RAJA)
+    message(FATAL_ERROR "Error: HIOP_USE_GPU is ON, but HIOP_USE_RAJA is OFF. HiOp requires using RAJA with CUDA/HIP.")
+  endif()
+
   include(CheckLanguage)
   if(HIOP_USE_MAGMA)
     set(HIOP_MAGMA_DIR CACHE PATH "Path to Magma directory")
   endif()
-
-  if(NOT HIOP_USE_RAJA)
-    set(HIOP_USE_RAJA "ON") #CUDA/HIP requires using RAJA.
-    message(STATUS "Enable RAJA since HIOP_USE_GPU is ON. HiOp requires using RAJA with CUDA/HIP.")
-  endif(NOT HIOP_USE_RAJA)
-
 
   if(HIOP_USE_CUDA)
     enable_language(CUDA)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -269,6 +269,7 @@ if(HIOP_USE_GPU)
         "\n* HIOP_USE_HIP"
     )
   endif()
+  set(HIOP_USE_RAJA "ON") #CUDA/HIP requires using RAJA. This dependency will be removed in a future release, after somee necessary implementations.
 endif(HIOP_USE_GPU)
 
 if(HIOP_USE_RAJA)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,8 +227,13 @@ if(HIOP_USE_GPU)
     set(HIOP_MAGMA_DIR CACHE PATH "Path to Magma directory")
   endif()
 
-  if(HIOP_USE_CUDA)
+  if(NOT HIOP_USE_RAJA)
     set(HIOP_USE_RAJA "ON") #CUDA/HIP requires using RAJA.
+    message(STATUS "Enable RAJA since HIOP_USE_GPU is ON. HiOp requires using RAJA with CUDA/HIP.")
+  endif(NOT HIOP_USE_RAJA)
+
+
+  if(HIOP_USE_CUDA)
     enable_language(CUDA)
     check_language(CUDA)
 

--- a/src/LinAlg/LinAlgFactory.cpp
+++ b/src/LinAlg/LinAlgFactory.cpp
@@ -353,7 +353,7 @@ hiopMatrixDense* LinearAlgebraFactory::create_matrix_dense(const ExecSpaceInfo& 
       return nullptr;
 #endif //HIOP_USE_RAJA
     } else {// for if(hi.exec_backend_ == "RAJA")
-
+      assert(false && "device memory backend not available because HiOp was not built with RAJA");
       if(mem_space_upper == "CUDA") {
 #ifdef HIOP_USE_CUDA
           assert(mem_space_upper == "DEVICE");


### PR DESCRIPTION
Update the cmake file and add an assertion, to prevent compiling hiop with GPU support but without RAJA.

CLOSE #675 