### PR TITLE
Update cmake paths be relative to hiop project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,7 +122,7 @@ if(HIOP_USE_MPI)
   set(HIOP_EXTRA_MPI_FLAGS "" CACHE STRING "Extra arguments to mpiexec when running tests")
 endif(HIOP_USE_MPI)
 
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
+list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
 target_compile_features(hiop_options
   INTERFACE
@@ -393,11 +393,11 @@ endif()
 
 # The binary dir is already a global include directory
 configure_file(
-  "${CMAKE_SOURCE_DIR}/src/Interface/hiop_defs.hpp.in"
-  "${CMAKE_BINARY_DIR}/hiop_defs.hpp")
+  "${PROJECT_SOURCE_DIR}/src/Interface/hiop_defs.hpp.in"
+  "${PROJECT_BINARY_DIR}/hiop_defs.hpp")
 
 # include build directory for Fortran name mangling header
-include_directories(${CMAKE_BINARY_DIR})
+include_directories(${PROJECT_BINARY_DIR})
 
 include_directories(src/Interface)
 include_directories(src/ExecBackends)
@@ -422,7 +422,7 @@ if("${CMAKE_BUILD_TYPE}" STREQUAL "")
 endif("${CMAKE_BUILD_TYPE}" STREQUAL "")
 
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-  set(CMAKE_INSTALL_PREFIX "${CMAKE_SOURCE_DIR}/_dist-${CMAKE_BUILD_TYPE}")
+  set(CMAKE_INSTALL_PREFIX "${PROJECT_SOURCE_DIR}/_dist-${CMAKE_BUILD_TYPE}")
 endif(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 
 ##########################################################

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,8 +6,8 @@ add_subdirectory(Utils)
 
 # Interface headers not already picked up by another subdirectory
 set(hiop_INTERFACE_HEADERS
-  ${CMAKE_BINARY_DIR}/hiop_defs.hpp
-  ${CMAKE_BINARY_DIR}/FortranCInterface.hpp
+  ${PROJECT_BINARY_DIR}/hiop_defs.hpp
+  ${PROJECT_BINARY_DIR}/FortranCInterface.hpp
   )
 
 install(


### PR DESCRIPTION
This PR will allow lido and other projects to utilize hiop as a submodule.

* Update cmake variables to use switch to using `PROJECT_BINARY_DIR` and `PROJECT_SOURCE_DIR` rather than their cmake counterparts. This should not affect regular hiop builds.