### PR TITLE
Patch two memory leaks that cause more leaks

### DIFF
--- a/src/Optimization/hiopKKTLinSys.hpp
+++ b/src/Optimization/hiopKKTLinSys.hpp
@@ -620,7 +620,9 @@ public:
   virtual ~hiopMatVecKKTFullOpr()
   {
     delete resid_;  
-    delete dir_;  
+    delete dir_;
+    delete dir_cv_;
+    delete res_cv_;
   };
 
   /** y = KKT * x */
@@ -673,7 +675,9 @@ public:
   virtual ~hiopPrecondKKTOpr()
   {
     delete resid_;  
-    delete dir_;  
+    delete dir_;
+    delete dir_cv_;
+    delete res_cv_;
   };
 
   /** y = inv(Preconditioner) * x = Preconditioner/x */


### PR DESCRIPTION
This PR plugs some memory leaks.
* Patch two leaked pointers that are the root cause of multiple other leaks.

Overall, I would strongly recommend replacing most if not all the raw pointers with `std::unique_ptr`.  `std::unique_ptr` has numerous benefits over raw pointers including:
* automatic deletion when the pointer goes out of scope
* automatic initialization to nullptr if it's not initialized explicitly
* essentially no runtime or memory overhead compared to raw pointers

In the case of `dir_cv_` and `res_cv_`, it's not clear to me why their pointers in the first place. IMHO, it seems like judicious use references instead of pointers could get rid of a variety of new/delete's or std::unique_ptr.