### PR TITLE
Fix hipblas path

### DIFF
--- a/cmake/FindHiopHipLibraries.cmake
+++ b/cmake/FindHiopHipLibraries.cmake
@@ -39,7 +39,7 @@ target_include_directories(Hipblas INTERFACE ${HIPBLAS_INCLUDE_DIR})
 include(FindHiopMagma)
 target_link_libraries(Magma    INTERFACE Hipblas)
 
-target_include_directories(hiop_hip INTERFACE ${ROCM_PATH}/hipfft/include)
+target_include_directories(hiop_hip INTERFACE ${ROCM_PATH}/include/hipfft)
 target_link_libraries(hiop_hip INTERFACE
   hip::hiprand roc::rocrand
   hip::hipfft

--- a/src/LinAlg/VectorHipKernels.cpp
+++ b/src/LinAlg/VectorHipKernels.cpp
@@ -53,7 +53,7 @@
  */
 #include "VectorHipKernels.hpp"
 #include <hip/hip_runtime.h>
-#include <hipblas.h>
+#include <hipblas/hipblas.h>
 
 #include <thrust/device_ptr.h>
 #include <thrust/device_vector.h>

--- a/src/LinAlg/VectorHipKernels.cpp
+++ b/src/LinAlg/VectorHipKernels.cpp
@@ -53,7 +53,11 @@
  */
 #include "VectorHipKernels.hpp"
 #include <hip/hip_runtime.h>
+#if HIP_VERSION >= 50200000
 #include <hipblas/hipblas.h>
+#else
+#include <hipblas.h>
+#endif
 
 #include <thrust/device_ptr.h>
 #include <thrust/device_vector.h>

--- a/src/LinAlg/hiopVectorHip.cpp
+++ b/src/LinAlg/hiopVectorHip.cpp
@@ -59,7 +59,7 @@
 #include "VectorHipKernels.hpp"
 #include "MathKernelsHip.hpp"
 #include <hip/hip_runtime.h>
-#include <hipblas.h>
+#include <hipblas/hipblas.h>
 
 #include "hiopVectorPar.hpp"
 

--- a/src/LinAlg/hiopVectorHip.cpp
+++ b/src/LinAlg/hiopVectorHip.cpp
@@ -59,7 +59,11 @@
 #include "VectorHipKernels.hpp"
 #include "MathKernelsHip.hpp"
 #include <hip/hip_runtime.h>
+#if HIP_VERSION >= 50200000
 #include <hipblas/hipblas.h>
+#else
+#include <hipblas.h>
+#endif
 
 #include "hiopVectorPar.hpp"
 

--- a/src/LinAlg/hiopVectorHip.hpp
+++ b/src/LinAlg/hiopVectorHip.hpp
@@ -65,7 +65,11 @@
 
 #include "hiopVector.hpp"
 
+#if HIP_VERSION >= 50200000
 #include <hipblas/hipblas.h>
+#else
+#include <hipblas.h>
+#endif
 
 namespace hiop
 {

--- a/src/LinAlg/hiopVectorHip.hpp
+++ b/src/LinAlg/hiopVectorHip.hpp
@@ -65,7 +65,7 @@
 
 #include "hiopVector.hpp"
 
-#include <hipblas.h>
+#include <hipblas/hipblas.h>
 
 namespace hiop
 {


### PR DESCRIPTION
This changes the `hipblas` include from `hipblas.h` to `hipblas/hipblas.h` for ROCm>=5.2. The paths have changed, and backward compatibility was removed in more recent ROCm versions. I found the issue when attempting to build with ROCm 6.3.1 on Frontier, and these changes seem to fix it at the build stage.

Got the idea of the fix from [Magma](https://github.com/icl-utk-edu/magma/blob/95903129f839bb401d9d9c53bd3d8e1b5e14c238/include/magma_types.h#L164).

cc @pelesh @cnpetra 