### PR TITLE
Use the latest RAJA and UMPIRE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,6 +236,8 @@ if(HIOP_USE_GPU)
     enable_language(CUDA)
     check_language(CUDA)
 
+    set(CMAKE_CUDA_HOST_COMPILER g++)
+
     if(NOT DEFINED CMAKE_CUDA_STANDARD)
       set(CMAKE_CUDA_STANDARD 14)
       set(CMAKE_CUDA_STANDARD_REQUIRED ON)

--- a/scripts/lassenVariables.sh
+++ b/scripts/lassenVariables.sh
@@ -1,100 +1,100 @@
-module use -a /usr/workspace/hiop/software/spack_modules_202408/linux-rhel7-power9le
+module use -a /usr/workspace/hiop/software/spack_modules_202501/linux-rhel7-power9le
 
 module purge
 
-module load gcc/8.3.1
-module load cmake/3.20.2 
+module load gcc/11.2.1
+module load cmake/3.23.1
 module load python/3.8.2
 
+# cmake@=3.23.1%gcc@=11.2.1~doc+ncurses+ownlibs build_system=generic build_type=Release patches=dbc3892 arch=linux-rhel7-power9le
+module load cmake/3.23.1-linux-rhel7-power9le-wkkrdll
+# glibc@=2.17%gcc@=11.2.1 build_system=autotools patches=be65fec,e179c43 arch=linux-rhel7-power9le
+module load glibc/2.17-linux-rhel7-power9le-7k6zu4s
+# gcc-runtime@=11.2.1%gcc@=11.2.1 build_system=generic arch=linux-rhel7-power9le
+module load gcc-runtime/11.2.1-linux-rhel7-power9le-ze6g3xs
+# blt@=0.6.2%gcc@=11.2.1 build_system=generic arch=linux-rhel7-power9le
+module load blt/0.6.2-linux-rhel7-power9le-gkzs3dj
+# cuda@=11.7.0%gcc@=11.2.1~allow-unsupported-compilers~dev build_system=generic arch=linux-rhel7-power9le
+module load cuda/11.7.0-linux-rhel7-power9le-5d4j5ta
+# gmake@=4.4.1%gcc@=11.2.1~guile build_system=generic arch=linux-rhel7-power9le
+module load gmake/4.4.1-linux-rhel7-power9le-22mrdsf
+# camp@=2024.07.0%gcc@=11.2.1+cuda~ipo~omptarget~openmp~rocm~sycl~tests build_system=cmake build_type=Release cuda_arch=70 generator=make arch=linux-rhel7-power9le
+module load camp/2024.07.0-linux-rhel7-power9le-pb3ih64
+# gnuconfig@=2022-09-17%gcc@=11.2.1 build_system=generic arch=linux-rhel7-power9le
+module load gnuconfig/2022-09-17-linux-rhel7-power9le-qf2eum2
+# berkeley-db@=18.1.40%gcc@=11.2.1+cxx~docs+stl build_system=autotools patches=26090f4,b231fcc arch=linux-rhel7-power9le
+module load berkeley-db/18.1.40-linux-rhel7-power9le-4z72abi
+# libiconv@=1.17%gcc@=11.2.1 build_system=autotools libs=shared,static arch=linux-rhel7-power9le
+module load libiconv/1.17-linux-rhel7-power9le-mty7cry
+# diffutils@=3.10%gcc@=11.2.1 build_system=autotools arch=linux-rhel7-power9le
+module load diffutils/3.10-linux-rhel7-power9le-65n77vt
+# bzip2@=1.0.8%gcc@=11.2.1~debug~pic+shared build_system=generic arch=linux-rhel7-power9le
+module load bzip2/1.0.8-linux-rhel7-power9le-jshnslw
+# pkgconf@=2.2.0%gcc@=11.2.1 build_system=autotools arch=linux-rhel7-power9le
+module load pkgconf/2.2.0-linux-rhel7-power9le-e47l3cy
+# ncurses@=6.5%gcc@=11.2.1~symlinks+termlib abi=none build_system=autotools patches=7a351bc arch=linux-rhel7-power9le
+module load ncurses/6.5-linux-rhel7-power9le-seblzpm
+# readline@=8.2%gcc@=11.2.1 build_system=autotools patches=bbf97f1 arch=linux-rhel7-power9le
+module load readline/8.2-linux-rhel7-power9le-5jt6gwi
+# gdbm@=1.23%gcc@=11.2.1 build_system=autotools arch=linux-rhel7-power9le
+module load gdbm/1.23-linux-rhel7-power9le-wqcrnp7
+# zlib-ng@=2.2.1%gcc@=11.2.1+compat+new_strategies+opt+pic+shared build_system=autotools arch=linux-rhel7-power9le
+module load zlib-ng/2.2.1-linux-rhel7-power9le-dtbpo6f
+# perl@=5.40.0%gcc@=11.2.1+cpanm+opcode+open+shared+threads build_system=generic arch=linux-rhel7-power9le
+module load perl/5.40.0-linux-rhel7-power9le-dm5nz4g
+# openblas@=0.3.27%gcc@=11.2.1~bignuma~consistent_fpcsr+dynamic_dispatch+fortran~ilp64+locking+pic+shared build_system=makefile symbol_suffix=none threads=none arch=linux-rhel7-power9le
+module load openblas/0.3.27-linux-rhel7-power9le-nuroloa
+# coinhsl@=2015.06.23%gcc@=11.2.1+blas build_system=autotools arch=linux-rhel7-power9le
+module load coinhsl/2015.06.23-linux-rhel7-power9le-ddp4zv4
+# magma@=2.8.0%gcc@=11.2.1+cuda+fortran~ipo~rocm+shared build_system=cmake build_type=Release cuda_arch=70 generator=make arch=linux-rhel7-power9le
+module load magma/2.8.0-linux-rhel7-power9le-hckttgy
+# metis@=5.1.0%gcc@=11.2.1~gdb~int64~ipo~real64+shared build_system=cmake build_type=Release generator=make patches=4991da9,93a7903,b1225da arch=linux-rhel7-power9le
+module load metis/5.1.0-linux-rhel7-power9le-bciofvn
+# raja@=2024.07.0%gcc@=11.2.1+cuda~desul+examples+exercises~ipo~omptarget~omptask~openmp~plugins~rocm~run-all-tests~shared~sycl~tests~vectorization build_system=cmake build_type=Release cuda_arch=70 generator=make arch=linux-rhel7-power9le
+module load raja/2024.07.0-linux-rhel7-power9le-23xik32
+# spectrum-mpi@=rolling-release%gcc@=11.2.1 build_system=bundle arch=linux-rhel7-power9le
+module load spectrum-mpi/rolling-release-linux-rhel7-power9le-4oma342
+# libsigsegv@=2.14%gcc@=11.2.1 build_system=autotools arch=linux-rhel7-power9le
+module load libsigsegv/2.14-linux-rhel7-power9le-4ctxf7z
+# m4@=1.4.19%gcc@=11.2.1+sigsegv build_system=autotools patches=9dc5fbd,bfdffa7 arch=linux-rhel7-power9le
+module load m4/1.4.19-linux-rhel7-power9le-7gxob2i
+# autoconf@=2.72%gcc@=11.2.1 build_system=autotools arch=linux-rhel7-power9le
+module load autoconf/2.72-linux-rhel7-power9le-ndavzxt
+# automake@=1.16.5%gcc@=11.2.1 build_system=autotools arch=linux-rhel7-power9le
+module load automake/1.16.5-linux-rhel7-power9le-ohdcq5s
+# findutils@=4.9.0%gcc@=11.2.1 build_system=autotools patches=440b954 arch=linux-rhel7-power9le
+module load findutils/4.9.0-linux-rhel7-power9le-fjcddvv
+# libtool@=2.4.7%gcc@=11.2.1 build_system=autotools arch=linux-rhel7-power9le
+module load libtool/2.4.7-linux-rhel7-power9le-pkgmuev
+# gmp@=6.3.0%gcc@=11.2.1+cxx build_system=autotools libs=shared,static arch=linux-rhel7-power9le
+module load gmp/6.3.0-linux-rhel7-power9le-bwq4h26
+# autoconf-archive@=2023.02.20%gcc@=11.2.1 build_system=autotools arch=linux-rhel7-power9le
+module load autoconf-archive/2023.02.20-linux-rhel7-power9le-xf2e7ia
+# xz@=5.4.6%gcc@=11.2.1~pic build_system=autotools libs=shared,static arch=linux-rhel7-power9le
+module load xz/5.4.6-linux-rhel7-power9le-t7fe3d7
+# libxml2@=2.10.3%gcc@=11.2.1+pic~python+shared build_system=autotools arch=linux-rhel7-power9le
+module load libxml2/2.10.3-linux-rhel7-power9le-tejjnjc
+# pigz@=2.8%gcc@=11.2.1 build_system=makefile arch=linux-rhel7-power9le
+module load pigz/2.8-linux-rhel7-power9le-7ziaqa5
+# zstd@=1.5.6%gcc@=11.2.1+programs build_system=makefile compression=none libs=shared,static arch=linux-rhel7-power9le
+module load zstd/1.5.6-linux-rhel7-power9le-j5eflwe
+# tar@=1.34%gcc@=11.2.1 build_system=autotools zip=pigz arch=linux-rhel7-power9le
+module load tar/1.34-linux-rhel7-power9le-rs7th2v
+# gettext@=0.22.5%gcc@=11.2.1+bzip2+curses+git~libunistring+libxml2+pic+shared+tar+xz build_system=autotools arch=linux-rhel7-power9le
+module load gettext/0.22.5-linux-rhel7-power9le-vjrjusm
+# texinfo@=7.1%gcc@=11.2.1 build_system=autotools arch=linux-rhel7-power9le
+module load texinfo/7.1-linux-rhel7-power9le-wciytfy
+# mpfr@=4.2.1%gcc@=11.2.1 build_system=autotools libs=shared,static arch=linux-rhel7-power9le
+module load mpfr/4.2.1-linux-rhel7-power9le-kgbrykj
+# suite-sparse@=7.7.0%gcc@=11.2.1~cuda~graphblas~openmp+pic build_system=generic arch=linux-rhel7-power9le
+module load suite-sparse/7.7.0-linux-rhel7-power9le-lt7472e
+# fmt@=11.0.2%gcc@=11.2.1~ipo+pic~shared build_system=cmake build_type=Release cxxstd=11 generator=make arch=linux-rhel7-power9le
+module load fmt/11.0.2-linux-rhel7-power9le-db6c3b6
+# umpire@=2024.07.0%gcc@=11.2.1~asan~backtrace+c+cuda~dev_benchmarks~device_alloc~deviceconst~examples+fmt_header_only~fortran~ipc_shmem~ipo~mpi~numa~omptarget~openmp~rocm~sanitizer_tests~shared~sqlite_experimental~tools~werror build_system=cmake build_type=Release cuda_arch=70 generator=make tests=none arch=linux-rhel7-power9le
+module load umpire/2024.07.0-linux-rhel7-power9le-ozkmp3f
+# hiop@=develop%gcc@=11.2.1+cuda+cusolver_lu+deepchecking~ginkgo~ipo~jsrun+kron+mpi+raja~rocm~shared+sparse build_system=cmake build_type=Release cuda_arch=70 dev_path=/usr/workspace/hiop/lassen/hiop_from_spack generator=make arch=linux-rhel7-power9le
+#module load hiop/develop-linux-rhel7-power9le-5yc5imr
 
-# cmake@=3.20.2%gcc@=8.3.1~doc+ncurses+ownlibs build_system=generic build_type=Release arch=linux-rhel7-power9le
-module load cmake/3.20.2-linux-rhel7-power9le-sgbbk2e
-# glibc@=2.17%gcc@=8.3.1 build_system=autotools patches=be65fec,e179c43 arch=linux-rhel7-power9le
-module load glibc/2.17-linux-rhel7-power9le-ltqhcqm
-# gcc-runtime@=8.3.1%gcc@=8.3.1 build_system=generic arch=linux-rhel7-power9le
-module load gcc-runtime/8.3.1-linux-rhel7-power9le-hvpgryd
-# blt@=0.4.1%gcc@=8.3.1 build_system=generic arch=linux-rhel7-power9le
-module load blt/0.4.1-linux-rhel7-power9le-yq3ifkk
-# cub@=1.16.0%gcc@=8.3.1 build_system=generic arch=linux-rhel7-power9le
-module load cub/1.16.0-linux-rhel7-power9le-mbi6tgn
-# gmake@=4.4.1%gcc@=8.3.1~guile build_system=generic arch=linux-rhel7-power9le
-module load gmake/4.4.1-linux-rhel7-power9le-76tj7qq
-# gnuconfig@=2022-09-17%gcc@=8.3.1 build_system=generic arch=linux-rhel7-power9le
-module load gnuconfig/2022-09-17-linux-rhel7-power9le-33h26h4
-# libiconv@=1.17%gcc@=8.3.1 build_system=autotools libs=shared,static arch=linux-rhel7-power9le
-module load libiconv/1.17-linux-rhel7-power9le-vomriir
-# pkgconf@=2.2.0%gcc@=8.3.1 build_system=autotools arch=linux-rhel7-power9le
-module load pkgconf/2.2.0-linux-rhel7-power9le-w5eyts5
-# xz@=5.4.6%gcc@=8.3.1~pic build_system=autotools libs=shared,static arch=linux-rhel7-power9le
-module load xz/5.4.6-linux-rhel7-power9le-wy2yvqt
-# zlib-ng@=2.2.1%gcc@=8.3.1+compat+new_strategies+opt+pic+shared build_system=autotools arch=linux-rhel7-power9le
-module load zlib-ng/2.2.1-linux-rhel7-power9le-zfirv2c
-# libxml2@=2.10.3%gcc@=8.3.1+pic~python+shared build_system=autotools arch=linux-rhel7-power9le
-module load libxml2/2.10.3-linux-rhel7-power9le-a2cuzya
-# cuda@=11.4.2%gcc@=8.3.1~allow-unsupported-compilers~dev build_system=generic arch=linux-rhel7-power9le
-module load cuda/11.4.2-linux-rhel7-power9le-rpeosz6
-# camp@=0.2.3%gcc@=8.3.1+cuda~ipo+openmp~rocm~tests build_system=cmake build_type=Release cuda_arch=70 generator=make patches=cb9e25b arch=linux-rhel7-power9le
-module load camp/0.2.3-linux-rhel7-power9le-seoxg6w
-# berkeley-db@=18.1.40%gcc@=8.3.1+cxx~docs+stl build_system=autotools patches=26090f4,b231fcc arch=linux-rhel7-power9le
-module load berkeley-db/18.1.40-linux-rhel7-power9le-xeq7mjg
-# diffutils@=3.10%gcc@=8.3.1 build_system=autotools arch=linux-rhel7-power9le
-module load diffutils/3.10-linux-rhel7-power9le-gg26vck
-# bzip2@=1.0.8%gcc@=8.3.1~debug~pic+shared build_system=generic arch=linux-rhel7-power9le
-module load bzip2/1.0.8-linux-rhel7-power9le-kzyaip2
-# ncurses@=6.5%gcc@=8.3.1~symlinks+termlib abi=none build_system=autotools patches=7a351bc arch=linux-rhel7-power9le
-module load ncurses/6.5-linux-rhel7-power9le-h3en26s
-# readline@=8.2%gcc@=8.3.1 build_system=autotools patches=bbf97f1 arch=linux-rhel7-power9le
-module load readline/8.2-linux-rhel7-power9le-dhcjafy
-# gdbm@=1.23%gcc@=8.3.1 build_system=autotools arch=linux-rhel7-power9le
-module load gdbm/1.23-linux-rhel7-power9le-eizs5lo
-# perl@=5.40.0%gcc@=8.3.1+cpanm+opcode+open+shared+threads build_system=generic arch=linux-rhel7-power9le
-module load perl/5.40.0-linux-rhel7-power9le-cmrz6t7
-# openblas@=0.3.24%gcc@=8.3.1~bignuma~consistent_fpcsr+dynamic_dispatch+fortran~ilp64+locking+pic+shared build_system=makefile symbol_suffix=none threads=none arch=linux-rhel7-power9le
-module load openblas/0.3.24-linux-rhel7-power9le-6ek5q6o
-# coinhsl@=2015.06.23%gcc@=8.3.1+blas build_system=autotools arch=linux-rhel7-power9le
-module load coinhsl/2015.06.23-linux-rhel7-power9le-7usp2us
-# ginkgo@=1.5.0.glu_experimental%gcc@=8.3.1+cuda~develtools~full_optimizations~hwloc~ipo~mpi+openmp~rocm+shared~sycl build_system=cmake build_type=Release cuda_arch=70 generator=make arch=linux-rhel7-power9le
-module load ginkgo/1.5.0.glu_experimental-linux-rhel7-power9le-ibgwveo
-# magma@=2.6.2%gcc@=8.3.1+cuda+fortran~ipo~rocm+shared build_system=cmake build_type=Release cuda_arch=70 generator=make arch=linux-rhel7-power9le
-module load magma/2.6.2-linux-rhel7-power9le-qdoblh3
-# metis@=5.1.0%gcc@=8.3.1~gdb~int64~ipo~real64+shared build_system=cmake build_type=Release generator=make patches=4991da9,93a7903,b1225da arch=linux-rhel7-power9le
-module load metis/5.1.0-linux-rhel7-power9le-pq37727
-# raja@=0.14.0%gcc@=8.3.1+cuda~desul~examples~exercises~ipo~omptask+openmp~plugins~rocm~run-all-tests+shared~tests~vectorization build_system=cmake build_type=Release cuda_arch=70 generator=make arch=linux-rhel7-power9le
-module load raja/0.14.0-linux-rhel7-power9le-i3do7mn
-# spectrum-mpi@=rolling-release%gcc@=8.3.1 build_system=bundle arch=linux-rhel7-power9le
-module load spectrum-mpi/rolling-release-linux-rhel7-power9le-cycs4kt
-# libsigsegv@=2.14%gcc@=8.3.1 build_system=autotools arch=linux-rhel7-power9le
-module load libsigsegv/2.14-linux-rhel7-power9le-fl37xzk
-# m4@=1.4.19%gcc@=8.3.1+sigsegv build_system=autotools patches=9dc5fbd,bfdffa7 arch=linux-rhel7-power9le
-module load m4/1.4.19-linux-rhel7-power9le-gwetdjs
-# autoconf@=2.72%gcc@=8.3.1 build_system=autotools arch=linux-rhel7-power9le
-module load autoconf/2.72-linux-rhel7-power9le-nr3otal
-# automake@=1.16.5%gcc@=8.3.1 build_system=autotools arch=linux-rhel7-power9le
-module load automake/1.16.5-linux-rhel7-power9le-4tpk52n
-# findutils@=4.9.0%gcc@=8.3.1 build_system=autotools patches=440b954 arch=linux-rhel7-power9le
-module load findutils/4.9.0-linux-rhel7-power9le-7lhqpqk
-# libtool@=2.4.7%gcc@=8.3.1 build_system=autotools arch=linux-rhel7-power9le
-module load libtool/2.4.7-linux-rhel7-power9le-fo55ddx
-# gmp@=6.3.0%gcc@=8.3.1+cxx build_system=autotools libs=shared,static arch=linux-rhel7-power9le
-module load gmp/6.3.0-linux-rhel7-power9le-wtffv4t
-# autoconf-archive@=2023.02.20%gcc@=8.3.1 build_system=autotools arch=linux-rhel7-power9le
-module load autoconf-archive/2023.02.20-linux-rhel7-power9le-nlgst5g
-# pigz@=2.8%gcc@=8.3.1 build_system=makefile arch=linux-rhel7-power9le
-module load pigz/2.8-linux-rhel7-power9le-du7lszg
-# zstd@=1.5.6%gcc@=8.3.1+programs build_system=makefile compression=none libs=shared,static arch=linux-rhel7-power9le
-module load zstd/1.5.6-linux-rhel7-power9le-rlza3tv
-# tar@=1.34%gcc@=8.3.1 build_system=autotools zip=pigz arch=linux-rhel7-power9le
-module load tar/1.34-linux-rhel7-power9le-66m3wvh
-# gettext@=0.22.5%gcc@=8.3.1+bzip2+curses+git~libunistring+libxml2+pic+shared+tar+xz build_system=autotools arch=linux-rhel7-power9le
-module load gettext/0.22.5-linux-rhel7-power9le-je7e7cy
-# texinfo@=7.1%gcc@=8.3.1 build_system=autotools arch=linux-rhel7-power9le
-module load texinfo/7.1-linux-rhel7-power9le-oss2b3r
-# mpfr@=4.2.1%gcc@=8.3.1 build_system=autotools libs=shared,static arch=linux-rhel7-power9le
-module load mpfr/4.2.1-linux-rhel7-power9le-tqg7cbt
-# suite-sparse@=5.13.0%gcc@=8.3.1~cuda~graphblas~openmp+pic build_system=generic arch=linux-rhel7-power9le
-module load suite-sparse/5.13.0-linux-rhel7-power9le-nhqdwpc
-# umpire@=6.0.0%gcc@=8.3.1~asan~backtrace~c+cuda~dev_benchmarks~device_alloc~deviceconst~examples~fortran~ipc_shmem~ipo~mpi~numa~openmp~openmp_target~rocm~sanitizer_tests~shared~sqlite_experimental~tools~werror build_system=cmake build_type=Release cuda_arch=70 generator=make tests=none arch=linux-rhel7-power9le
-module load umpire/6.0.0-linux-rhel7-power9le-qndtsb2
 
 [ -f $PWD/nvblas.conf ] && rm $PWD/nvblas.conf
 cat > $PWD/nvblas.conf <<-EOD

--- a/scripts/platforms/lassen/spack.yaml
+++ b/scripts/platforms/lassen/spack.yaml
@@ -1,0 +1,58 @@
+spack:
+  specs:
+  - hiop@develop+kron+mpi+raja+sparse+cuda+cusolver_lu cuda_arch=70
+  - raja@2024.07.0
+  - umpire@2024.07.0
+  - coinhsl@2015.06.23
+  
+  view: false
+  concretizer:
+    unify: true
+    reuse: false
+  packages:
+    all:
+      providers:
+        mpi: [spectrum-mpi]
+        blas: [openblas]
+        lapack: [openblas]
+    spectrum-mpi:
+      externals:
+      - spec: spectrum-mpi@rolling-release
+        modules: [spectrum-mpi/rolling-release]
+      buildable: false
+    coinnhsl:
+      variants: +blas+metis   
+    python:
+      externals:
+      - spec: python@3.8.2
+        modules: [python/3.8.2]
+      buildable: false
+    cuda:
+      externals:
+      - spec: cuda@11.7.0
+        modules:
+        - cuda/11.7.0
+      buildable: false
+    cmake:
+      externals:
+      - spec: cmake@3.23.1
+        modules: [cmake/3.23.1]
+      buildable: false
+  compilers:
+  - compiler:
+      spec: gcc@11.2.1
+      paths:
+        cc: /usr/tce/packages/gcc/gcc-11.2.1/bin/cc
+        cxx: /usr/tce/packages/gcc/gcc-11.2.1/bin/g++
+        f77: /usr/tce/packages/gcc/gcc-11.2.1/bin/gfortran
+        fc: /usr/tce/packages/gcc/gcc-11.2.1/bin/gfortran
+      flags: {}
+      operating_system: rhel7
+      target: ppc64le
+      modules: []
+      environment: {}
+      extra_rpaths: []
+  develop:
+    hiop:
+      path: /usr/workspace/hiop/lassen/hiop_from_spack
+      spec: hiop@develop

--- a/scripts/platforms/marianas/spack.yaml
+++ b/scripts/platforms/marianas/spack.yaml
@@ -1,6 +1,6 @@
 spack:
   specs:
-  - hiop%gcc@10.2.0@develop+cuda+deepchecking+sparse+kron+cusolver+ginkgo+raja cuda_arch=60
+  - hiop%gcc@10.2.0@develop+cuda+deepchecking+sparse+kron+cusolver_lu+ginkgo+raja cuda_arch=60
   - raja@0.14.0
   - umpire@6.0.0
   - coinhsl@2019.05.21

--- a/scripts/platforms/newell/spack.yaml
+++ b/scripts/platforms/newell/spack.yaml
@@ -1,6 +1,6 @@
 spack:
   specs:
-  - hiop@develop+kron+mpi+raja+sparse+cuda+ginkgo+deepchecking+cusolver cuda_arch=70
+  - hiop@develop+kron+mpi+raja+sparse+cuda+ginkgo+deepchecking+cusolver_lu cuda_arch=70
   - raja@0.14.0
   - umpire@6.0.0
   - coinhsl@2019.05.21

--- a/src/Drivers/MDS/NlpMdsRajaEx1.cpp
+++ b/src/Drivers/MDS/NlpMdsRajaEx1.cpp
@@ -240,7 +240,7 @@ bool MdsEx1::get_vars_info(const size_type& n, double* xlow, double* xupp, Nonli
       });
 
   // Use a sequential policy for host computations for now
-  RAJA::forall<RAJA::loop_exec>(RAJA::RangeSegment(0, n), [=](RAJA::Index_type i) { type[i] = hiopNonlinear; });
+  RAJA::forall<RAJA::seq_exec>(RAJA::RangeSegment(0, n), [=](RAJA::Index_type i) { type[i] = hiopNonlinear; });
   return true;
 }
 
@@ -277,7 +277,7 @@ bool MdsEx1::get_cons_info(const size_type& m, double* clow, double* cupp, Nonli
       });
 
   // Must be a sequential host policy for now
-  RAJA::forall<RAJA::loop_exec>(RAJA::RangeSegment(0, m), [=](RAJA::Index_type i) { type[i] = hiopNonlinear; });
+  RAJA::forall<RAJA::seq_exec>(RAJA::RangeSegment(0, m), [=](RAJA::Index_type i) { type[i] = hiopNonlinear; });
   return true;
 }
 

--- a/src/Drivers/PriDec/NlpPriDecEx2UserRecourseSparseRaja.hpp
+++ b/src/Drivers/PriDec/NlpPriDecEx2UserRecourseSparseRaja.hpp
@@ -211,7 +211,7 @@ public:
           }
         });
 
-    RAJA::forall<RAJA::loop_exec>(RAJA::RangeSegment(0, n), [=](RAJA::Index_type i) { type[i] = hiopNonlinear; });
+    RAJA::forall<RAJA::seq_exec>(RAJA::RangeSegment(0, n), [=](RAJA::Index_type i) { type[i] = hiopNonlinear; });
     return true;
   }
 

--- a/src/Drivers/Sparse/CMakeLists.txt
+++ b/src/Drivers/Sparse/CMakeLists.txt
@@ -18,7 +18,7 @@ add_executable(NlpSparseEx4.exe NlpSparseEx4.cpp NlpSparseEx4Driver.cpp)
 target_link_libraries(NlpSparseEx4.exe HiOp::HiOp)
 
 if(HIOP_USE_RAJA)
-  if(HIOP_USE_GPU AND HIOP_USE_CUDA)
+  if(HIOP_USE_GPU AND HIOP_USE_CUDA AND HIOP_USE_RESOLVE)
     set_source_files_properties(
       NlpSparseRajaEx2.cpp 
       NlpSparseRajaEx2Driver.cpp 
@@ -83,7 +83,7 @@ if(HIOP_USE_GINKGO)
   endif(HIOP_USE_HIP)
 endif(HIOP_USE_GINKGO)
 
-if(HIOP_USE_RAJA AND HIOP_USE_GPU AND HIOP_USE_CUDA)
+if(HIOP_USE_RAJA AND HIOP_USE_GPU AND HIOP_USE_CUDA AND HIOP_USE_RESOLVE)
   add_test(NAME NlpSparseRaja2_1 COMMAND ${RUNCMD} "$<TARGET_FILE:NlpSparseRajaEx2.exe>" "500" "-inertiafree" "-selfcheck" "-resolve_cuda_glu")
   add_test(NAME NlpSparseRaja2_2 COMMAND ${RUNCMD} "$<TARGET_FILE:NlpSparseRajaEx2.exe>" "500" "-inertiafree" "-selfcheck" "-resolve_cuda_rf")
 endif()

--- a/src/Drivers/Sparse/NlpSparseRajaEx2.cpp
+++ b/src/Drivers/Sparse/NlpSparseRajaEx2.cpp
@@ -174,7 +174,7 @@ bool SparseRajaEx2::get_vars_info(const size_type& n, double* xlow, double* xupp
   }
 
   // Use a sequential policy for host computations for now
-  RAJA::forall<RAJA::loop_exec>(RAJA::RangeSegment(0, n), [=](RAJA::Index_type i) { type[i] = hiopNonlinear; });
+  RAJA::forall<RAJA::seq_exec>(RAJA::RangeSegment(0, n), [=](RAJA::Index_type i) { type[i] = hiopNonlinear; });
 
   return true;
 }
@@ -226,7 +226,7 @@ bool SparseRajaEx2::get_cons_info(const size_type& m, double* clow, double* cupp
   }
 
   // Must be a sequential host policy for now
-  RAJA::forall<RAJA::loop_exec>(RAJA::RangeSegment(0, m), [=](RAJA::Index_type i) { type[i] = hiopNonlinear; });
+  RAJA::forall<RAJA::seq_exec>(RAJA::RangeSegment(0, m), [=](RAJA::Index_type i) { type[i] = hiopNonlinear; });
 
   return true;
 }


### PR DESCRIPTION
Update HiOp to use the latest versions for RAJA and UMPIRE.

Note that `HIOP_USE_RESOLVE` is switched off since it fails ALL the cuda-related tests, i.e., even the `testVectors` fails.  For example, function `vectorSetToZero` fails with the error message 
```
terminate called after throwing an instance of 'thrust::system::system_error'
  what():  parallel_for failed: cudaErrorInvalidDeviceFunction: invalid device function
```

However, when I switch off `HIOP_USE_RESOLVE`, nothing wrong except for two unit tests under `NlpSparseRajaEx2`.
It is expected as these two unit tests need to use `ReSolve` [(see here)](https://github.com/LLNL/hiop/blob/develop/src/Drivers/Sparse/CMakeLists.txt#L86C1-L89C8)

Therefore this PR also corrects the Cmake file. Now these two examples are created only if `ReSolve` is given.

@pelesh Have you ever seen this kind of error? Does `ReSolve` require some specific cusolver packages?