### PR TITLE
spack v1.0 support: `%foo +bar` -> `+bar %foo`

### DIFF
--- a/scripts/platforms/marianas/spack.yaml
+++ b/scripts/platforms/marianas/spack.yaml
@@ -1,6 +1,6 @@
 spack:
   specs:
-  - hiop%gcc@10.2.0@develop+cuda+deepchecking+sparse+kron+cusolver_lu+ginkgo+raja cuda_arch=60
+  - hiop@develop+cuda+deepchecking+sparse+kron+cusolver_lu+ginkgo+raja cuda_arch=60 %gcc@10.2.0
   - raja@0.14.0
   - umpire@6.0.0
   - coinhsl@2019.05.21


### PR DESCRIPTION
Spack v1.0 will parse `pkg %gcc +foo` as "pkg with direct dependency gcc
with variant foo enabled" instead of "pkg with variant foo enabled and compiler
gcc". Reorder as `pkg +foo %gcc` to be compatible with Spack v0.x and
v1.0.
