### PR TITLE
derivative checker 

### DIFF
--- a/src/Drivers/Dense/CMakeLists.txt
+++ b/src/Drivers/Dense/CMakeLists.txt
@@ -30,7 +30,7 @@ install(
 ##########################################################
 # CMake Tests
 ##########################################################
-add_test(NAME NlpDenseCons1_5H  COMMAND ${RUNCMD} "$<TARGET_FILE:NlpDenseConsEx1.exe>"  "500" "1.0" "-selfcheck")
+add_test(NAME NlpDenseCons1_5H  COMMAND ${RUNCMD} "$<TARGET_FILE:NlpDenseConsEx1.exe>"  "10" "1.0" "-selfcheck")
 add_test(NAME NlpDenseCons1_5K  COMMAND ${RUNCMD} "$<TARGET_FILE:NlpDenseConsEx1.exe>" "5000" "1.0" "-selfcheck")
 add_test(NAME NlpDenseCons1_50K COMMAND ${RUNCMD} "$<TARGET_FILE:NlpDenseConsEx1.exe>" "50000" "1.0" "-selfcheck")
 if(HIOP_USE_MPI)

--- a/src/Drivers/Dense/CMakeLists.txt
+++ b/src/Drivers/Dense/CMakeLists.txt
@@ -30,7 +30,7 @@ install(
 ##########################################################
 # CMake Tests
 ##########################################################
-add_test(NAME NlpDenseCons1_5H  COMMAND ${RUNCMD} "$<TARGET_FILE:NlpDenseConsEx1.exe>"  "10" "1.0" "-selfcheck")
+add_test(NAME NlpDenseCons1_5H  COMMAND ${RUNCMD} "$<TARGET_FILE:NlpDenseConsEx1.exe>"  "500" "1.0" "-selfcheck")
 add_test(NAME NlpDenseCons1_5K  COMMAND ${RUNCMD} "$<TARGET_FILE:NlpDenseConsEx1.exe>" "5000" "1.0" "-selfcheck")
 add_test(NAME NlpDenseCons1_50K COMMAND ${RUNCMD} "$<TARGET_FILE:NlpDenseConsEx1.exe>" "50000" "1.0" "-selfcheck")
 if(HIOP_USE_MPI)

--- a/src/Drivers/Dense/NlpDenseConsEx1Driver.cpp
+++ b/src/Drivers/Dense/NlpDenseConsEx1Driver.cpp
@@ -102,9 +102,16 @@ int main(int argc, char** argv)
   DenseConsEx1 problem(mesh_size, ratio);
   hiop::hiopNlpDenseConstraints nlp(problem);
 
+  if(mesh_size==10) {
+    nlp.options->SetStringValue("derivative_check", "first-order");
+    nlp.options->SetStringValue("derivative_check_print_all", "yes");
+  }
+
+  
   hiop::hiopAlgFilterIPM solver(&nlp);
   problem.set_solver(&solver);
 
+  
   hiop::hiopSolveStatus status = solver.run();
   objective = solver.getObjective();
 

--- a/src/Drivers/Dense/NlpDenseConsEx1Driver.cpp
+++ b/src/Drivers/Dense/NlpDenseConsEx1Driver.cpp
@@ -101,10 +101,10 @@ int main(int argc, char** argv)
 
   DenseConsEx1 problem(mesh_size, ratio);
   hiop::hiopNlpDenseConstraints nlp(problem);
-  
+
   hiop::hiopAlgFilterIPM solver(&nlp);
   problem.set_solver(&solver);
-  
+
   hiop::hiopSolveStatus status = solver.run();
   objective = solver.getObjective();
 

--- a/src/Drivers/Dense/NlpDenseConsEx1Driver.cpp
+++ b/src/Drivers/Dense/NlpDenseConsEx1Driver.cpp
@@ -101,16 +101,9 @@ int main(int argc, char** argv)
 
   DenseConsEx1 problem(mesh_size, ratio);
   hiop::hiopNlpDenseConstraints nlp(problem);
-
-  if(mesh_size==10) {
-    nlp.options->SetStringValue("derivative_check", "first-order");
-    nlp.options->SetStringValue("derivative_check_print_all", "yes");
-  }
-
   
   hiop::hiopAlgFilterIPM solver(&nlp);
   problem.set_solver(&solver);
-
   
   hiop::hiopSolveStatus status = solver.run();
   objective = solver.getObjective();

--- a/src/Interface/hiopInterface.hpp
+++ b/src/Interface/hiopInterface.hpp
@@ -256,7 +256,10 @@ public:
    *
    *  @note When MPI is enabled, every rank populates @p cons since the constraints are not distributed.
    */
-  virtual bool eval_cons(const size_type& n, const size_type& m, const double* x, bool new_x, double* cons) { return false; }
+  virtual bool eval_cons(const size_type& n, const size_type& m, const double* x, bool new_x, double* cons)
+  {
+    return false;
+  }
 
   /** Passes the communicator, defaults to MPI_COMM_WORLD (dummy for non-MPI builds)  */
   virtual bool get_MPI_comm(MPI_Comm& comm_out)

--- a/src/LinAlg/hiopVector.hpp
+++ b/src/LinAlg/hiopVector.hpp
@@ -992,6 +992,28 @@ public:
    */
   virtual bool is_equal(const hiopVector& vec) const = 0;
 
+  /** 
+   * @brief Set element with index 'idx_global' to value 'val'.
+   *
+   * @pre idx_global must be a valid (global) index
+   *
+   * @note Avoid using this method repeatedly in performance-oriented part of the code since 
+   * cpu-device communication occurs for device implementations.
+   */
+  virtual void set_elem(const index_type& idx_global, const double& val) = 0;
+
+  /** 
+   * @brief Returns value of element with index 'idx_global'.
+   *
+   * The element is returned on all rank in MPI-based implementations.
+   * 
+   * @pre idx_global must be a valid (global) index
+   *
+   * @note Avoid using this method repeatedly in performance-oriented part of the code since 
+   * cpu-device or inter-process communication occurs.
+   */
+  virtual double get_elem(const index_type& idx_global) const = 0;
+  
 protected:
   size_type n_;  // we assume sequential data
 protected:

--- a/src/LinAlg/hiopVectorCompoundPD.hpp
+++ b/src/LinAlg/hiopVectorCompoundPD.hpp
@@ -328,9 +328,20 @@ public:
 
   virtual bool is_equal(const hiopVector& vec) const;
 
+  void set_elem(const index_type& idx_global, const double& val)
+  {
+    assert(0 && "not required.");
+  }
+  double get_elem(const index_type& idx_global) const
+  {
+    assert(0 && "not required.");
+    return 0;
+  }
+
+  
   void copy_from_resid(const hiopResidual* resid);
   void copy_from_iterate(const hiopIterate* it);
-
+  
 private:
   std::vector<hiopVector*> vectors_;
   size_type n_parts_;

--- a/src/LinAlg/hiopVectorCuda.cpp
+++ b/src/LinAlg/hiopVectorCuda.cpp
@@ -179,7 +179,7 @@ double hiopVectorCuda::get_elem(const index_type& idx_global) const
   double val;
   if(idx_local>=0 && idx_global<glob_iu_) {
     //val = data_dev_[idx_local];
-    exec_space_host.copy(&val, data_+idx_local, 1, exec_space_);
+    exec_space_host_.copy(&val, data_+idx_local, 1, exec_space_);
   } else {
     val = 0.;
   }

--- a/src/LinAlg/hiopVectorCuda.cpp
+++ b/src/LinAlg/hiopVectorCuda.cpp
@@ -147,7 +147,7 @@ void hiopVectorCuda::set_to_random_uniform(double minv, double maxv)
 {
   double* data = data_;
   hiop::cuda::array_random_uniform_kernel(n_local_, data, minv, maxv);
-}  // namespace hiop
+}
 
 /// @brief Set all elements that are not zero in ix to  c, and the rest to 0
 void hiopVectorCuda::setToConstant_w_patternSelect(double c, const hiopVector& select)
@@ -157,6 +157,43 @@ void hiopVectorCuda::setToConstant_w_patternSelect(double c, const hiopVector& s
   componentMult(select);
 }
 
+void hiopVectorCuda::set_elem(const index_type& idx_global, const double& val)
+{
+  assert(idx_global>=0 && idx_global<n_);
+  assert(idx_global-glob_il_ < n_local_);
+  const index_type idx_local = idx_global - glob_il_;
+  assert(idx_local < n_local_);
+  if(idx_local>=0 && idx_global<glob_iu_) {
+    //data_[idx_local] = val;
+    exec_space_.copy(data_dev_+idx_local, &val, 1, exec_space_host_);
+  }
+}
+
+double hiopVectorCuda::get_elem(const index_type& idx_global) const
+{
+  assert(idx_global>=0 && idx_global<n_);
+  assert(idx_global-glob_il_ < n_local_);
+  const index_type idx_local = idx_global - glob_il_;
+  assert(idx_local < n_local_);
+
+  double val;
+  if(idx_local>=0 && idx_global<glob_iu_) {
+    //val = data_dev_[idx_local];
+    exec_space_host.copy(&val, data_dev_+idx_local, 1, exec_space_);
+  } else {
+    val = 0.;
+  }
+#ifdef HIOP_USE_MPI
+  double valg;
+  //Bcast would be slightly more efficient but "root" rank is not known to the "other" ranks since
+  //we do not store the global index patitioning.
+  MPI_Allreduce(&val, &valg, 1, MPI_DOUBLE, MPI_SUM, comm_);
+  return valg;
+#else
+  return val;
+#endif
+}
+  
 /// @brief Copy the elements of v
 void hiopVectorCuda::copyFrom(const hiopVector& v_in)
 {

--- a/src/LinAlg/hiopVectorCuda.cpp
+++ b/src/LinAlg/hiopVectorCuda.cpp
@@ -165,7 +165,7 @@ void hiopVectorCuda::set_elem(const index_type& idx_global, const double& val)
   assert(idx_local < n_local_);
   if(idx_local>=0 && idx_global<glob_iu_) {
     //data_[idx_local] = val;
-    exec_space_.copy(data_dev_+idx_local, &val, 1, exec_space_host_);
+    exec_space_.copy(data_+idx_local, &val, 1, exec_space_host_);
   }
 }
 
@@ -179,7 +179,7 @@ double hiopVectorCuda::get_elem(const index_type& idx_global) const
   double val;
   if(idx_local>=0 && idx_global<glob_iu_) {
     //val = data_dev_[idx_local];
-    exec_space_host.copy(&val, data_dev_+idx_local, 1, exec_space_);
+    exec_space_host.copy(&val, data_+idx_local, 1, exec_space_);
   } else {
     val = 0.;
   }
@@ -975,10 +975,16 @@ hiopVector* hiopVectorCuda::new_copy() const
 }
 
 /// @brief copy data from host mirror to device
-void hiopVectorCuda::copyToDev() { exec_space_.copy(data_, data_host_mirror_, n_local_, exec_space_host_); }
+void hiopVectorCuda::copyToDev()
+{
+  exec_space_.copy(data_, data_host_mirror_, n_local_, exec_space_host_);
+}
 
 /// @brief copy data from device to host mirror
-void hiopVectorCuda::copyFromDev() { exec_space_host_.copy(data_host_mirror_, data_, n_local_, exec_space_); }
+void hiopVectorCuda::copyFromDev()
+{
+  exec_space_host_.copy(data_host_mirror_, data_, n_local_, exec_space_);
+}
 
 /// @brief copy data from host mirror to device
 void hiopVectorCuda::copyToDev() const

--- a/src/LinAlg/hiopVectorCuda.cpp
+++ b/src/LinAlg/hiopVectorCuda.cpp
@@ -160,10 +160,9 @@ void hiopVectorCuda::setToConstant_w_patternSelect(double c, const hiopVector& s
 void hiopVectorCuda::set_elem(const index_type& idx_global, const double& val)
 {
   assert(idx_global>=0 && idx_global<n_);
-  assert(idx_global-glob_il_ < n_local_);
   const index_type idx_local = idx_global - glob_il_;
-  assert(idx_local < n_local_);
   if(idx_local>=0 && idx_global<glob_iu_) {
+    assert(idx_local < n_local_);
     //data_[idx_local] = val;
     exec_space_.copy(data_+idx_local, &val, 1, exec_space_host_);
   }
@@ -172,12 +171,11 @@ void hiopVectorCuda::set_elem(const index_type& idx_global, const double& val)
 double hiopVectorCuda::get_elem(const index_type& idx_global) const
 {
   assert(idx_global>=0 && idx_global<n_);
-  assert(idx_global-glob_il_ < n_local_);
   const index_type idx_local = idx_global - glob_il_;
-  assert(idx_local < n_local_);
 
   double val;
   if(idx_local>=0 && idx_global<glob_iu_) {
+    assert(idx_local < n_local_);
     //val = data_dev_[idx_local];
     exec_space_host_.copy(&val, data_+idx_local, 1, exec_space_);
   } else {

--- a/src/LinAlg/hiopVectorCuda.hpp
+++ b/src/LinAlg/hiopVectorCuda.hpp
@@ -343,6 +343,28 @@ public:
   /// @brief check if `this` vector is identical to `vec`
   virtual bool is_equal(const hiopVector& vec) const;
 
+  /** 
+   * @brief Set element with index 'idx_global' to value 'val'.
+   *
+   * @pre idx_global must be a valid (global) index
+   *
+   * @note Avoid using this method repeatedly in performance-oriented part of the code since 
+   * cpu-device communication occurs for device implementations.
+   */
+  virtual void set_elem(const index_type& idx_global, const double& val);
+
+  /** 
+   * @brief Returns value of element with index 'idx_global'.
+   *
+   * The element is returned on all rank in MPI-based implementations.
+   * 
+   * @pre idx_global must be a valid (global) index
+   *
+   * @note Avoid using this method repeatedly in performance-oriented part of the code since 
+   * cpu-device or inter-process communication occurs.
+   */
+  virtual double get_elem(const index_type& idx_global) const;
+  
   /* functions for this class */
   inline MPI_Comm get_mpi_comm() const { return comm_; }
 

--- a/src/LinAlg/hiopVectorCuda.hpp
+++ b/src/LinAlg/hiopVectorCuda.hpp
@@ -373,7 +373,7 @@ public:
 
 private:
   ExecSpace<MemBackendCuda, ExecPolicyCuda> exec_space_;
-  ExecSpace<MemBackendCpp, ExecPolicySeq> exec_space_host_;
+  mutable ExecSpace<MemBackendCpp, ExecPolicySeq> exec_space_host_;
 
   MPI_Comm comm_;
   double* data_host_mirror_;

--- a/src/LinAlg/hiopVectorHip.cpp
+++ b/src/LinAlg/hiopVectorHip.cpp
@@ -165,7 +165,7 @@ void hiopVectorHip::set_elem(const index_type& idx_global, const double& val)
   assert(idx_local < n_local_);
   if(idx_local>=0 && idx_global<glob_iu_) {
     //data_[idx_local] = val;
-    exec_space_.copy(data_dev_+idx_local, &val, 1, exec_space_host_);
+    exec_space_.copy(data_+idx_local, &val, 1, exec_space_host_);
   }
 }
 
@@ -179,7 +179,7 @@ double hiopVectorHip::get_elem(const index_type& idx_global) const
   double val;
   if(idx_local>=0 && idx_global<glob_iu_) {
     //val = data_dev_[idx_local];
-    exec_space_host.copy(&val, data_dev_+idx_local, 1, exec_space_);
+    exec_space_host.copy(&val, data_+idx_local, 1, exec_space_);
   } else {
     val = 0.;
   }

--- a/src/LinAlg/hiopVectorHip.cpp
+++ b/src/LinAlg/hiopVectorHip.cpp
@@ -179,7 +179,7 @@ double hiopVectorHip::get_elem(const index_type& idx_global) const
   double val;
   if(idx_local>=0 && idx_global<glob_iu_) {
     //val = data_dev_[idx_local];
-    exec_space_host.copy(&val, data_+idx_local, 1, exec_space_);
+    exec_space_host_.copy(&val, data_+idx_local, 1, exec_space_);
   } else {
     val = 0.;
   }

--- a/src/LinAlg/hiopVectorHip.cpp
+++ b/src/LinAlg/hiopVectorHip.cpp
@@ -160,10 +160,10 @@ void hiopVectorHip::set_to_random_uniform(double minv, double maxv)
 void hiopVectorHip::set_elem(const index_type& idx_global, const double& val)
 {
   assert(idx_global>=0 && idx_global<n_);
-  assert(idx_global-glob_il_ < n_local_);
   const index_type idx_local = idx_global - glob_il_;
-  assert(idx_local < n_local_);
+
   if(idx_local>=0 && idx_global<glob_iu_) {
+    assert(idx_local < n_local_);
     //data_[idx_local] = val;
     exec_space_.copy(data_+idx_local, &val, 1, exec_space_host_);
   }
@@ -172,12 +172,11 @@ void hiopVectorHip::set_elem(const index_type& idx_global, const double& val)
 double hiopVectorHip::get_elem(const index_type& idx_global) const
 {
   assert(idx_global>=0 && idx_global<n_);
-  assert(idx_global-glob_il_ < n_local_);
   const index_type idx_local = idx_global - glob_il_;
-  assert(idx_local < n_local_);
 
   double val;
   if(idx_local>=0 && idx_global<glob_iu_) {
+    assert(idx_local < n_local_);
     //val = data_dev_[idx_local];
     exec_space_host_.copy(&val, data_+idx_local, 1, exec_space_);
   } else {

--- a/src/LinAlg/hiopVectorHip.cpp
+++ b/src/LinAlg/hiopVectorHip.cpp
@@ -155,8 +155,45 @@ void hiopVectorHip::set_to_random_uniform(double minv, double maxv)
 {
   double* data = data_;
   hiop::hip::array_random_uniform_kernel(n_local_, data, minv, maxv);
-}  // namespace hiop
+}
 
+void hiopVectorHip::set_elem(const index_type& idx_global, const double& val)
+{
+  assert(idx_global>=0 && idx_global<n_);
+  assert(idx_global-glob_il_ < n_local_);
+  const index_type idx_local = idx_global - glob_il_;
+  assert(idx_local < n_local_);
+  if(idx_local>=0 && idx_global<glob_iu_) {
+    //data_[idx_local] = val;
+    exec_space_.copy(data_dev_+idx_local, &val, 1, exec_space_host_);
+  }
+}
+
+double hiopVectorHip::get_elem(const index_type& idx_global) const
+{
+  assert(idx_global>=0 && idx_global<n_);
+  assert(idx_global-glob_il_ < n_local_);
+  const index_type idx_local = idx_global - glob_il_;
+  assert(idx_local < n_local_);
+
+  double val;
+  if(idx_local>=0 && idx_global<glob_iu_) {
+    //val = data_dev_[idx_local];
+    exec_space_host.copy(&val, data_dev_+idx_local, 1, exec_space_);
+  } else {
+    val = 0.;
+  }
+#ifdef HIOP_USE_MPI
+  double valg;
+  //Bcast would be slightly more efficient but "root" rank is not known to the "other" ranks since
+  //we do not store the global index patitioning.
+  MPI_Allreduce(&val, &valg, 1, MPI_DOUBLE, MPI_SUM, comm_);
+  return valg;
+#else
+  return val;
+#endif
+}
+  
 /// @brief Set all elements that are not zero in ix to  c, and the rest to 0
 void hiopVectorHip::setToConstant_w_patternSelect(double c, const hiopVector& select)
 {

--- a/src/LinAlg/hiopVectorHip.hpp
+++ b/src/LinAlg/hiopVectorHip.hpp
@@ -346,7 +346,29 @@ public:
 
   /// @brief check if `this` vector is identical to `vec`
   virtual bool is_equal(const hiopVector& vec) const;
+  
+  /** 
+   * @brief Set element with index 'idx_global' to value 'val'.
+   *
+   * @pre idx_global must be a valid (global) index
+   *
+   * @note Avoid using this method repeatedly in performance-oriented part of the code since 
+   * cpu-device communication occurs for device implementations.
+   */
+  virtual void set_elem(const index_type& idx_global, const double& val);
 
+  /** 
+   * @brief Returns value of element with index 'idx_global'.
+   *
+   * The element is returned on all rank in MPI-based implementations.
+   * 
+   * @pre idx_global must be a valid (global) index
+   *
+   * @note Avoid using this method repeatedly in performance-oriented part of the code since 
+   * cpu-device or inter-process communication occurs.
+   */
+  virtual double get_elem(const index_type& idx_global) const;
+  
   /* functions for this class */
   inline MPI_Comm get_mpi_comm() const { return comm_; }
 

--- a/src/LinAlg/hiopVectorHip.hpp
+++ b/src/LinAlg/hiopVectorHip.hpp
@@ -387,10 +387,10 @@ private:
   size_type n_local_;
   mutable hiopVectorInt* idx_cumsum_;
 
-  /** needed for cuda **/
+  /** HIP Blas handle **/
   hipblasHandle_t handle_hipblas_;
 
-  /** copy constructor, for internal/private use only (it doesn't copy the elements.) */
+  /** Copy constructor, for internal/private use only (it doesn't copy the elements.) */
   hiopVectorHip(const hiopVectorHip&);
 };
 

--- a/src/LinAlg/hiopVectorHip.hpp
+++ b/src/LinAlg/hiopVectorHip.hpp
@@ -377,7 +377,7 @@ public:
 
 private:
   ExecSpace<MemBackendHip, ExecPolicyHip> exec_space_;
-  ExecSpace<MemBackendCpp, ExecPolicySeq> exec_space_host_;
+  mutable ExecSpace<MemBackendCpp, ExecPolicySeq> exec_space_host_;
 
   MPI_Comm comm_;
   double* data_host_mirror_;

--- a/src/LinAlg/hiopVectorPar.cpp
+++ b/src/LinAlg/hiopVectorPar.cpp
@@ -181,13 +181,12 @@ double hiopVectorPar::get_elem(const index_type& idx_global) const
 #ifdef HIOP_USE_MPI
   double valg;
   //Bcast would be slightly more efficient but "root" rank is not known to the "other" ranks since
-  //we do not store the global index distribution.
+  //we do not store the global index patitioning.
   MPI_Allreduce(&val, &valg, 1, MPI_DOUBLE, MPI_SUM, comm_);
   return valg;
 #else
   return val;
 #endif
-
 }
 
 void hiopVectorPar::copyFrom(const hiopVector& v_in)

--- a/src/LinAlg/hiopVectorPar.cpp
+++ b/src/LinAlg/hiopVectorPar.cpp
@@ -153,6 +153,43 @@ void hiopVectorPar::setToConstant_w_patternSelect(double c, const hiopVector& se
     }
   }
 }
+
+void hiopVectorPar::set_elem(const index_type& idx_global, const double& val)
+{
+  assert(idx_global>=0 && idx_global<n_);
+  assert(idx_global-glob_il_ < n_local_);
+  const index_type idx_local = idx_global - glob_il_;
+  assert(idx_local < n_local_);
+  if(idx_local>=0 && idx_global<glob_iu_) {
+    data_[idx_local] = val;
+  }
+}
+  
+double hiopVectorPar::get_elem(const index_type& idx_global) const
+{
+  assert(idx_global>=0 && idx_global<n_);
+  assert(idx_global-glob_il_ < n_local_);
+  const index_type idx_local = idx_global - glob_il_;
+  assert(idx_local < n_local_);
+
+  double val;
+  if(idx_local>=0 && idx_global<glob_iu_) {
+    val = data_[idx_local];
+  } else {
+    val = 0.;
+  }
+#ifdef HIOP_USE_MPI
+  double valg;
+  //Bcast would be slightly more efficient but "root" rank is not known to the "other" ranks since
+  //we do not store the global index distribution.
+  MPI_Allreduce(&val, &valg, 1, MPI_DOUBLE, MPI_SUM, comm_);
+  return valg;
+#else
+  return val;
+#endif
+
+}
+
 void hiopVectorPar::copyFrom(const hiopVector& v_in)
 {
   const hiopVectorPar& v = dynamic_cast<const hiopVectorPar&>(v_in);

--- a/src/LinAlg/hiopVectorPar.cpp
+++ b/src/LinAlg/hiopVectorPar.cpp
@@ -157,10 +157,10 @@ void hiopVectorPar::setToConstant_w_patternSelect(double c, const hiopVector& se
 void hiopVectorPar::set_elem(const index_type& idx_global, const double& val)
 {
   assert(idx_global>=0 && idx_global<n_);
-  assert(idx_global-glob_il_ < n_local_);
   const index_type idx_local = idx_global - glob_il_;
-  assert(idx_local < n_local_);
+
   if(idx_local>=0 && idx_global<glob_iu_) {
+    assert(idx_local < n_local_);
     data_[idx_local] = val;
   }
 }
@@ -168,12 +168,10 @@ void hiopVectorPar::set_elem(const index_type& idx_global, const double& val)
 double hiopVectorPar::get_elem(const index_type& idx_global) const
 {
   assert(idx_global>=0 && idx_global<n_);
-  assert(idx_global-glob_il_ < n_local_);
   const index_type idx_local = idx_global - glob_il_;
-  assert(idx_local < n_local_);
-
   double val;
   if(idx_local>=0 && idx_global<glob_iu_) {
+    assert(idx_local < n_local_);
     val = data_[idx_local];
   } else {
     val = 0.;

--- a/src/LinAlg/hiopVectorPar.hpp
+++ b/src/LinAlg/hiopVectorPar.hpp
@@ -299,6 +299,29 @@ public:
 
   virtual bool is_equal(const hiopVector& vec) const;
 
+  /** 
+   * @brief Set element with index 'idx_global' to value 'val'.
+   *
+   * @pre idx_global must be a valid (global) index
+   *
+   * @note Avoid using this method repeatedly in performance-oriented part of the code since 
+   * cpu-device communication occurs for device implementations.
+   */
+  virtual void set_elem(const index_type& idx_global, const double& val);
+
+  /** 
+   * @brief Returns value of element with index 'idx_global'.
+   *
+   * The element is returned on all rank in MPI-based implementations.
+   * 
+   * @pre idx_global must be a valid (global) index
+   *
+   * @note Avoid using this method repeatedly in performance-oriented part of the code since 
+   * inter-process communication occurs.
+   */
+  virtual double get_elem(const index_type& idx_global) const;
+
+  
   /**
    * @brief accessor to the execution policy
    */

--- a/src/LinAlg/hiopVectorRaja.hpp
+++ b/src/LinAlg/hiopVectorRaja.hpp
@@ -329,7 +329,6 @@ public:
    */
   virtual double get_elem(const index_type& idx_global) const;
 
-  
   const ExecSpace<MEMBACKEND, EXECPOLICYRAJA>& exec_space() const { return exec_space_; }
   
 private:
@@ -341,7 +340,7 @@ private:
   // and transfers within and from `exec_space_host_` work with EXECPOLICYHOST (currently all such
   // combinations work).
   using EXECPOLICYHOST = hiop::ExecPolicySeq;
-  ExecSpace<MEMBACKENDHOST, EXECPOLICYHOST> exec_space_host_;
+  mutable ExecSpace<MEMBACKENDHOST, EXECPOLICYHOST> exec_space_host_;
 
   std::string mem_space_;
   MPI_Comm comm_;

--- a/src/LinAlg/hiopVectorRaja.hpp
+++ b/src/LinAlg/hiopVectorRaja.hpp
@@ -307,8 +307,31 @@ public:
 
   virtual bool is_equal(const hiopVector& vec) const;
 
-  const ExecSpace<MEMBACKEND, EXECPOLICYRAJA>& exec_space() const { return exec_space_; }
+    /** 
+   * @brief Set element with index 'idx_global' to value 'val'.
+   *
+   * @pre idx_global must be a valid (global) index
+   *
+   * @note Avoid using this method repeatedly in performance-oriented part of the code since 
+   * cpu-device communication occurs for device implementations.
+   */
+  virtual void set_elem(const index_type& idx_global, const double& val);
 
+  /** 
+   * @brief Returns value of element with index 'idx_global'.
+   *
+   * The element is returned on all rank in MPI-based implementations.
+   * 
+   * @pre idx_global must be a valid (global) index
+   *
+   * @note Avoid using this method repeatedly in performance-oriented part of the code since 
+   * cpu-device or inter-process communication occurs.
+   */
+  virtual double get_elem(const index_type& idx_global) const;
+
+  
+  const ExecSpace<MEMBACKEND, EXECPOLICYRAJA>& exec_space() const { return exec_space_; }
+  
 private:
   ExecSpace<MEMBACKEND, EXECPOLICYRAJA> exec_space_;
   using MEMBACKENDHOST = typename MEMBACKEND::MemBackendHost;

--- a/src/LinAlg/hiopVectorRajaImpl.hpp
+++ b/src/LinAlg/hiopVectorRajaImpl.hpp
@@ -762,6 +762,47 @@ void hiopVectorRaja<MEM, POL>::copyTo(double* dest) const
   this_nonconst->exec_space_.copy(dest, data_dev_, n_local_);
 }
 
+template<class MEM, class POL>
+void hiopVector<MEM, POL>::set_elem(const index_type& idx_global, const double& val)
+{
+  assert(idx_global>=0 && idx_global<n_);
+  assert(idx_global-glob_il_ < n_local_);
+  const index_type idx_local = idx_global - glob_il_;
+  assert(idx_local < n_local_);
+  if(idx_local>=0 && idx_global<glob_iu_) {
+    //data_[idx_local] = val;
+    exec_space_.copy(data_dev_+idx_local, &val, 1, exec_space_host_);
+  }
+}
+
+template<class MEM, class POL>
+double hiopVectorRaja<MEM, POL>::get_elem(const index_type& idx_global) const
+{
+  assert(idx_global>=0 && idx_global<n_);
+  assert(idx_global-glob_il_ < n_local_);
+  const index_type idx_local = idx_global - glob_il_;
+  assert(idx_local < n_local_);
+
+  double val;
+  if(idx_local>=0 && idx_global<glob_iu_) {
+    //val = data_dev_[idx_local];
+    exec_space_host.copy(&val, data_dev_+idx_local, 1, exec_space_);
+  } else {
+    val = 0.;
+  }
+#ifdef HIOP_USE_MPI
+  double valg;
+  //Bcast would be slightly more efficient but "root" rank is not known to the "other" ranks since
+  //we do not store the global index patitioning.
+  MPI_Allreduce(&val, &valg, 1, MPI_DOUBLE, MPI_SUM, comm_);
+  return valg;
+#else
+  return val;
+#endif
+
+}
+
+
 /**
  * @brief L2 vector norm.
  *

--- a/src/LinAlg/hiopVectorRajaImpl.hpp
+++ b/src/LinAlg/hiopVectorRajaImpl.hpp
@@ -784,8 +784,20 @@ double hiopVectorRaja<MEM, POL>::get_elem(const index_type& idx_global) const
   double val;
   if(idx_local>=0 && idx_global<glob_iu_) {
     assert(idx_local < n_local_);
-    //val = data_dev_[idx_local];
-    exec_space_host_.copy(&val, data_dev_+idx_local, 1, exec_space_);
+
+    //copyFromDev would copy unnecessary many elems
+    //this->copyFromDev();
+    
+    //one elem direct copy fails because UMPIRE does not recognize data_dev_+idx_local as a pointer he allocated!
+
+    //using one elem reduce
+    double* data = data_dev_;
+    RAJA::ReduceSum<hiop_raja_reduce, double> sum(0.0);
+    RAJA::forall<hiop_raja_exec>(
+      RAJA::RangeSegment(idx_local, idx_local+1),
+      RAJA_LAMBDA(RAJA::Index_type i) { sum += data[i]; });
+
+    val = sum.get();
   } else {
     val = 0.;
   }

--- a/src/LinAlg/hiopVectorRajaImpl.hpp
+++ b/src/LinAlg/hiopVectorRajaImpl.hpp
@@ -799,7 +799,6 @@ double hiopVectorRaja<MEM, POL>::get_elem(const index_type& idx_global) const
 #else
   return val;
 #endif
-
 }
 
 

--- a/src/LinAlg/hiopVectorRajaImpl.hpp
+++ b/src/LinAlg/hiopVectorRajaImpl.hpp
@@ -766,10 +766,10 @@ template<class MEM, class POL>
 void hiopVectorRaja<MEM, POL>::set_elem(const index_type& idx_global, const double& val)
 {
   assert(idx_global>=0 && idx_global<n_);
-  assert(idx_global-glob_il_ < n_local_);
   const index_type idx_local = idx_global - glob_il_;
-  assert(idx_local < n_local_);
+
   if(idx_local>=0 && idx_global<glob_iu_) {
+    assert(idx_local < n_local_);
     //data_[idx_local] = val;
     exec_space_.copy(data_dev_+idx_local, &val, 1, exec_space_host_);
   }
@@ -779,14 +779,12 @@ template<class MEM, class POL>
 double hiopVectorRaja<MEM, POL>::get_elem(const index_type& idx_global) const
 {
   assert(idx_global>=0 && idx_global<n_);
-  assert(idx_global-glob_il_ < n_local_);
   const index_type idx_local = idx_global - glob_il_;
-  assert(idx_local < n_local_);
-
   double val;
   if(idx_local>=0 && idx_global<glob_iu_) {
+    assert(idx_local < n_local_);
     //val = data_dev_[idx_local];
-    exec_space_host.copy(&val, data_dev_+idx_local, 1, exec_space_);
+    exec_space_host_.copy(&val, data_dev_+idx_local, 1, exec_space_);
   } else {
     val = 0.;
   }

--- a/src/LinAlg/hiopVectorRajaImpl.hpp
+++ b/src/LinAlg/hiopVectorRajaImpl.hpp
@@ -763,7 +763,7 @@ void hiopVectorRaja<MEM, POL>::copyTo(double* dest) const
 }
 
 template<class MEM, class POL>
-void hiopVector<MEM, POL>::set_elem(const index_type& idx_global, const double& val)
+void hiopVectorRaja<MEM, POL>::set_elem(const index_type& idx_global, const double& val)
 {
   assert(idx_global>=0 && idx_global<n_);
   assert(idx_global-glob_il_ < n_local_);

--- a/src/LinAlg/hiopVectorRajaImpl.hpp
+++ b/src/LinAlg/hiopVectorRajaImpl.hpp
@@ -770,8 +770,9 @@ void hiopVectorRaja<MEM, POL>::set_elem(const index_type& idx_global, const doub
 
   if(idx_local>=0 && idx_global<glob_iu_) {
     assert(idx_local < n_local_);
+    double* data = data_dev_;
     //data_[idx_local] = val;
-    exec_space_.copy(data_dev_+idx_local, &val, 1, exec_space_host_);
+    RAJA::forall<hiop_raja_exec>(RAJA::RangeSegment(idx_local, idx_local+1), RAJA_LAMBDA(RAJA::Index_type i) { data[i] = val; });
   }
 }
 

--- a/src/Optimization/hiopAlgFilterIPM.cpp
+++ b/src/Optimization/hiopAlgFilterIPM.cpp
@@ -953,6 +953,10 @@ hiopSolveStatus hiopAlgFilterIPMQuasiNewton::run()
   // types of linear algebra objects are known now
   auto* Hess = dynamic_cast<HessianDiagPlusRowRank*>(_Hess_Lagr);
 
+  if(nlp->options->GetString("derivative_check") != "no") {
+    nlp->run_derivative_checker();
+  }
+  
   nlp->runStats.initialize();
   nlp->runStats.kkt.initialize();
   ////////////////////////////////////////////////////////////////////////////////////

--- a/src/Optimization/hiopAlgFilterIPM.cpp
+++ b/src/Optimization/hiopAlgFilterIPM.cpp
@@ -662,25 +662,16 @@ bool hiopAlgFilterIPMBase::evalNlpAndLogErrors(const hiopIterate& it,
   nlp->log->printf(hovScalars, "nrmOneDualEqu %g   nrmOneDualBo %g\n", nrmDualEqu, nrmDualBou);
   if(nrmDualBou > 1e+10) {
     nlp->log->printf(hovWarning,
-                     "Unusually large bound dual variables (norm1=%g) occured, "
-                     "which may cause numerical instabilities if it persists. Convergence "
-                     " issues or inacurate optimal solutions may be experienced. Possible causes: "
-                     " tight bounds or bad scaling of the optimization variables.\n",
+                     "Unusually large bound dual variables (norm1=%g) occured, \n"
+                     "          which may cause numerical instabilities, convergence issues, \n"
+                     "          and/or inacurate optimal solutions. Generally this is due to \n"
+                     "          lower and upper bounds being too close to each other or due to \n"
+                     "          ill scaling of the optimization variables.\n",
                      nrmDualBou);
-    if(nlp->options->GetString("fixed_var") == "remove") {
-      nlp->log->printf(hovWarning,
-                       "For example, increase 'fixed_var_tolerance' to remove "
-                       "additional variables.\n");
-    } else if(nlp->options->GetString("fixed_var") == "relax") {
-      nlp->log->printf(hovWarning,
-                       "For example, increase 'fixed_var_tolerance' to relax "
-                       "aditional (tight) variables and/or increase 'fixed_var_perturb' "
-                       "to decrease the tightness.\n");
-    } else {
-      nlp->log->printf(hovWarning,
-                       "Potential fixes: fix or relax variables with tight bounds "
-                       "(see 'fixed_var' option) or rescale variables.\n");
-    }
+
+    nlp->log->printf(hovWarning,
+                     "HiOp options 'fixed_var_tolerance', 'bound_relax_perturb', or \n"
+                     "          'elastic_mode' may remedy this issue. Also see 'scaling_type' option.\n");
   }
 
   // scaling factors

--- a/src/Optimization/hiopAlgFilterIPM.cpp
+++ b/src/Optimization/hiopAlgFilterIPM.cpp
@@ -349,7 +349,7 @@ int hiopAlgFilterIPMBase::startingProcedure(hiopIterate& it_ini,
     return false;
   }
 
-  [[maybe_unused]] const bool do_nlp_scaling = nlp->apply_scaling(c, d, gradf, Jac_c, Jac_d);
+  nlp->apply_scaling(c, d, gradf, Jac_c, Jac_d);
 
   nlp->runStats.tmSolverInternal.start();
   nlp->runStats.tmStartingPoint.start();

--- a/src/Optimization/hiopFRProb.cpp
+++ b/src/Optimization/hiopFRProb.cpp
@@ -1397,7 +1397,7 @@ hiopFRProbDense::hiopFRProbDense(hiopAlgFilterIPMBase& solver_base)
   m_eq_ = nlp_base_->m_eq();
   m_ineq_ = nlp_base_->m_ineq();
 #ifdef HIOP_USE_MPI
-  vec_distrib_base_ = nlp_base_->getVecDistInfo();
+  vec_distrib_base_ = nlp_base_->get_vector_distrib();
 #endif
   n_ = n_x_ + 2 * m_eq_ + 2 * m_ineq_;
   m_ = m_eq_ + m_ineq_;
@@ -1432,7 +1432,7 @@ hiopFRProbDense::hiopFRProbDense(hiopAlgFilterIPMBase& solver_base)
 #ifdef HIOP_USE_MPI
   if(vec_distrib_base_) {
     for(int i = 0; i < comm_size_; ++i) {
-      col_partition_[i] = nlp_base_->getVecDistInfo()[i];
+      col_partition_[i] = nlp_base_->get_vector_distrib()[i];
     }
   }
   if(col_partition_) {

--- a/src/Optimization/hiopNlpFormulation.cpp
+++ b/src/Optimization/hiopNlpFormulation.cpp
@@ -1031,7 +1031,8 @@ void hiopNlpFormulation::run_derivative_checker()
   // Second-order checks
   //  
   if(!user_eval_err && options->GetString("derivative_check") == "second-order") {
-    run_derivative_checker_order2(*x0_user, *grad_exact, *Jac_c_ref, *Jac_d_ref);
+    //TODO - finish 2nd order derivatives (Hessian of Lagrangian) check
+    //run_derivative_checker_order2(*x0_user, *grad_exact, *Jac_c_ref, *Jac_d_ref);
   }
   
   disable_nlp_transformations_ = false;
@@ -2613,7 +2614,7 @@ size_type hiopNlpSparse::run_derivative_checker_order2(hiopVector& x_ref,
   //
   // constraints Hessian
   //
-  // Jacobians at perturbed x
+  // Jacobians at perturbed x (TODO)
   hiopMatrix* Jacc_pert = Jacc_ref.alloc_clone();
   hiopMatrix* Jacd_pert = Jacd_ref.alloc_clone();
 

--- a/src/Optimization/hiopNlpFormulation.cpp
+++ b/src/Optimization/hiopNlpFormulation.cpp
@@ -804,7 +804,7 @@ void hiopNlpFormulation::run_derivative_checker()
   assert(n_cons_ == it_hiop->get_yc()->get_size() + it_hiop->get_yd()->get_size());
 
   // finite difference (FD) check at initial point provided by the user 
-  hiopVector* x0_for_user = nlp_transformations_.apply_inv_to_x(*it_hiop->get_x(), true);
+  hiopVector* x0_user = nlp_transformations_.apply_inv_to_x(*it_hiop->get_x(), true);
 
   double* zL0_for_user = it_hiop->get_zl()->local_data();
   double* zU0_for_user = it_hiop->get_zu()->local_data();
@@ -821,7 +821,7 @@ void hiopNlpFormulation::run_derivative_checker()
   bool slacks_avail = false;
   bool bret = interface_base.get_starting_point(nlp_transformations_.n_pre(),
                                                 n_cons_,
-                                                x0_for_user->local_data(),
+                                                x0_user->local_data(),
                                                 duals_avail,
                                                 zL0_for_user,
                                                 zU0_for_user,
@@ -830,18 +830,40 @@ void hiopNlpFormulation::run_derivative_checker()
                                                 d_for_user);
   //if above failed, try the other user-provided starting point method
   if(!bret) {
-    bret = interface_base.get_starting_point(nlp_transformations_.n_pre(), x0_for_user->local_data());
+    bret = interface_base.get_starting_point(nlp_transformations_.n_pre(), x0_user->local_data());
   }
   if(!bret) {
-    log->printf(hovError, "Derivate check failed due to failure(s) in user-provided starting point methods.");
-    return;
+    log->printf(hovError, "Derivate check error in user-provided starting point methods. Using vector of all zero.");
+    x0_user->setToConstant(0.0);
   }
   
-  hiopVector& x_ref = *x0_for_user;
+  hiopVector& x_ref = *x0_user;
   const double pert = options->GetNumeric("derivative_check_perturbation");
   const double derivative_check_tolerance = options->GetNumeric("derivative_check_tolerance");
   const bool print_all = ( options->GetString("derivative_check_print_all") != "no" );
   hiopVector* x_pert = x_ref.alloc_clone();
+
+  hiopVector* grad_exact = x_ref.alloc_clone();
+  bret = interface_base.eval_grad_f(nlp_transformations_.n_pre(),
+                                    x_ref.local_data_const(),
+                                    true,
+                                    grad_exact->local_data());
+  bool user_eval_err = false;
+  if(!bret) {
+    log->printf(hovError, "Derivative check error: in evaluating user gradient.");
+    user_eval_err = true;
+  }
+    
+  
+  //evaluate "exact"/user Jacobian(s)
+  //alocate Jacobians at the reference point - need to be in the user's sizes
+  hiopMatrix* Jac_c_ref = this->alloc_Jac_c_user();
+  hiopMatrix* Jac_d_ref = this->alloc_Jac_c_user();
+  
+  if(!eval_Jac_c_d(x_ref, true, *Jac_c_ref, *Jac_d_ref)) {
+    log->printf(hovError, "Derivative checker error: in user Jacobian function.\n");
+    user_eval_err = true;
+  }
 
   //
   // gradient and Jacobian
@@ -850,25 +872,17 @@ void hiopNlpFormulation::run_derivative_checker()
     
     log->printf(hovSummary, "Starting derivative checker for gradient ...\n");
     size_t num_errs = 0;
+
+    // objective function
     double f_ref;
     bret = interface_base.eval_f(nlp_transformations_.n_pre(), x_ref.local_data_const(), true, f_ref);
     if(!bret) {
       log->printf(hovError, "Derivative check error: in evaluating user objective.");
-      return;
-    }
-    
-    hiopVector* grad_exact = x_ref.alloc_clone();
-    bret = interface_base.eval_grad_f(nlp_transformations_.n_pre(),
-                                      x_ref.local_data_const(),
-                                      false,
-                                      grad_exact->local_data());
-    if(!bret) {
-      log->printf(hovError, "Derivative check error: in evaluating user gradient.");
-      return;
+      user_eval_err = true;
     }
     
     // grad_fd = (f(x_pert) - f(x_ref)) / pert    
-    for(index_type idx=0; idx<nlp_transformations_.n_pre(); ++idx) {
+    for(index_type idx=0; idx<nlp_transformations_.n_pre() && !user_eval_err; ++idx) {
       const double val_ref = x_ref.get_elem(idx);
 
       x_pert->copyFrom(x_ref);
@@ -877,7 +891,11 @@ void hiopNlpFormulation::run_derivative_checker()
       //evaluate at the perturbed point
       double f_pert;
       bret = interface_base.eval_f(nlp_transformations_.n_pre(), x_pert->local_data_const(), true, f_pert);
-
+      if(!bret) {
+        log->printf(hovError, "Derivative check error: in evaluating user objective.");
+        user_eval_err = true;
+        break;
+      }
       const double grad_fd = (f_pert-f_ref)/pert;
       const double grad_ex = grad_exact->get_elem(idx);
       const double scale = max(grad_ex, max(abs(grad_fd), derivative_check_tolerance));
@@ -900,119 +918,127 @@ void hiopNlpFormulation::run_derivative_checker()
       }
       
     }
-    log->printf(hovSummary, "Derivative checker for gradient finished: %d errors detected.\n", num_errs);
-    delete grad_exact;
+    if(user_eval_err) {
+      log->printf(hovSummary, "Derivative checker halted because of error(s) in user provided functions.");
+    } else {
+      log->printf(hovSummary, "Derivative checker for gradient finished: %d errors detected.\n", num_errs);
 
-    //
-    // Jacobian check
-    //
-    log->printf(hovSummary, "Starting derivative checker for Jacobian ...\n");
-    num_errs = 0;
-    disable_nlp_transformations_ = true;
-
-    hiopVector* cons_ref = this->alloc_dual_vec();
-    if(temp_eq_ == nullptr) {
-      temp_eq_ = this->alloc_dual_eq_vec();
-    }
-    if(temp_ineq_ == nullptr) {
-      temp_ineq_ = this->alloc_dual_ineq_vec();
-    }
-    hiopVector& cons_c_ref = *temp_eq_;
-    hiopVector& cons_d_ref = *temp_ineq_;
-    
-    if(!this->eval_c_d(x_ref, true, cons_c_ref, cons_d_ref)) {
-      log->printf(hovError, "Derivative checker error: in user constraint function.\n");
-      return;
-    }
-    cons_ref->copy_from_two_vec_w_pattern(cons_c_ref,
-                                          *cons_eq_mapping_,
-                                          cons_d_ref,
-                                          *cons_ineq_mapping_);
-
-    //evaluate "exact"/user Jacobian(s)
-
-    //alocate Jacobians at the reference point - need to be in the user's sizes
-    hiopMatrix* Jac_c_ref = this->alloc_Jac_c_user();
-    hiopMatrix* Jac_d_ref = this->alloc_Jac_c_user();
-
-    if(!eval_Jac_c_d(x_ref, false, *Jac_c_ref, *Jac_d_ref)) {
-      log->printf(hovError, "Derivative checker error: in user Jacobian function.\n");
-      return;
-    }
-    // perturbed constraint body
-    hiopVector* cons_pert = cons_ref->alloc_clone();
-
-    // ith column in the "exact" user Jacobian
-    hiopVector* Jac_ex_col = cons_ref->alloc_clone();
-    //perturbed equality/c constraint body
-    hiopVector* cons_c_pert = cons_c_ref.alloc_clone();
-    //perturbed inequality/d constraint body
-    hiopVector* cons_d_pert = cons_d_ref.alloc_clone();
-    // vector of all zero except ith position which is one
-    hiopVector* ei = x_ref.alloc_clone();
-
-    //main loop
-    for(index_type idx=0; idx<nlp_transformations_.n_pre(); ++idx) {
-
-      const double val_ref = x_ref.get_elem(idx);
-      x_pert->copyFrom(x_ref);
-      x_pert->set_elem(idx, val_ref+pert*max(abs(val_ref), 1.0));
+      //
+      // Jacobian check
+      //
+      log->printf(hovSummary, "Starting derivative checker for Jacobian ...\n");
+      num_errs = 0;
+      disable_nlp_transformations_ = true;
       
-      //eval at the perturbed point
-      this->eval_c_d(*x_pert, true, *cons_c_pert, *cons_d_pert);
-      cons_pert->copy_from_two_vec_w_pattern(*cons_c_pert, *cons_eq_mapping_, *cons_d_pert, *cons_ineq_mapping_);
-      // compute finite difference Jacobian (ith column)
-      hiopVector& Jac_fd_col = *cons_pert;
-      Jac_fd_col.axpy(-1.0, *cons_ref);
-      Jac_fd_col.scale(1/pert);
-
-
-      //we multiply Jacobian with ei=(0,...,1,...0) to get the ith column
-      ei->setToZero();
-      ei->set_elem(idx, 1.);
-      //reuse
-      hiopVector& Jac_ex_d_col = *cons_d_pert;
-      hiopVector& Jac_ex_c_col = *cons_c_pert;
-      Jac_c_ref->timesVec(0, Jac_ex_c_col, 1.0, *ei);
-      Jac_d_ref->timesVec(0, Jac_ex_d_col, 1.0, *ei);
-      Jac_ex_col->copy_from_two_vec_w_pattern(Jac_ex_c_col, *cons_eq_mapping_, Jac_ex_d_col, *cons_ineq_mapping_);
-
-      // compute error
-      for(index_type row=0; row<m(); ++row) {
-        const double Jac_fd_ij = Jac_fd_col.get_elem(row);
-        const double Jac_ex_ij = Jac_ex_col->get_elem(row);
-        const double scale = max(Jac_ex_ij, max(abs(Jac_fd_ij), derivative_check_tolerance));
-        double rel_error = abs(Jac_fd_ij - Jac_ex_ij) / scale;
-
-        const bool b_err = rel_error > derivative_check_tolerance;
-        char err_marker = ' ';
-        if(b_err) {
-          err_marker = '!';
-          num_errs++;
+      hiopVector* cons_ref = this->alloc_dual_vec();
+      if(temp_eq_ == nullptr) {
+        temp_eq_ = this->alloc_dual_eq_vec();
+      }
+      if(temp_ineq_ == nullptr) {
+        temp_ineq_ = this->alloc_dual_ineq_vec();
+      }
+      hiopVector& cons_c_ref = *temp_eq_;
+      hiopVector& cons_d_ref = *temp_ineq_;
+      
+      if(!this->eval_c_d(x_ref, true, cons_c_ref, cons_d_ref)) {
+        log->printf(hovError, "Derivative checker error: in user constraint function.\n");
+        user_eval_err = true;
+      }
+      cons_ref->copy_from_two_vec_w_pattern(cons_c_ref,
+                                            *cons_eq_mapping_,
+                                            cons_d_ref,
+                                            *cons_ineq_mapping_);
+      // perturbed constraint body
+      hiopVector* cons_pert = cons_ref->alloc_clone();
+      
+      // ith column in the "exact" user Jacobian
+      hiopVector* Jac_ex_col = cons_ref->alloc_clone();
+      //perturbed equality/c constraint body
+      hiopVector* cons_c_pert = cons_c_ref.alloc_clone();
+      //perturbed inequality/d constraint body
+      hiopVector* cons_d_pert = cons_d_ref.alloc_clone();
+      // vector of all zero except ith position which is one
+      hiopVector* ei = x_ref.alloc_clone();
+      
+      //main loop
+      for(index_type idx=0; idx<nlp_transformations_.n_pre() &&!user_eval_err; ++idx) {
+        
+        const double val_ref = x_ref.get_elem(idx);
+        x_pert->copyFrom(x_ref);
+        x_pert->set_elem(idx, val_ref+pert*max(abs(val_ref), 1.0));
+        
+        //eval at the perturbed point
+        if(!this->eval_c_d(*x_pert, true, *cons_c_pert, *cons_d_pert)) {
+          log->printf(hovError, "Derivative checker error: in user constraint function.\n");
+          user_eval_err = true;
         }
-        if(b_err || print_all) {
-          stringstream ss;
-          ss << err_marker << " Jac[" << setw(5) << row << "," << setw(5) << idx << "] "
-             << "user " << fixed << setprecision(14) << setw(21) << Jac_ex_ij << "  "
-             << "fd " << fixed << setprecision(14) << setw(21) << Jac_fd_ij
-             << " relerr [" << scientific << setprecision(3) << setw(9) << rel_error << "]";
-          log->printf(hovSummary, "%s\n", ss.str().c_str());
-          fflush(stdout);
-        }
-      } // end for j=1,..,m
-    }
-    log->printf(hovSummary, "Derivative checker for Jacobian finished: %d errors detected.\n", num_errs);
-    disable_nlp_transformations_ = false;
-    delete Jac_ex_col;
-    delete ei;
-    delete Jac_d_ref;
-    delete Jac_c_ref;
-    delete cons_d_pert;
-    delete cons_c_pert;
-    delete cons_pert;
-    delete cons_ref;
+        cons_pert->copy_from_two_vec_w_pattern(*cons_c_pert, *cons_eq_mapping_, *cons_d_pert, *cons_ineq_mapping_);
+        
+        // compute finite difference Jacobian (ith column)
+        hiopVector& Jac_fd_col = *cons_pert;
+        Jac_fd_col.axpy(-1.0, *cons_ref);
+        Jac_fd_col.scale(1/pert);
+
+        //we multiply Jacobian with ei=(0,...,1,...0) to get the ith column
+        ei->setToZero();
+        ei->set_elem(idx, 1.);
+        //reuse
+        hiopVector& Jac_ex_d_col = *cons_d_pert;
+        hiopVector& Jac_ex_c_col = *cons_c_pert;
+        Jac_c_ref->timesVec(0, Jac_ex_c_col, 1.0, *ei);
+        Jac_d_ref->timesVec(0, Jac_ex_d_col, 1.0, *ei);
+        Jac_ex_col->copy_from_two_vec_w_pattern(Jac_ex_c_col, *cons_eq_mapping_, Jac_ex_d_col, *cons_ineq_mapping_);
+        
+        // compute error
+        for(index_type row=0; row<m() && !user_eval_err; ++row) {
+          const double Jac_fd_ij = Jac_fd_col.get_elem(row);
+          const double Jac_ex_ij = Jac_ex_col->get_elem(row);
+          const double scale = max(Jac_ex_ij, max(abs(Jac_fd_ij), derivative_check_tolerance));
+          double rel_error = abs(Jac_fd_ij - Jac_ex_ij) / scale;
+          
+          const bool b_err = rel_error > derivative_check_tolerance;
+          char err_marker = ' ';
+          if(b_err) {
+            err_marker = '!';
+            num_errs++;
+          }
+          if(b_err || print_all) {
+            stringstream ss;
+            ss << err_marker << " Jac[" << setw(5) << row << "," << setw(5) << idx << "] "
+               << "user " << fixed << setprecision(14) << setw(21) << Jac_ex_ij << "  "
+               << "fd " << fixed << setprecision(14) << setw(21) << Jac_fd_ij
+               << " relerr [" << scientific << setprecision(3) << setw(9) << rel_error << "]";
+            log->printf(hovSummary, "%s\n", ss.str().c_str());
+            fflush(stdout);
+          }
+        } // end for j=1,..,m
+      }
+      if(user_eval_err) {
+        log->printf(hovSummary, "Derivative checker halted because of error(s) in user provided functions.");        
+      } else {
+        log->printf(hovSummary, "Derivative checker for Jacobian finished: %d errors detected.\n", num_errs);
+      }
+      delete Jac_ex_col;
+      delete ei;
+      delete cons_d_pert;
+      delete cons_c_pert;
+      delete cons_pert;
+      delete cons_ref;
+    } // end of Jacobian check
+  } //end of first-order check
+
+  //
+  // Second-order checks
+  //  
+  if(!user_eval_err && options->GetString("derivative_check") == "second-order") {
+    run_derivative_checker_order2(*x0_user, *grad_exact, *Jac_c_ref, *Jac_d_ref);
   }
-
+  
+  disable_nlp_transformations_ = false;
+  //clean up
+  delete Jac_d_ref;
+  delete Jac_c_ref;
+  delete grad_exact;  
   delete x_pert;
   delete it_hiop;
   delete lambdas;
@@ -2481,6 +2507,73 @@ bool hiopNlpSparse::finalizeInitialization()
   assert(nx == n_vars_);
   return hiopNlpFormulation::finalizeInitialization();
 }
+
+size_type hiopNlpSparse::run_derivative_checker_order2(hiopVector& x_ref,
+                                                       hiopVector& grad_ref,
+                                                       hiopMatrix& Jacc_ref,
+                                                       hiopMatrix& Jacd_ref)
+{
+  size_type num_errs=0;
+  if(options->GetString("derivative_check") != "second-order") {
+    return 0;
+  }
+  log->printf(hovSummary, "Starting derivative checker for Hessian ...\n");
+
+  // perturbation of x working vector
+  hiopVector* x_pert = x_ref.alloc_clone();
+  // gradient at perturbed x
+  hiopVector* grad_pert = grad_ref.alloc_clone();
+  //user "exact" Hessian
+  auto* Hess_exact = alloc_Hess_Lagr();
+
+  bool user_eval_err = false; 
+  
+  //
+  //objective Hessian first
+  //
+  //evaluate 
+  double obj_factor = 1.5;
+  hiopVector* lambda_eq = this->alloc_dual_eq_vec();
+  hiopVector* lambda_ineq = this->alloc_dual_ineq_vec();
+  lambda_eq->setToZero();
+  lambda_ineq->setToZero();
+
+  if(!eval_Hess_Lagr(x_ref, true, obj_factor, *lambda_eq, *lambda_ineq, true, *Hess_exact)) {
+    log->printf(hovError, "Derivative checker (2nd order) error in user Hessian function.\n");
+    user_eval_err = true;
+  }
+
+  for(index_type i=0; i<n() && !user_eval_err; i++) {
+    
+  }
+
+  if(user_eval_err) {
+    log->printf(hovSummary, "Derivative checker for Objective Hessian finished: %d errors detected.\n", num_errs);
+  } else {
+    
+  }
+  delete grad_pert;
+  
+  //
+  // constraints Hessian
+  //
+  // Jacobians at perturbed x
+  hiopMatrix* Jacc_pert = Jacc_ref.alloc_clone();
+  hiopMatrix* Jacd_pert = Jacd_ref.alloc_clone();
+
+
+  //cleanup
+  delete Jacd_pert;
+  delete Jacc_pert;
+  delete lambda_eq;
+  delete lambda_ineq;
+  delete Hess_exact;
+  delete x_pert;
+
+  return num_errs;
+}
+
+
 
 /////////////////////////////////////////////////////////////
 //   hiopNlpSparseIneq

--- a/src/Optimization/hiopNlpFormulation.cpp
+++ b/src/Optimization/hiopNlpFormulation.cpp
@@ -64,6 +64,7 @@
 
 #include <stdlib.h> /* exit, EXIT_FAILURE */
 #include <cassert>
+#include <sstream>
 
 using namespace std;
 namespace hiop
@@ -809,7 +810,7 @@ void hiopNlpFormulation::run_derivative_checker()
   //
   if(options->GetString("derivative_check") == "first-order") {
     
-    std::cout << "Starting derivative checker for gradient ..." << std::endl;
+    log->printf(hovWarning, "Starting derivative checker for gradient ...\n");
     size_t num_errs = 0;
     double f_ref;
     bret = interface_base.eval_f(nlp_transformations_.n_pre(), x_ref.local_data_const(), true, f_ref);
@@ -831,17 +832,18 @@ void hiopNlpFormulation::run_derivative_checker()
     // grad_fd = (f(x_pert) - f(x_ref)) / pert    
     for(index_type idx=0; idx<nlp_transformations_.n_pre(); ++idx) {
       const double val_ref = x_ref.get_elem(idx);
-      cout << "val =" << val_ref << std::endl;
+
       x_pert->copyFrom(x_ref);
-      x_pert->set_elem(idx, val_ref+pert*::std::max(::std::abs(val_ref), 1.0));
+      x_pert->set_elem(idx, val_ref+pert*max(abs(val_ref), 1.0));
+      
       //evaluate at the perturbed point
       double f_pert;
       bret = interface_base.eval_f(nlp_transformations_.n_pre(), x_pert->local_data_const(), true, f_pert);
 
       const double grad_fd = (f_pert-f_ref)/pert;
-      const double grad_ex = grad_exact->local_data()[idx];
-      const double scale = ::std::max(grad_ex, ::std::max(::std::abs(grad_fd), derivative_check_tolerance));
-      double rel_error = ::std::abs(grad_fd - grad_ex) / scale;
+      const double grad_ex = grad_exact->get_elem(idx);
+      const double scale = max(grad_ex, max(abs(grad_fd), derivative_check_tolerance));
+      double rel_error = abs(grad_fd - grad_ex) / scale;
 
       const bool b_err = rel_error > derivative_check_tolerance;
       char err_marker = ' ';
@@ -850,17 +852,24 @@ void hiopNlpFormulation::run_derivative_checker()
         num_errs++;
       }
       if(b_err || print_all) {
-        std::cout << err_marker << " grad[" << std::setw(5) << idx << "] "
-                  << "user " << std::fixed << std::setprecision(14) << std::setw(21) << grad_ex << "  "
-                  << "fd " << std::fixed << std::setprecision(14) << std::setw(21) << grad_fd
-                  << " relerr [" << std::scientific << std::setprecision(3) << std::setw(9) << rel_error << "]"
-                  << std::endl;
+        stringstream ss;
+        ss << err_marker << " grad[" << setw(5) << idx << "] "
+           << "user " << fixed << setprecision(14) << setw(21) << grad_ex << "  "
+           << "fd " << fixed << setprecision(14) << setw(21) << grad_fd
+           << " relerr [" << scientific << setprecision(3) << setw(9) << rel_error << "]";
+        log->printf(hovWarning, "%s\n", ss.str().c_str());
+        fflush(stdout);
       }
       
     }
-
-    std::cout << "Derivative checker for gradient finished: " << num_errs << " errors detected." << std::endl;
+    log->printf(hovWarning, "Derivative checker for gradient finished: %d errors detected.\n", num_errs);
     delete grad_exact;
+
+    // Jacobian
+    log->printf(hovWarning, "Starting derivative checker for Jacobian ...\n");
+    num_errs = 0;
+
+    log->printf(hovWarning, "Derivative checker for Jacobian finished: %d errors detected.\n", num_errs);
   }
 
   delete x_pert;

--- a/src/Optimization/hiopNlpFormulation.cpp
+++ b/src/Optimization/hiopNlpFormulation.cpp
@@ -78,6 +78,7 @@ hiopNlpFormulation::hiopNlpFormulation(hiopInterfaceBase& interface_, const char
       prob_type_(hiopInterfaceBase::hiopNonlinear),
       nlp_evaluated_(false),
       nlp_transformations_(this),
+      disable_nlp_transformations_(false),
       interface_base(interface_)
 {
   strFixedVars_ = "";    // uninitialized
@@ -869,6 +870,10 @@ void hiopNlpFormulation::run_derivative_checker()
     log->printf(hovWarning, "Starting derivative checker for Jacobian ...\n");
     num_errs = 0;
 
+    disable_nlp_transformations_ = true;
+    //hiopVector* a;
+
+    disable_nlp_transformations_ = false;
     log->printf(hovWarning, "Derivative checker for Jacobian finished: %d errors detected.\n", num_errs);
   }
 
@@ -983,7 +988,10 @@ bool hiopNlpFormulation::get_warmstart_point(hiopVector& x0_for_hiop,
 
 bool hiopNlpFormulation::eval_c(hiopVector& x, bool new_x, hiopVector& c)
 {
-  hiopVector* xx = nlp_transformations_.apply_inv_to_x(x, new_x);
+  hiopVector* xx = &x;
+  if(!disable_nlp_transformations_) {
+    xx = nlp_transformations_.apply_inv_to_x(x, new_x);
+  }
   hiopVector* cc = &c;
   // nlp_transformations_.apply_inv_to_cons_eq(c, n_cons_eq_);  // NOT required
 
@@ -998,13 +1006,18 @@ bool hiopNlpFormulation::eval_c(hiopVector& x, bool new_x, hiopVector& c)
   runStats.tmEvalCons.stop();
   runStats.nEvalCons_eq++;
 
-  // scale the constraint
-  c = *(nlp_transformations_.apply_to_cons_eq(c, n_cons_eq_));
+  if(!disable_nlp_transformations_) {
+    // scale the constraint
+    c = *(nlp_transformations_.apply_to_cons_eq(c, n_cons_eq_));
+  }
   return bret;
 }
 bool hiopNlpFormulation::eval_d(hiopVector& x, bool new_x, hiopVector& d)
 {
-  hiopVector* xx = nlp_transformations_.apply_inv_to_x(x, new_x);
+  hiopVector* xx = &x;
+  if(!disable_nlp_transformations_) {
+    xx = nlp_transformations_.apply_inv_to_x(x, new_x);
+  }
   hiopVector* dd = &d;
   // nlp_transformations_.apply_inv_to_cons_ineq(d, n_cons_ineq_);  // NOT required for now
 
@@ -1019,8 +1032,10 @@ bool hiopNlpFormulation::eval_d(hiopVector& x, bool new_x, hiopVector& d)
   runStats.tmEvalCons.stop();
   runStats.nEvalCons_ineq++;
 
-  // scale the constraint
-  d = *(nlp_transformations_.apply_to_cons_ineq(d, n_cons_ineq_));
+  if(!disable_nlp_transformations_) {
+    // scale the constraint
+    d = *(nlp_transformations_.apply_to_cons_ineq(d, n_cons_ineq_));
+  }
   return bret;
 }
 
@@ -1060,10 +1075,14 @@ bool hiopNlpFormulation::eval_c_d(hiopVector& x, bool new_x, hiopVector& c, hiop
     assert(1 == cons_eval_type_);
     assert(cons_body_ != nullptr);
 
-    hiopVector* xx = nlp_transformations_.apply_inv_to_x(x, new_x);
+    hiopVector* xx = &x;
+    if(!disable_nlp_transformations_) {
+      xx = nlp_transformations_.apply_inv_to_x(x, new_x);
+    }
     // FIXME do NOT support removing fixed var for now
     // double* body = cons_body_;//nlp_transformations_.apply_inv_to_cons(d, n_cons_ineq_); //not needed for now
-
+    //also observe disable_nlp_transformations_
+    
     runStats.tmEvalCons.start();
     bool bret = interface_base.eval_cons(nlp_transformations_.n_pre(),
                                          n_cons_,
@@ -1073,12 +1092,13 @@ bool hiopNlpFormulation::eval_c_d(hiopVector& x, bool new_x, hiopVector& c, hiop
     // copy back to c and d
     cons_body_->copy_to_two_vec_w_pattern(c, *cons_eq_mapping_, d, *cons_ineq_mapping_);
 
-    // scale c
-    c = *(nlp_transformations_.apply_to_cons_eq(c, n_cons_eq_));
-
-    // scale d
-    d = *(nlp_transformations_.apply_to_cons_ineq(d, n_cons_ineq_));
-
+    if(!disable_nlp_transformations_) {
+      // scale c
+      c = *(nlp_transformations_.apply_to_cons_eq(c, n_cons_eq_));
+      
+      // scale d
+      d = *(nlp_transformations_.apply_to_cons_ineq(d, n_cons_ineq_));
+    }
     runStats.tmEvalCons.stop();
     runStats.nEvalCons_eq++;
     runStats.nEvalCons_ineq++;
@@ -1541,8 +1561,12 @@ bool hiopNlpDenseConstraints::eval_Jac_c(hiopVector& x, bool new_x, double* Jac_
     return true;
   }
 
-  hiopVector* x_user  = nlp_transformations_.apply_inv_to_x(x, new_x);
-  double* Jac_c_user = nlp_transformations_.apply_inv_to_jacob_eq(Jac_c, n_cons_eq_);
+  hiopVector* x_user  = &x;
+  double* Jac_c_user = Jac_c;
+  if(!disable_nlp_transformations_) {
+    x_user = nlp_transformations_.apply_inv_to_x(x, new_x);
+    Jac_c_user = nlp_transformations_.apply_inv_to_jacob_eq(Jac_c, n_cons_eq_);
+  }
 
   runStats.tmEvalJac_con.start();
   bool bret = interface.eval_Jac_cons(nlp_transformations_.n_pre(), n_cons_,
@@ -1550,7 +1574,10 @@ bool hiopNlpDenseConstraints::eval_Jac_c(hiopVector& x, bool new_x, double* Jac_
                                       x_user->local_data_const(), new_x, Jac_c_user);
   runStats.tmEvalJac_con.stop(); runStats.nEvalJac_con_eq++;
 
-  Jac_c = nlp_transformations_.apply_to_jacob_eq(Jac_c_user, n_cons_eq_);
+  Jac_c = Jac_c_user;
+  if(!disable_nlp_transformations_) {
+    Jac_c = nlp_transformations_.apply_to_jacob_eq(Jac_c_user, n_cons_eq_);
+  }
 #endif  // 0
 
   assert(0 && "not needed");
@@ -1564,8 +1591,12 @@ bool hiopNlpDenseConstraints::eval_Jac_d(hiopVector& x, bool new_x, double* Jac_
     return true;
   }
 
-  hiopVector* x_user  = nlp_transformations_.apply_inv_to_x(x, new_x);
-  double* Jac_d_user = nlp_transformations_.apply_inv_to_jacob_ineq(Jac_d, n_cons_ineq_);
+  hiopVector* x_user  = &x;
+  double* Jac_d_user = Jac_d;
+  if(!disable_nlp_transformations_) {
+    x_user = nlp_transformations_.apply_inv_to_x(x, new_x);
+    Jac_d_user = nlp_transformations_.apply_inv_to_jacob_ineq(Jac_d, n_cons_ineq_);
+  }
 
   runStats.tmEvalJac_con.start();
   bool bret = interface.eval_Jac_cons(nlp_transformations_.n_pre(), n_cons_,
@@ -1573,7 +1604,10 @@ bool hiopNlpDenseConstraints::eval_Jac_d(hiopVector& x, bool new_x, double* Jac_
                                       x_user->local_data_const(), new_x,Jac_d_user);
   runStats.tmEvalJac_con.stop(); runStats.nEvalJac_con_ineq++;
 
-  Jac_d = nlp_transformations_.apply_to_jacob_ineq(Jac_d_user, n_cons_ineq_);
+  Jac_d = Jac_d_user;
+  if(!disable_nlp_transformations_) {    
+    Jac_d = nlp_transformations_.apply_to_jacob_ineq(Jac_d_user, n_cons_ineq_);
+  }
 #endif  // 0
 
   assert(0 && "not needed");
@@ -1588,12 +1622,17 @@ bool hiopNlpDenseConstraints::eval_Jac_c_d_interface_impl(hiopVector& x, bool ne
     return false;
   }
 
-  hiopVector* x_user = nlp_transformations_.apply_inv_to_x(x, new_x);
+  hiopVector* x_user = &x;
   double* Jac_consde = cons_Jac_de->local_data();
-  hiopMatrix* Jac_user = nlp_transformations_.apply_inv_to_jacob_cons(*cons_Jac_, n_cons_);
+  hiopMatrix* Jac_user = cons_Jac_;
+
+  if(!disable_nlp_transformations_) {
+    x_user = nlp_transformations_.apply_inv_to_x(x, new_x);
+    Jac_user = nlp_transformations_.apply_inv_to_jacob_cons(*cons_Jac_, n_cons_);
+  }
 
   hiopMatrixDense* cons_Jac_user_de = dynamic_cast<hiopMatrixDense*>(Jac_user);
-  if(cons_Jac_user_de == NULL) {
+  if(cons_Jac_user_de == nullptr) {
     log->printf(hovError, "[internal error] hiopNlpDenseConstraints NLP received an unexpected matrix\n");
     return false;
   }
@@ -1605,7 +1644,10 @@ bool hiopNlpDenseConstraints::eval_Jac_c_d_interface_impl(hiopVector& x, bool ne
                                       new_x,
                                       cons_Jac_user_de->local_data());
 
-  cons_Jac_ = nlp_transformations_.apply_to_jacob_cons(*Jac_user, n_cons_);
+  cons_Jac_ = Jac_user;
+  if(!disable_nlp_transformations_) {
+    cons_Jac_ = nlp_transformations_.apply_to_jacob_cons(*Jac_user, n_cons_);
+  }
 
   hiopMatrixDense* Jac_cde = dynamic_cast<hiopMatrixDense*>(&Jac_c);
   hiopMatrixDense* Jac_dde = dynamic_cast<hiopMatrixDense*>(&Jac_d);
@@ -1620,9 +1662,11 @@ bool hiopNlpDenseConstraints::eval_Jac_c_d_interface_impl(hiopVector& x, bool ne
   Jac_cde->copyRowsFrom(*cons_Jac_, cons_eq_mapping_->local_data_const(), n_cons_eq_);
   Jac_dde->copyRowsFrom(*cons_Jac_, cons_ineq_mapping_->local_data_const(), n_cons_ineq_);
 
-  // scale Jacobian matrices
-  Jac_c = *(nlp_transformations_.apply_inv_to_jacob_eq(Jac_c, n_cons_eq_));
-  Jac_d = *(nlp_transformations_.apply_inv_to_jacob_ineq(Jac_d, n_cons_ineq_));
+  if(!disable_nlp_transformations_) {
+    // scale Jacobian matrices
+    Jac_c = *(nlp_transformations_.apply_inv_to_jacob_eq(Jac_c, n_cons_eq_));
+    Jac_d = *(nlp_transformations_.apply_inv_to_jacob_ineq(Jac_d, n_cons_ineq_));
+  }
 
   runStats.tmEvalJac_con.stop();
   runStats.nEvalJac_con_eq++;
@@ -1642,8 +1686,13 @@ bool hiopNlpDenseConstraints::eval_Jac_c(hiopVector& x, bool new_x, hiopMatrix& 
     log->printf(hovError, "[internal error] hiopNlpDenseConstraints NLP works only with dense matrices\n");
     return false;
   } else {
-    hiopVector* x_user = nlp_transformations_.apply_inv_to_x(x, new_x);
-    hiopMatrix* Jac_c_user = nlp_transformations_.apply_inv_to_jacob_eq(Jac_c, n_cons_eq_);
+    hiopVector* x_user = &x;
+    hiopMatrix* Jac_c_user = &Jac_c;
+
+    if(!disable_nlp_transformations_) {
+      nlp_transformations_.apply_inv_to_x(x, new_x);
+      Jac_c_user = nlp_transformations_.apply_inv_to_jacob_eq(Jac_c, n_cons_eq_);
+    }
     if(Jac_c_user == nullptr) {
       log->printf(hovError, "[internal error] hiopFixedVarsRemover works only with dense matrices\n");
       return false;
@@ -1662,10 +1711,13 @@ bool hiopNlpDenseConstraints::eval_Jac_c(hiopVector& x, bool new_x, hiopMatrix& 
     runStats.tmEvalJac_con.stop();
     runStats.nEvalJac_con_eq++;
 
-    auto* Jac_c_p = nlp_transformations_.apply_to_jacob_eq(*Jac_c_user, n_cons_eq_);
-    if(Jac_c_p == nullptr) {
-      log->printf(hovError, "[internal error] hiopFixedVarsRemover works only with dense matrices\n");
-      return false;
+    auto* Jac_c_p = Jac_c_user;
+    if(!disable_nlp_transformations_) {
+      Jac_c_p = nlp_transformations_.apply_to_jacob_eq(*Jac_c_user, n_cons_eq_);
+      if(Jac_c_p == nullptr) {
+        log->printf(hovError, "[internal error] hiopFixedVarsRemover works only with dense matrices\n");
+        return false;
+      }
     }
     Jac_c = *Jac_c_p;
     return bret;
@@ -1683,8 +1735,14 @@ bool hiopNlpDenseConstraints::eval_Jac_d(hiopVector& x, bool new_x, hiopMatrix& 
     log->printf(hovError, "[internal error] hiopNlpDenseConstraints NLP works only with dense matrices\n");
     return false;
   } else {
-    hiopVector* x_user = nlp_transformations_.apply_inv_to_x(x, new_x);
-    hiopMatrix* Jac_d_user = nlp_transformations_.apply_inv_to_jacob_ineq(Jac_d, n_cons_ineq_);
+    hiopVector* x_user = &x;
+    hiopMatrix* Jac_d_user = &Jac_d;
+
+    if(!disable_nlp_transformations_) {
+      x_user = nlp_transformations_.apply_inv_to_x(x, new_x);
+      Jac_d_user = nlp_transformations_.apply_inv_to_jacob_ineq(Jac_d, n_cons_ineq_);
+    }
+    
     if(Jac_d_user == nullptr) {
       log->printf(hovError, "[internal error] hiopFixedVarsRemover works only with dense matrices\n");
       return false;
@@ -1703,10 +1761,15 @@ bool hiopNlpDenseConstraints::eval_Jac_d(hiopVector& x, bool new_x, hiopMatrix& 
     runStats.tmEvalJac_con.stop();
     runStats.nEvalJac_con_ineq++;
 
-    auto* Jac_d_p = nlp_transformations_.apply_to_jacob_ineq(*Jac_d_user, n_cons_ineq_);
-    if(Jac_d_p == nullptr) {
-      log->printf(hovError, "[internal error] hiopFixedVarsRemover works only with dense matrices\n");
-      return false;
+    auto* Jac_d_p = Jac_d_user;
+
+    if(!disable_nlp_transformations_) {
+      Jac_d_p = nlp_transformations_.apply_to_jacob_ineq(*Jac_d_user, n_cons_ineq_);
+    
+      if(Jac_d_p == nullptr) {
+        log->printf(hovError, "[internal error] hiopFixedVarsRemover works only with dense matrices\n");
+        return false;
+      }
     }
     Jac_d = *Jac_d_p;
     return bret;
@@ -1777,7 +1840,10 @@ bool hiopNlpMDS::eval_Jac_c(hiopVector& x, bool new_x, hiopMatrix& Jac_c)
   hiopMatrixMDS* pJac_c = dynamic_cast<hiopMatrixMDS*>(&Jac_c);
   assert(pJac_c);
   if(pJac_c) {
-    hiopVector* x_user = nlp_transformations_.apply_inv_to_x(x, new_x);
+    hiopVector* x_user = &x;
+    if(!disable_nlp_transformations_) {
+      x_user = nlp_transformations_.apply_inv_to_x(x, new_x);
+    }
 
     // NOT needed for now
     //    hiopMatrix* Jac_c_user = nlp_transformations_.apply_inv_to_jacob_eq(Jac_c, n_cons_eq);
@@ -1799,9 +1865,10 @@ bool hiopNlpMDS::eval_Jac_c(hiopVector& x, bool new_x, hiopMatrix& Jac_c)
                                         pJac_c->sp_jcol(),
                                         pJac_c->sp_M(),
                                         pJac_c->de_local_data());
-
-    // scale the matrix
-    Jac_c = *(nlp_transformations_.apply_to_jacob_eq(Jac_c, n_cons_eq_));
+    if(!disable_nlp_transformations_) {
+      // scale the matrix
+      Jac_c = *(nlp_transformations_.apply_to_jacob_eq(Jac_c, n_cons_eq_));
+    }
 
     runStats.tmEvalJac_con.stop();
     runStats.nEvalJac_con_eq++;
@@ -1820,7 +1887,10 @@ bool hiopNlpMDS::eval_Jac_d(hiopVector& x, bool new_x, hiopMatrix& Jac_d)
   hiopMatrixMDS* pJac_d = dynamic_cast<hiopMatrixMDS*>(&Jac_d);
   assert(pJac_d);
   if(pJac_d) {
-    hiopVector* x_user = nlp_transformations_.apply_inv_to_x(x, new_x);
+    hiopVector* x_user = &x;
+    if(!disable_nlp_transformations_) {
+      x_user = nlp_transformations_.apply_inv_to_x(x, new_x);
+    }
 
     // NOT needed for now
     //    hiopMatrix* Jac_d_user = nlp_transformations_.apply_inv_to_jacob_ineq(Jac_d, n_cons_ineq_);
@@ -1842,9 +1912,10 @@ bool hiopNlpMDS::eval_Jac_d(hiopVector& x, bool new_x, hiopMatrix& Jac_d)
                                         pJac_d->sp_jcol(),
                                         pJac_d->sp_M(),
                                         pJac_d->de_local_data());
-    // scale the matrix
-    Jac_d = *(nlp_transformations_.apply_to_jacob_ineq(Jac_d, n_cons_ineq_));
-
+    if(!disable_nlp_transformations_) {
+      // scale the matrix
+      Jac_d = *(nlp_transformations_.apply_to_jacob_ineq(Jac_d, n_cons_ineq_));
+    }
     runStats.tmEvalJac_con.stop();
     runStats.nEvalJac_con_ineq++;
     return bret;
@@ -1866,7 +1937,10 @@ bool hiopNlpMDS::eval_Jac_c_d_interface_impl(hiopVector& x, bool new_x, hiopMatr
     assert(cons_Jac->n_sp() == pJac_d->n_sp());
     assert(cons_Jac->sp_nnz() == pJac_c->sp_nnz() + pJac_d->sp_nnz());
 
-    hiopVector* x_user = nlp_transformations_.apply_inv_to_x(x, new_x);
+    hiopVector* x_user = &x;
+    if(!disable_nlp_transformations_) {
+      x_user = nlp_transformations_.apply_inv_to_x(x, new_x);
+    }
     //! todo -> need hiopNlpTransformation::apply_to_jacob_ineq to work with MDS Jacobian
     // double** Jac_d_user = nlp_transformations_.apply_inv_to_jacob_ineq(Jac_d, n_cons_ineq_);
 
@@ -1888,9 +1962,11 @@ bool hiopNlpMDS::eval_Jac_c_d_interface_impl(hiopVector& x, bool new_x, hiopMatr
     pJac_c->copyRowsFrom(*cons_Jac, cons_eq_mapping_->local_data_const(), n_cons_eq_);
     pJac_d->copyRowsFrom(*cons_Jac, cons_ineq_mapping_->local_data_const(), n_cons_ineq_);
 
-    // scale the matrices
-    Jac_c = *(nlp_transformations_.apply_to_jacob_eq(Jac_c, n_cons_eq_));
-    Jac_d = *(nlp_transformations_.apply_to_jacob_ineq(Jac_d, n_cons_ineq_));
+    if(!disable_nlp_transformations_) {
+      // scale the matrices
+      Jac_c = *(nlp_transformations_.apply_to_jacob_eq(Jac_c, n_cons_eq_));
+      Jac_d = *(nlp_transformations_.apply_to_jacob_ineq(Jac_d, n_cons_ineq_));
+    }
 
     runStats.tmEvalJac_con.stop();
     runStats.nEvalJac_con_eq++;
@@ -1932,7 +2008,9 @@ bool hiopNlpMDS::eval_Hess_Lagr(const hiopVector& x,
 
     // scale lambda before passing it to user interface to compute Hess
     int n_cons_eq_ineq = n_cons_eq_ + n_cons_ineq_;
-    buf_lambda_ = nlp_transformations_.apply_to_cons(*buf_lambda_, n_cons_eq_ineq);
+    if(!disable_nlp_transformations_) {
+      buf_lambda_ = nlp_transformations_.apply_to_cons(*buf_lambda_, n_cons_eq_ineq);
+    }
 
     double obj_factor_with_scale = obj_factor * get_obj_scale();
 
@@ -1998,7 +2076,10 @@ bool hiopNlpSparse::eval_Jac_c(hiopVector& x, bool new_x, hiopMatrix& Jac_c)
   hiopMatrixSparse* pJac_c = dynamic_cast<hiopMatrixSparse*>(&Jac_c);
   assert(pJac_c);
   if(pJac_c) {
-    hiopVector* x_user = nlp_transformations_.apply_inv_to_x(x, new_x);
+    hiopVector* x_user = &x;
+    if(!disable_nlp_transformations_) {
+      x_user = nlp_transformations_.apply_inv_to_x(x, new_x);
+    }
 
     runStats.tmEvalJac_con.start();
 
@@ -2013,9 +2094,10 @@ bool hiopNlpSparse::eval_Jac_c(hiopVector& x, bool new_x, hiopMatrix& Jac_c)
                                         pJac_c->i_row(),
                                         pJac_c->j_col(),
                                         pJac_c->M());
-
-    // scale the matrix
-    Jac_c = *(nlp_transformations_.apply_to_jacob_eq(Jac_c, n_cons_eq_));
+    if(!disable_nlp_transformations_) {
+      // scale the matrix
+      Jac_c = *(nlp_transformations_.apply_to_jacob_eq(Jac_c, n_cons_eq_));
+    }
 
     runStats.tmEvalJac_con.stop();
     runStats.nEvalJac_con_eq++;
@@ -2034,8 +2116,10 @@ bool hiopNlpSparse::eval_Jac_d(hiopVector& x, bool new_x, hiopMatrix& Jac_d)
   hiopMatrixSparse* pJac_d = dynamic_cast<hiopMatrixSparse*>(&Jac_d);
   assert(pJac_d);
   if(pJac_d) {
-    hiopVector* x_user = nlp_transformations_.apply_inv_to_x(x, new_x);
-
+    hiopVector* x_user = &x;
+    if(!disable_nlp_transformations_) {
+      x_user = nlp_transformations_.apply_inv_to_x(x, new_x);
+    }
     runStats.tmEvalJac_con.start();
 
     int nnz = pJac_d->numberOfNonzeros();
@@ -2050,9 +2134,10 @@ bool hiopNlpSparse::eval_Jac_d(hiopVector& x, bool new_x, hiopMatrix& Jac_d)
                                         pJac_d->i_row(),
                                         pJac_d->j_col(),
                                         pJac_d->M());
-
-    // scale the matrix
-    Jac_d = *(nlp_transformations_.apply_to_jacob_ineq(Jac_d, n_cons_ineq_));
+    if(!disable_nlp_transformations_) {
+      // scale the matrix
+      Jac_d = *(nlp_transformations_.apply_to_jacob_ineq(Jac_d, n_cons_ineq_));
+    }
 
     runStats.tmEvalJac_con.stop();
     runStats.nEvalJac_con_ineq++;
@@ -2069,11 +2154,16 @@ bool hiopNlpSparse::eval_Jac_c_d_interface_impl(hiopVector& x, bool new_x, hiopM
   hiopMatrixSparse* cons_Jac = dynamic_cast<hiopMatrixSparse*>(cons_Jac_);
   if(pJac_c && pJac_d) {
     assert(cons_Jac);
-    if(NULL == cons_Jac) return false;
+    if(nullptr == cons_Jac) {
+      return false;
+    }
 
     assert(cons_Jac->numberOfNonzeros() == pJac_c->numberOfNonzeros() + pJac_d->numberOfNonzeros());
 
-    hiopVector* x_user = nlp_transformations_.apply_inv_to_x(x, new_x);
+    hiopVector* x_user = &x;
+    if(!disable_nlp_transformations_) {
+      x_user = nlp_transformations_.apply_inv_to_x(x, new_x);
+    }
 
     runStats.tmEvalJac_con.start();
 
@@ -2097,10 +2187,11 @@ bool hiopNlpSparse::eval_Jac_c_d_interface_impl(hiopVector& x, bool new_x, hiopM
     // copy back to Jac_c and Jac_d
     pJac_c->copyRowsFrom(*cons_Jac, cons_eq_mapping_->local_data_const(), n_cons_eq_);
     pJac_d->copyRowsFrom(*cons_Jac, cons_ineq_mapping_->local_data_const(), n_cons_ineq_);
-
-    // scale the matrix
-    Jac_c = *(nlp_transformations_.apply_to_jacob_eq(Jac_c, n_cons_eq_));
-    Jac_d = *(nlp_transformations_.apply_to_jacob_ineq(Jac_d, n_cons_ineq_));
+    if(!disable_nlp_transformations_) {
+      // scale the matrix
+      Jac_c = *(nlp_transformations_.apply_to_jacob_eq(Jac_c, n_cons_eq_));
+      Jac_d = *(nlp_transformations_.apply_to_jacob_ineq(Jac_d, n_cons_ineq_));
+    }
 
     runStats.tmEvalJac_con.stop();
     runStats.nEvalJac_con_eq++;
@@ -2142,7 +2233,9 @@ bool hiopNlpSparse::eval_Hess_Lagr(const hiopVector& x,
 
     // scale lambda before passing it to user interface to compute Hess
     int n_cons_eq_ineq = n_cons_eq_ + n_cons_ineq_;
-    buf_lambda_ = nlp_transformations_.apply_to_cons(*buf_lambda_, n_cons_eq_ineq);
+    if(!disable_nlp_transformations_) {
+      buf_lambda_ = nlp_transformations_.apply_to_cons(*buf_lambda_, n_cons_eq_ineq);
+    }
 
     double obj_factor_with_scale = obj_factor * get_obj_scale();
 

--- a/src/Optimization/hiopNlpFormulation.cpp
+++ b/src/Optimization/hiopNlpFormulation.cpp
@@ -1935,14 +1935,14 @@ hiopMatrixDense* hiopNlpDenseConstraints::alloc_Jac_c_user()
   if(nullptr==fixed_vars_remover_) {      
     return alloc_multivector_primal(n_cons_eq_);
   }
-
-  index_type* vec_distrib_user = nullptr;
   const size_type n_user = nlp_transformations_.n_pre();
   assert(n_user == fixed_vars_remover_->fs_n() && "Somehow order or NLP transformations is incorrect.");
 #ifdef HIOP_USE_MPI
-  vec_distrib_user = fixed_vars_remover_->get_fs_vector_distrib();
-#endif
+  index_type* vec_distrib_user = fixed_vars_remover_->get_fs_vector_distrib();
   return LinearAlgebraFactory::create_matrix_dense("DEFAULT", n_cons_eq_, n_user, vec_distrib_user, comm_);
+#else
+  return LinearAlgebraFactory::create_matrix_dense("DEFAULT", n_cons_eq_, n_user);
+#endif
 }
 
 hiopMatrixDense* hiopNlpDenseConstraints::alloc_Jac_d_user()
@@ -1950,13 +1950,14 @@ hiopMatrixDense* hiopNlpDenseConstraints::alloc_Jac_d_user()
   if(nullptr==fixed_vars_remover_) {
     return alloc_multivector_primal(n_cons_ineq_);
   }
-  index_type* vec_distrib_user = nullptr;
   const size_type n_user = nlp_transformations_.n_pre();
   assert(n_user == fixed_vars_remover_->fs_n() && "Somehow order or NLP transformations is incorrect.");
 #ifdef HIOP_USE_MPI
-  vec_distrib_user = fixed_vars_remover_->get_fs_vector_distrib();
-#endif
+  index_type* vec_distrib_user = fixed_vars_remover_->get_fs_vector_distrib();
   return LinearAlgebraFactory::create_matrix_dense("DEFAULT", n_cons_ineq_, n_user, vec_distrib_user, comm_);
+#else
+  return LinearAlgebraFactory::create_matrix_dense("DEFAULT", n_cons_ineq_, n_user);
+#endif
 }
 
 hiopMatrixDense* hiopNlpDenseConstraints::alloc_Jac_cons_user()
@@ -1964,15 +1965,15 @@ hiopMatrixDense* hiopNlpDenseConstraints::alloc_Jac_cons_user()
   if(nullptr==fixed_vars_remover_) {
     return alloc_multivector_primal(n_cons_);
   }
-  index_type* vec_distrib_user = nullptr;
   const size_type n_user = nlp_transformations_.n_pre();
   assert(n_user == fixed_vars_remover_->fs_n() && "Somehow order or NLP transformations is incorrect.");
 #ifdef HIOP_USE_MPI
-  vec_distrib_user = fixed_vars_remover_->get_fs_vector_distrib();
-#endif
+  index_type* vec_distrib_user = fixed_vars_remover_->get_fs_vector_distrib();
   return LinearAlgebraFactory::create_matrix_dense("DEFAULT", n_cons_, n_user, vec_distrib_user, comm_);
+#else
+  return LinearAlgebraFactory::create_matrix_dense("DEFAULT", n_cons_, n_user);
+#endif
 }
-
 
 hiopMatrix* hiopNlpDenseConstraints::alloc_Hess_Lagr()
 {

--- a/src/Optimization/hiopNlpFormulation.cpp
+++ b/src/Optimization/hiopNlpFormulation.cpp
@@ -145,6 +145,8 @@ hiopNlpFormulation::hiopNlpFormulation(hiopInterfaceBase& interface_, const char
   temp_x_ = nullptr;
   nlp_scaling_ = nullptr;
   relax_bounds_ = nullptr;
+  fixed_vars_remover_ = nullptr;
+  fixed_vars_relaxer_ = nullptr;
 }
 
 hiopNlpFormulation::~hiopNlpFormulation()
@@ -185,15 +187,39 @@ hiopNlpFormulation::~hiopNlpFormulation()
   delete temp_eq_;
   delete temp_ineq_;
   delete temp_x_;
-  /// nlp_scaling_ and relax_bounds_ are deleted inside nlp_transformations_
+  /// nlp_scaling_, relax_bounds_, fixed_vars_remover_, fixed_vars_relaxer_ are deleted by nlp_transformations_
 }
 
 bool hiopNlpFormulation::finalizeInitialization()
 {
   // check if there was a change in the user options that requires reinitialization of 'this'
   bool doinit = false;
+
   if(strFixedVars_ != options->GetString("fixed_var")) {
     doinit = true;
+    
+    if(strFixedVars_ == "remove") {
+      //remove fixed vars NLP transformation
+      assert(fixed_vars_remover_);
+      nlp_transformations_.remove(fixed_vars_remover_);
+      fixed_vars_remover_ = nullptr;
+    } else if(strFixedVars_ == "relax") {
+      //remove relaxers
+      assert(fixed_vars_relaxer_!=nullptr || relax_bounds_!=nullptr);
+      if(fixed_vars_relaxer_) {
+        nlp_transformations_.remove(fixed_vars_relaxer_);
+        fixed_vars_relaxer_ = nullptr;
+        assert(relax_bounds_==nullptr);
+      }
+      if(relax_bounds_) {
+        nlp_transformations_.remove(relax_bounds_);
+        relax_bounds_ = nullptr;
+        assert(fixed_vars_relaxer_==nullptr);
+      }
+    }
+
+    // save the new value of 'fixed_var' option
+    strFixedVars_ = options->GetString("fixed_var");
   }
   const double fixedVarTol = options->GetNumeric("fixed_var_tolerance");
   if(dFixedVarsTol_ != fixedVarTol) {
@@ -205,7 +231,8 @@ bool hiopNlpFormulation::finalizeInitialization()
   if(!doinit) {
     return true;
   }
-
+  log->printf(hovWarning, "Triggering partial reinitialization since some user options has changed.\n");
+  
   // Select memory space where to create linear algebra objects
   string mem_space = options->GetString("mem_space");
   log->printf(hovScalars, "NlpFormulation initialization: using mem_space='%s'\n", mem_space.c_str());
@@ -271,28 +298,27 @@ bool hiopNlpFormulation::finalizeInitialization()
   int ierr = MPI_Allreduce(&nfixed_vars_local, &nfixed_vars, 1, MPI_HIOP_SIZE_TYPE, MPI_SUM, comm_);
   assert(MPI_SUCCESS == ierr);
 #endif
-  hiopFixedVarsRemover* fixedVarsRemover = NULL;
+
   if(nfixed_vars > 0) {
-    log->printf(hovWarning, "Detected %lld fixed variables out of a total of %lld.\n", nfixed_vars, n_vars_);
+    log->printf(hovSummary, "Detected %lld fixed variables out of a total of %lld.\n", nfixed_vars, n_vars_);
 
     if(options->GetString("fixed_var") == "remove") {
       //
       // remove free variables
       //
-      log->printf(hovWarning, "Fixed variables will be removed internally.\n");
+      log->printf(hovSummary, "Fixed variables will be removed internally.\n");
 
-      fixedVarsRemover = new hiopFixedVarsRemover(this, *xl_, *xu_, fixedVarTol, nfixed_vars, nfixed_vars_local);
+      fixed_vars_remover_ = new hiopFixedVarsRemover(this, *xl_, *xu_, fixedVarTol, nfixed_vars, nfixed_vars_local);
 
 #ifdef HIOP_USE_MPI
-      fixedVarsRemover->setFSVectorDistrib(vec_distrib_, num_ranks_);
-      fixedVarsRemover->setMPIComm(comm_);
+      fixed_vars_remover_->set_fs_vector_distrib(vec_distrib_, num_ranks_);
 #endif
-      bret = fixedVarsRemover->setupDecisionVectorPart();
+      bret = fixed_vars_remover_->setupDecisionVectorPart();
       assert(bret && "error while removing fixed variables");
 
-      n_vars_ = fixedVarsRemover->rs_n();
+      n_vars_ = fixed_vars_remover_->rs_n();
 #ifdef HIOP_USE_MPI
-      index_type* vec_distrib_rs = fixedVarsRemover->allocRSVectorDistrib();
+      index_type* vec_distrib_rs = fixed_vars_remover_->alloc_rs_vector_distrib();
       delete[] vec_distrib_;
       vec_distrib_ = vec_distrib_rs;
 #endif
@@ -312,14 +338,14 @@ bool hiopNlpFormulation::finalizeInitialization()
       hiopVector* ixl_rs = xl_rs->alloc_clone();
       hiopVector* ixu_rs = xu_rs->alloc_clone();
 
-      fixedVarsRemover->copyFsToRs(*xl_, *xl_rs);
-      fixedVarsRemover->copyFsToRs(*xu_, *xu_rs);
-      fixedVarsRemover->copyFsToRs(*ixl_, *ixl_rs);
-      fixedVarsRemover->copyFsToRs(*ixu_, *ixu_rs);
+      fixed_vars_remover_->copyFsToRs(*xl_, *xl_rs);
+      fixed_vars_remover_->copyFsToRs(*xu_, *xu_rs);
+      fixed_vars_remover_->copyFsToRs(*ixl_, *ixl_rs);
+      fixed_vars_remover_->copyFsToRs(*ixu_, *ixu_rs);
 
       nlocal = xl_rs->get_local_size();
       hiopInterfaceBase::NonlinearityType* vars_type_rs = new hiopInterfaceBase::NonlinearityType[nlocal];
-      fixedVarsRemover->copyFsToRs(vars_type_, vars_type_rs);
+      fixed_vars_remover_->copyFsToRs(vars_type_, vars_type_rs);
 
       delete xl_;
       delete xu_;
@@ -336,30 +362,35 @@ bool hiopNlpFormulation::finalizeInitialization()
       n_bnds_upp_local_ -= nfixed_vars_local;
       n_bnds_lu_ -= nfixed_vars_local;
 
-      nlp_transformations_.append(fixedVarsRemover);
+      nlp_transformations_.append(fixed_vars_remover_);
     } else {
       /*
        * Relax fixed variables according to 2 conditions:
        * 1. bound_relax_perturb==0.0: Relax fixed variables according to fixed_var_perturb and fixed_var_tolerance.
        *    Other variables are not relaxed. hiopFixedVarsRelaxer is used to relax fixed var
-       * 2. bound_relax_perturb!=0.0: Later we will use hiopBoundsRelaxer to relax the variable and inequlity bounds,
+       * 2. bound_relax_perturb!=0.0: Later we will use hiopBoundsRelaxer to relax the variables and inequality bounds,
        *    according to bound_relax_perturb. It will also relax the fixed variables, hence we can skip relax fixed var here.
        */
-      if(options->GetString("fixed_var") == "relax" && options->GetNumeric("bound_relax_perturb") == 0.0) {
-        log->printf(hovWarning, "Fixed variables will be relaxed internally.\n");
-        auto* fixedVarsRelaxer = new hiopFixedVarsRelaxer(this, *xl_, *xu_, nfixed_vars, nfixed_vars_local);
-        fixedVarsRelaxer->setup();
+      if(options->GetString("fixed_var") == "relax" &&
+         options->GetNumeric("bound_relax_perturb") == 0.0 &&
+         options->GetString("elastic_mode")=="none") {
+        assert(nullptr==fixed_vars_relaxer_);
+        log->printf(hovSummary,
+                    "Fixed variables (bounds) will be relaxed internally with all other variables "
+                    "(fixed var strategy (1)).\n");
+        fixed_vars_relaxer_ = new hiopFixedVarsRelaxer(this, *xl_, *xu_, nfixed_vars, nfixed_vars_local);
+        fixed_vars_relaxer_->setup();
 
         const double fv_tol = options->GetNumeric("fixed_var_tolerance");
         const double fv_per = options->GetNumeric("fixed_var_perturb");
-        fixedVarsRelaxer->relax(fv_tol, fv_per, *xl_, *xu_);
+        fixed_vars_relaxer_->relax(fv_tol, fv_per, *xl_, *xu_);
 
-        nlp_transformations_.append(fixedVarsRelaxer);
+        nlp_transformations_.append(fixed_vars_relaxer_);
 
-      } else if(options->GetNumeric("bound_relax_perturb") == 0.0) {
+      } else if(options->GetNumeric("bound_relax_perturb") == 0.0 && options->GetString("elastic_mode")=="none") {
         log->printf(hovError,
-                    "detected fixed variables but HiOp was not instructed how to deal with them (option "
-                    "'fixed_var' is 'none').\n");
+                    "Fixed variables were detected but HiOp was not instructed how to deal with them (option "
+                    "'fixed_var' is 'none', option 'bound_relax_perturb' is 0.0, and 'elastic_mode' is 'none').\n");
         exit(EXIT_FAILURE);
       }
     }
@@ -372,11 +403,9 @@ bool hiopNlpFormulation::finalizeInitialization()
     return false;
   }
 
-  if(fixedVarsRemover) {
-    fixedVarsRemover->setupConstraintsPart(n_cons_eq_, n_cons_ineq_);
+  if(fixed_vars_remover_) {
+    fixed_vars_remover_->setupConstraintsPart(n_cons_eq_, n_cons_ineq_);
   }
-  // save the new value of 'fixed_var' option
-  strFixedVars_ = options->GetString("fixed_var");
 
   // compute the overall n_low and n_upp
 #ifdef HIOP_USE_MPI
@@ -393,17 +422,26 @@ bool hiopNlpFormulation::finalizeInitialization()
 #endif
 
   //
-  // relax bounds for simple bounds and constraints)
+  // relax bounds for simple bounds and constraints
   //
-  if(options->GetNumeric("bound_relax_perturb") > 0.0) {
+  if((options->GetNumeric("bound_relax_perturb")>0.0) || (options->GetString("elastic_mode")!="none")) {
+    if(nfixed_vars>0 && nullptr==fixed_vars_remover_) {
+      log->printf(hovSummary,
+                  "Fixed variables (bounds) will be relaxed internally together with the other variables.\n");
+    }
     relax_bounds_ = new hiopBoundsRelaxer(this, *xl_, *xu_, *dl_, *du_);
     relax_bounds_->setup();
     if(options->GetString("elastic_mode") == "none") {
-      relax_bounds_->relax(options->GetNumeric("bound_relax_perturb"), *xl_, *xu_, *dl_, *du_);
+      const double bound_relax_perturb = options->GetNumeric("bound_relax_perturb");
+      relax_bounds_->relax(bound_relax_perturb, *xl_, *xu_, *dl_, *du_);
+      log->printf(hovSummary, "Relaxing bounds simple strategy (2) - perturb=%g\n",  bound_relax_perturb);
     } else {
-      relax_bounds_->relax(options->GetNumeric("elastic_mode_bound_relax_initial"), *xl_, *xu_, *dl_, *du_);
+      const double bound_relax_perturb = options->GetNumeric("elastic_mode_bound_relax_initial");
+      relax_bounds_->relax(bound_relax_perturb, *xl_, *xu_, *dl_, *du_);
+      log->printf(hovSummary, "Relaxing bounds elastic strategy (3) - (initial) perturb=%g\n",  bound_relax_perturb);
     }
     nlp_transformations_.append(relax_bounds_);
+
   }
 
   // reset/release info and data related to one-call constraints evaluation
@@ -810,7 +848,7 @@ void hiopNlpFormulation::run_derivative_checker()
   //
   if(options->GetString("derivative_check") == "first-order") {
     
-    log->printf(hovWarning, "Starting derivative checker for gradient ...\n");
+    log->printf(hovSummary, "Starting derivative checker for gradient ...\n");
     size_t num_errs = 0;
     double f_ref;
     bret = interface_base.eval_f(nlp_transformations_.n_pre(), x_ref.local_data_const(), true, f_ref);
@@ -857,18 +895,18 @@ void hiopNlpFormulation::run_derivative_checker()
            << "user " << fixed << setprecision(14) << setw(21) << grad_ex << "  "
            << "fd " << fixed << setprecision(14) << setw(21) << grad_fd
            << " relerr [" << scientific << setprecision(3) << setw(9) << rel_error << "]";
-        log->printf(hovWarning, "%s\n", ss.str().c_str());
+        log->printf(hovSummary, "%s\n", ss.str().c_str());
         fflush(stdout);
       }
       
     }
-    log->printf(hovWarning, "Derivative checker for gradient finished: %d errors detected.\n", num_errs);
+    log->printf(hovSummary, "Derivative checker for gradient finished: %d errors detected.\n", num_errs);
     delete grad_exact;
 
     //
     // Jacobian check
     //
-    log->printf(hovWarning, "Starting derivative checker for Jacobian ...\n");
+    log->printf(hovSummary, "Starting derivative checker for Jacobian ...\n");
     num_errs = 0;
     disable_nlp_transformations_ = true;
 
@@ -891,25 +929,19 @@ void hiopNlpFormulation::run_derivative_checker()
                                           cons_d_ref,
                                           *cons_ineq_mapping_);
 
-    cout << "aaaa evaluated c_d x_ref size=" << x_ref.get_size() 
-         << "\n"; fflush(stdout);
     //evaluate "exact"/user Jacobian(s)
-    hiopMatrix* Jac_c_ref = this->alloc_Jac_c();
-    hiopMatrix* Jac_d_ref = this->alloc_Jac_d();
 
-    cout << "aaaa Jac c and d sizes: " << Jac_c_ref->m() << " " << Jac_d_ref->m()
-         << " columns: " << Jac_c_ref->n() << " " << Jac_d_ref->n() 
-         << "\n"; fflush(stdout);
+    //alocate Jacobians at the reference point - need to be in the user's sizes
+    hiopMatrix* Jac_c_ref = this->alloc_Jac_c_user();
+    hiopMatrix* Jac_d_ref = this->alloc_Jac_c_user();
 
     if(!eval_Jac_c_d(x_ref, false, *Jac_c_ref, *Jac_d_ref)) {
       log->printf(hovError, "Derivative checker error: in user Jacobian function.\n");
       return;
     }
-        cout << "aaaa evaluated JJJJJJJJacc_d\n"; fflush(stdout);
-        cout << "bbb cons_ref size" << cons_ref->get_local_size() << "\n"; fflush(stdout);
     // perturbed constraint body
     hiopVector* cons_pert = cons_ref->alloc_clone();
-            cout << "aaa cons_ref size" << cons_ref->get_local_size() << "\n"; fflush(stdout);
+
     // ith column in the "exact" user Jacobian
     hiopVector* Jac_ex_col = cons_ref->alloc_clone();
     //perturbed equality/c constraint body
@@ -921,12 +953,10 @@ void hiopNlpFormulation::run_derivative_checker()
 
     //main loop
     for(index_type idx=0; idx<nlp_transformations_.n_pre(); ++idx) {
-      cout << "aaa evaluated c_d idx=" << idx << "\n"; fflush(stdout);
+
       const double val_ref = x_ref.get_elem(idx);
       x_pert->copyFrom(x_ref);
       x_pert->set_elem(idx, val_ref+pert*max(abs(val_ref), 1.0));
-
-
       
       //eval at the perturbed point
       this->eval_c_d(*x_pert, true, *cons_c_pert, *cons_d_pert);
@@ -966,12 +996,12 @@ void hiopNlpFormulation::run_derivative_checker()
              << "user " << fixed << setprecision(14) << setw(21) << Jac_ex_ij << "  "
              << "fd " << fixed << setprecision(14) << setw(21) << Jac_fd_ij
              << " relerr [" << scientific << setprecision(3) << setw(9) << rel_error << "]";
-          log->printf(hovWarning, "%s\n", ss.str().c_str());
+          log->printf(hovSummary, "%s\n", ss.str().c_str());
           fflush(stdout);
         }
       } // end for j=1,..,m
     }
-    log->printf(hovWarning, "Derivative checker for Jacobian finished: %d errors detected.\n", num_errs);
+    log->printf(hovSummary, "Derivative checker for Jacobian finished: %d errors detected.\n", num_errs);
     disable_nlp_transformations_ = false;
     delete Jac_ex_col;
     delete ei;
@@ -1639,6 +1669,7 @@ void hiopNlpFormulation::adjust_bounds(const hiopIterate& it)
 
 void hiopNlpFormulation::reset_bounds(double bound_relax_perturb)
 {
+  assert(relax_bounds_);
   relax_bounds_->relax_from_ori(bound_relax_perturb, *xl_, *xu_, *dl_, *du_);
 }
 
@@ -1884,11 +1915,64 @@ bool hiopNlpDenseConstraints::eval_Jac_d(hiopVector& x, bool new_x, hiopMatrix& 
   }
 }
 
-hiopMatrixDense* hiopNlpDenseConstraints::alloc_Jac_c() { return alloc_multivector_primal(n_cons_eq_); }
+hiopMatrixDense* hiopNlpDenseConstraints::alloc_Jac_c()
+{
+  return alloc_multivector_primal(n_cons_eq_);
+}
 
-hiopMatrixDense* hiopNlpDenseConstraints::alloc_Jac_d() { return alloc_multivector_primal(n_cons_ineq_); }
+hiopMatrixDense* hiopNlpDenseConstraints::alloc_Jac_d()
+{
+  return alloc_multivector_primal(n_cons_ineq_);
+}
 
-hiopMatrixDense* hiopNlpDenseConstraints::alloc_Jac_cons() { return alloc_multivector_primal(n_cons_); }
+hiopMatrixDense* hiopNlpDenseConstraints::alloc_Jac_cons()
+{
+  return alloc_multivector_primal(n_cons_);
+}
+
+hiopMatrixDense* hiopNlpDenseConstraints::alloc_Jac_c_user()
+{
+  if(nullptr==fixed_vars_remover_) {      
+    return alloc_multivector_primal(n_cons_eq_);
+  }
+
+  index_type* vec_distrib_user = nullptr;
+  const size_type n_user = nlp_transformations_.n_pre();
+  assert(n_user == fixed_vars_remover_->fs_n() && "Somehow order or NLP transformations is incorrect.");
+#ifdef HIOP_USE_MPI
+  vec_distrib_user = fixed_vars_remover_->get_fs_vector_distrib();
+#endif
+  return LinearAlgebraFactory::create_matrix_dense("DEFAULT", n_cons_eq_, n_user, vec_distrib_user, comm_);
+}
+
+hiopMatrixDense* hiopNlpDenseConstraints::alloc_Jac_d_user()
+{
+  if(nullptr==fixed_vars_remover_) {
+    return alloc_multivector_primal(n_cons_ineq_);
+  }
+  index_type* vec_distrib_user = nullptr;
+  const size_type n_user = nlp_transformations_.n_pre();
+  assert(n_user == fixed_vars_remover_->fs_n() && "Somehow order or NLP transformations is incorrect.");
+#ifdef HIOP_USE_MPI
+  vec_distrib_user = fixed_vars_remover_->get_fs_vector_distrib();
+#endif
+  return LinearAlgebraFactory::create_matrix_dense("DEFAULT", n_cons_ineq_, n_user, vec_distrib_user, comm_);
+}
+
+hiopMatrixDense* hiopNlpDenseConstraints::alloc_Jac_cons_user()
+{
+  if(nullptr==fixed_vars_remover_) {
+    return alloc_multivector_primal(n_cons_);
+  }
+  index_type* vec_distrib_user = nullptr;
+  const size_type n_user = nlp_transformations_.n_pre();
+  assert(n_user == fixed_vars_remover_->fs_n() && "Somehow order or NLP transformations is incorrect.");
+#ifdef HIOP_USE_MPI
+  vec_distrib_user = fixed_vars_remover_->get_fs_vector_distrib();
+#endif
+  return LinearAlgebraFactory::create_matrix_dense("DEFAULT", n_cons_, n_user, vec_distrib_user, comm_);
+}
+
 
 hiopMatrix* hiopNlpDenseConstraints::alloc_Hess_Lagr()
 {

--- a/src/Optimization/hiopNlpFormulation.cpp
+++ b/src/Optimization/hiopNlpFormulation.cpp
@@ -762,8 +762,7 @@ bool hiopNlpFormulation::eval_grad_f(hiopVector& x, bool new_x, hiopVector& grad
 void hiopNlpFormulation::run_derivative_checker()
 {
   auto* it_hiop = new hiopIterate(this);
-  hiopVector* lambdas =
-    hiop::LinearAlgebraFactory::create_vector(options->GetString("mem_space"), n_cons_);
+  hiopVector* lambdas = this->alloc_dual_vec();
   assert(n_cons_ == it_hiop->get_yc()->get_size() + it_hiop->get_yd()->get_size());
 
   // finite difference (FD) check at initial point provided by the user 
@@ -866,15 +865,122 @@ void hiopNlpFormulation::run_derivative_checker()
     log->printf(hovWarning, "Derivative checker for gradient finished: %d errors detected.\n", num_errs);
     delete grad_exact;
 
-    // Jacobian
+    //
+    // Jacobian check
+    //
     log->printf(hovWarning, "Starting derivative checker for Jacobian ...\n");
     num_errs = 0;
-
     disable_nlp_transformations_ = true;
-    //hiopVector* a;
 
-    disable_nlp_transformations_ = false;
+    hiopVector* cons_ref = this->alloc_dual_vec();
+    if(temp_eq_ == nullptr) {
+      temp_eq_ = this->alloc_dual_eq_vec();
+    }
+    if(temp_ineq_ == nullptr) {
+      temp_ineq_ = this->alloc_dual_ineq_vec();
+    }
+    hiopVector& cons_c_ref = *temp_eq_;
+    hiopVector& cons_d_ref = *temp_ineq_;
+    
+    if(!this->eval_c_d(x_ref, true, cons_c_ref, cons_d_ref)) {
+      log->printf(hovError, "Derivative checker error: in user constraint function.\n");
+      return;
+    }
+    cons_ref->copy_from_two_vec_w_pattern(cons_c_ref,
+                                          *cons_eq_mapping_,
+                                          cons_d_ref,
+                                          *cons_ineq_mapping_);
+
+    cout << "aaaa evaluated c_d x_ref size=" << x_ref.get_size() 
+         << "\n"; fflush(stdout);
+    //evaluate "exact"/user Jacobian(s)
+    hiopMatrix* Jac_c_ref = this->alloc_Jac_c();
+    hiopMatrix* Jac_d_ref = this->alloc_Jac_d();
+
+    cout << "aaaa Jac c and d sizes: " << Jac_c_ref->m() << " " << Jac_d_ref->m()
+         << " columns: " << Jac_c_ref->n() << " " << Jac_d_ref->n() 
+         << "\n"; fflush(stdout);
+
+    if(!eval_Jac_c_d(x_ref, false, *Jac_c_ref, *Jac_d_ref)) {
+      log->printf(hovError, "Derivative checker error: in user Jacobian function.\n");
+      return;
+    }
+        cout << "aaaa evaluated JJJJJJJJacc_d\n"; fflush(stdout);
+        cout << "bbb cons_ref size" << cons_ref->get_local_size() << "\n"; fflush(stdout);
+    // perturbed constraint body
+    hiopVector* cons_pert = cons_ref->alloc_clone();
+            cout << "aaa cons_ref size" << cons_ref->get_local_size() << "\n"; fflush(stdout);
+    // ith column in the "exact" user Jacobian
+    hiopVector* Jac_ex_col = cons_ref->alloc_clone();
+    //perturbed equality/c constraint body
+    hiopVector* cons_c_pert = cons_c_ref.alloc_clone();
+    //perturbed inequality/d constraint body
+    hiopVector* cons_d_pert = cons_d_ref.alloc_clone();
+    // vector of all zero except ith position which is one
+    hiopVector* ei = x_ref.alloc_clone();
+
+    //main loop
+    for(index_type idx=0; idx<nlp_transformations_.n_pre(); ++idx) {
+      cout << "aaa evaluated c_d idx=" << idx << "\n"; fflush(stdout);
+      const double val_ref = x_ref.get_elem(idx);
+      x_pert->copyFrom(x_ref);
+      x_pert->set_elem(idx, val_ref+pert*max(abs(val_ref), 1.0));
+
+
+      
+      //eval at the perturbed point
+      this->eval_c_d(*x_pert, true, *cons_c_pert, *cons_d_pert);
+      cons_pert->copy_from_two_vec_w_pattern(*cons_c_pert, *cons_eq_mapping_, *cons_d_pert, *cons_ineq_mapping_);
+      // compute finite difference Jacobian (ith column)
+      hiopVector& Jac_fd_col = *cons_pert;
+      Jac_fd_col.axpy(-1.0, *cons_ref);
+      Jac_fd_col.scale(1/pert);
+
+
+      //we multiply Jacobian with ei=(0,...,1,...0) to get the ith column
+      ei->setToZero();
+      ei->set_elem(idx, 1.);
+      //reuse
+      hiopVector& Jac_ex_d_col = *cons_d_pert;
+      hiopVector& Jac_ex_c_col = *cons_c_pert;
+      Jac_c_ref->timesVec(0, Jac_ex_c_col, 1.0, *ei);
+      Jac_d_ref->timesVec(0, Jac_ex_d_col, 1.0, *ei);
+      Jac_ex_col->copy_from_two_vec_w_pattern(Jac_ex_c_col, *cons_eq_mapping_, Jac_ex_d_col, *cons_ineq_mapping_);
+
+      // compute error
+      for(index_type row=0; row<m(); ++row) {
+        const double Jac_fd_ij = Jac_fd_col.get_elem(row);
+        const double Jac_ex_ij = Jac_ex_col->get_elem(row);
+        const double scale = max(Jac_ex_ij, max(abs(Jac_fd_ij), derivative_check_tolerance));
+        double rel_error = abs(Jac_fd_ij - Jac_ex_ij) / scale;
+
+        const bool b_err = rel_error > derivative_check_tolerance;
+        char err_marker = ' ';
+        if(b_err) {
+          err_marker = '!';
+          num_errs++;
+        }
+        if(b_err || print_all) {
+          stringstream ss;
+          ss << err_marker << " Jac[" << setw(5) << row << "," << setw(5) << idx << "] "
+             << "user " << fixed << setprecision(14) << setw(21) << Jac_ex_ij << "  "
+             << "fd " << fixed << setprecision(14) << setw(21) << Jac_fd_ij
+             << " relerr [" << scientific << setprecision(3) << setw(9) << rel_error << "]";
+          log->printf(hovWarning, "%s\n", ss.str().c_str());
+          fflush(stdout);
+        }
+      } // end for j=1,..,m
+    }
     log->printf(hovWarning, "Derivative checker for Jacobian finished: %d errors detected.\n", num_errs);
+    disable_nlp_transformations_ = false;
+    delete Jac_ex_col;
+    delete ei;
+    delete Jac_d_ref;
+    delete Jac_c_ref;
+    delete cons_d_pert;
+    delete cons_c_pert;
+    delete cons_pert;
+    delete cons_ref;
   }
 
   delete x_pert;
@@ -1125,6 +1231,7 @@ bool hiopNlpFormulation::eval_Jac_c_d(hiopVector& x, bool new_x, hiopMatrix& Jac
         cons_body_ = this->alloc_dual_vec();
         // cons_body_ = new double[n_cons_];
         cons_Jac_ = alloc_Jac_cons();
+
       } else {
         cons_eval_type_ = 0;
         return false;
@@ -1136,10 +1243,11 @@ bool hiopNlpFormulation::eval_Jac_c_d(hiopVector& x, bool new_x, hiopMatrix& Jac
   }
 
   if(0 == cons_eval_type_) {
-    if(do_eval_Jac_c)
+    if(do_eval_Jac_c) {
       if(!eval_Jac_c(x, new_x, Jac_c)) {
         return false;
       }
+    }
     if(!eval_Jac_d(x, new_x, Jac_d)) {
       return false;
     }

--- a/src/Optimization/hiopNlpFormulation.cpp
+++ b/src/Optimization/hiopNlpFormulation.cpp
@@ -877,7 +877,7 @@ void hiopNlpFormulation::run_derivative_checker()
     double f_ref;
     bret = interface_base.eval_f(nlp_transformations_.n_pre(), x_ref.local_data_const(), true, f_ref);
     if(!bret) {
-      log->printf(hovError, "Derivative check error: in evaluating user objective.");
+      log->printf(hovError, "Derivative check error: in evaluating user objective.\n");
       user_eval_err = true;
     }
     
@@ -892,7 +892,7 @@ void hiopNlpFormulation::run_derivative_checker()
       double f_pert;
       bret = interface_base.eval_f(nlp_transformations_.n_pre(), x_pert->local_data_const(), true, f_pert);
       if(!bret) {
-        log->printf(hovError, "Derivative check error: in evaluating user objective.");
+        log->printf(hovError, "Derivative check error: in evaluating user objective.\n");
         user_eval_err = true;
         break;
       }
@@ -919,7 +919,7 @@ void hiopNlpFormulation::run_derivative_checker()
       
     }
     if(user_eval_err) {
-      log->printf(hovSummary, "Derivative checker halted because of error(s) in user provided functions.");
+      log->printf(hovSummary, "Derivative checker halted because of error(s) in user provided functions.\n");
     } else {
       log->printf(hovSummary, "Derivative checker for gradient finished: %d errors detected.\n", num_errs);
 
@@ -961,7 +961,7 @@ void hiopNlpFormulation::run_derivative_checker()
       hiopVector* ei = x_ref.alloc_clone();
       
       //main loop
-      for(index_type idx=0; idx<nlp_transformations_.n_pre() &&!user_eval_err; ++idx) {
+      for(index_type idx=0; idx<nlp_transformations_.n_pre() && !user_eval_err; ++idx) {
         
         const double val_ref = x_ref.get_elem(idx);
         x_pert->copyFrom(x_ref);
@@ -993,7 +993,7 @@ void hiopNlpFormulation::run_derivative_checker()
         for(index_type row=0; row<m() && !user_eval_err; ++row) {
           const double Jac_fd_ij = Jac_fd_col.get_elem(row);
           const double Jac_ex_ij = Jac_ex_col->get_elem(row);
-          const double scale = max(Jac_ex_ij, max(abs(Jac_fd_ij), derivative_check_tolerance));
+          const double scale = max(abs(Jac_ex_ij), max(abs(Jac_fd_ij), derivative_check_tolerance));
           double rel_error = abs(Jac_fd_ij - Jac_ex_ij) / scale;
           
           const bool b_err = rel_error > derivative_check_tolerance;
@@ -1011,7 +1011,7 @@ void hiopNlpFormulation::run_derivative_checker()
             log->printf(hovSummary, "%s\n", ss.str().c_str());
             fflush(stdout);
           }
-        } // end for j=1,..,m
+        } // end for row=1,..,m
       }
       if(user_eval_err) {
         log->printf(hovSummary, "Derivative checker halted because of error(s) in user provided functions.");        
@@ -2523,13 +2523,17 @@ size_type hiopNlpSparse::run_derivative_checker_order2(hiopVector& x_ref,
   hiopVector* x_pert = x_ref.alloc_clone();
   // gradient at perturbed x
   hiopVector* grad_pert = grad_ref.alloc_clone();
+  // ei vector used to get columns of the Hessian(s0
+  hiopVector* ei = x_ref.alloc_clone();
+  // vector to store a column of the Hessian
+  hiopVector* Hess_ex_col = x_ref.alloc_clone();
   //user "exact" Hessian
   auto* Hess_exact = alloc_Hess_Lagr();
 
   bool user_eval_err = false; 
   
   //
-  //objective Hessian first
+  //objective reference Hessian first
   //
   //evaluate 
   double obj_factor = 1.5;
@@ -2543,12 +2547,64 @@ size_type hiopNlpSparse::run_derivative_checker_order2(hiopVector& x_ref,
     user_eval_err = true;
   }
 
-  for(index_type i=0; i<n() && !user_eval_err; i++) {
+  const double pert = options->GetNumeric("derivative_check_perturbation");
+  const double derivative_check_tolerance = options->GetNumeric("derivative_check_tolerance");
+  const bool print_all = ( options->GetString("derivative_check_print_all") != "no" );
+
+  
+  for(index_type idx=0; idx<n() && !user_eval_err; idx++) {
+    const double val_ref = x_ref.get_elem(idx);
+    x_pert->copyFrom(x_ref);
+    x_pert->set_elem(idx, val_ref+pert*max(abs(val_ref), 1.0));
+
+    //evaluate gradient (of objective)
+    if(!interface_base.eval_grad_f(nlp_transformations_.n_pre(),
+                                   x_pert->local_data_const(),
+                                   true,
+                                   grad_pert->local_data())) {
+      user_eval_err = true;
+      log->printf(hovError, "Derivative check error: in evaluating user gradient at perturbed point.\n");
+      break;
+    }
+
+    hiopVector& Hess_fd_col = *grad_pert;
+    Hess_fd_col.axpy(-1.0, grad_ref);
+    Hess_fd_col.scale(1/pert);
     
+    //obtain 'idx' column of the Hessian
+    ei->setToZero();
+    ei->set_elem(idx, 1.);
+    Hess_exact->timesVec(0, *Hess_ex_col, 1.0, *ei);
+
+    //loop over (i,j) <- (idx,row)
+    for(index_type row=0; row<n() && !user_eval_err; row++) {
+      const double Hess_fd_ij = Hess_fd_col.get_elem(row);
+      const double Hess_ex_ij = Hess_ex_col->get_elem(row);
+      const double scale = max(abs(Hess_ex_ij), max(abs(Hess_fd_ij), derivative_check_tolerance));
+      double rel_error = abs(Hess_fd_ij-Hess_ex_ij) / scale;
+
+      const bool b_err = rel_error > derivative_check_tolerance;
+      char err_marker = ' ';
+      if(b_err) {
+        err_marker = '!';
+        num_errs++;
+      }
+      if(b_err || print_all) {
+        stringstream ss;
+        ss << err_marker << " Hess[" << setw(5) << idx << "," << setw(5) << row << "] "
+           << "user " << fixed << setprecision(14) << setw(21) << Hess_ex_ij << "  "
+           << "fd " << fixed << setprecision(14) << setw(21) << Hess_fd_ij
+           << " relerr [" << scientific << setprecision(3) << setw(9) << rel_error << "]";
+        log->printf(hovSummary, "%s\n", ss.str().c_str());
+        fflush(stdout);
+
+      }
+    } // end for row=1,2,...
   }
 
-  if(user_eval_err) {
+  if(!user_eval_err) {
     log->printf(hovSummary, "Derivative checker for Objective Hessian finished: %d errors detected.\n", num_errs);
+    
   } else {
     
   }
@@ -2568,8 +2624,10 @@ size_type hiopNlpSparse::run_derivative_checker_order2(hiopVector& x_ref,
   delete lambda_eq;
   delete lambda_ineq;
   delete Hess_exact;
+  delete Hess_ex_col;
+  delete ei;
   delete x_pert;
-
+  
   return num_errs;
 }
 

--- a/src/Optimization/hiopNlpFormulation.cpp
+++ b/src/Optimization/hiopNlpFormulation.cpp
@@ -798,7 +798,6 @@ void hiopNlpFormulation::run_derivative_checker()
     return;
   }
   
-
   hiopVector& x_ref = *x0_for_user;
   const double pert = options->GetNumeric("derivative_check_perturbation");
   const double derivative_check_tolerance = options->GetNumeric("derivative_check_tolerance");
@@ -831,8 +830,10 @@ void hiopNlpFormulation::run_derivative_checker()
     
     // grad_fd = (f(x_pert) - f(x_ref)) / pert    
     for(index_type idx=0; idx<nlp_transformations_.n_pre(); ++idx) {
+      const double val_ref = x_ref.get_elem(idx);
+      cout << "val =" << val_ref << std::endl;
       x_pert->copyFrom(x_ref);
-      x_pert->local_data()[idx] += pert * ::std::max(::std::abs(x_ref.local_data()[idx]), 1.0);
+      x_pert->set_elem(idx, val_ref+pert*::std::max(::std::abs(val_ref), 1.0));
       //evaluate at the perturbed point
       double f_pert;
       bret = interface_base.eval_f(nlp_transformations_.n_pre(), x_pert->local_data_const(), true, f_pert);

--- a/src/Optimization/hiopNlpFormulation.cpp
+++ b/src/Optimization/hiopNlpFormulation.cpp
@@ -757,6 +757,108 @@ bool hiopNlpFormulation::eval_grad_f(hiopVector& x, bool new_x, hiopVector& grad
   return bret;
 }
 
+void hiopNlpFormulation::run_derivative_checker()
+{
+  auto* it_hiop = new hiopIterate(this);
+  hiopVector* lambdas =
+    hiop::LinearAlgebraFactory::create_vector(options->GetString("mem_space"), n_cons_);
+  assert(n_cons_ == it_hiop->get_yc()->get_size() + it_hiop->get_yd()->get_size());
+
+  // finite difference (FD) check at initial point provided by the user 
+  hiopVector* x0_for_user = nlp_transformations_.apply_inv_to_x(*it_hiop->get_x(), true);
+
+  double* zL0_for_user = it_hiop->get_zl()->local_data();
+  double* zU0_for_user = it_hiop->get_zu()->local_data();
+  double* lambda_for_user = lambdas->local_data();
+  double* d_for_user = it_hiop->get_d()->local_data();
+
+  if(options->GetString("warm_start") == "yes") {
+    log->printf(hovError,
+                "Derivative check NOT supported for 'warm' starting points. Use 'get_starting_point' "
+                "instead to specifiy the point to which the derivatives should be checked.");
+    return;
+  }
+  bool duals_avail = false;
+  bool slacks_avail = false;
+  bool bret = interface_base.get_starting_point(nlp_transformations_.n_pre(),
+                                                n_cons_,
+                                                x0_for_user->local_data(),
+                                                duals_avail,
+                                                zL0_for_user,
+                                                zU0_for_user,
+                                                lambda_for_user,
+                                                slacks_avail,
+                                                d_for_user);
+  //if above failed, try the other user-provided starting point method
+  if(!bret) {
+    bret = interface_base.get_starting_point(nlp_transformations_.n_pre(), x0_for_user->local_data());
+  }
+  if(!bret) {
+    log->printf(hovError, "Derivate check failed due to failure(s) in user-provided starting point methods.");
+    return;
+  }
+  
+
+  hiopVector& x_ref = *x0_for_user;
+  const double pert = options->GetNumeric("derivative_check_perturbation");
+  const double derivative_check_tolerance = options->GetNumeric("derivative_check_tolerance");
+  const bool print_all = ( options->GetString("derivative_check_print_all") != "no" );
+  hiopVector* x_pert = x_ref.alloc_clone();
+
+  //
+  // gradient and Jacobian
+  //
+  if(options->GetString("derivative_check") == "first-order") {
+    std::cout << "Starting derivative checker for gradient ..." << std::endl;
+    double f_ref;
+    bret = interface_base.eval_f(nlp_transformations_.n_pre(), x_ref.local_data_const(), true, f_ref);
+    if(!bret) {
+      log->printf(hovError, "Derivative check error: in evaluating user objective.");
+      return;
+    }
+    
+    hiopVector* grad_exact = x_ref.alloc_clone();
+    bret = interface_base.eval_grad_f(nlp_transformations_.n_pre(),
+                                      x_ref.local_data_const(),
+                                      false,
+                                      grad_exact->local_data());
+    if(!bret) {
+      log->printf(hovError, "Derivative check error: in evaluating user gradient.");
+      return;
+    }
+    
+    // grad_fd = (f(x_pert) - f(x_ref)) / pert    
+    for(index_type idx=0; idx<nlp_transformations_.n_pre(); ++idx) {
+      x_pert->copyFrom(x_ref);
+      x_pert->local_data()[idx] += pert * ::std::max(::std::abs(x_ref.local_data()[idx]), 1.0);
+      //evaluate at the perturbed point
+      double f_pert;
+      bret = interface_base.eval_f(nlp_transformations_.n_pre(), x_pert->local_data_const(), true, f_pert);
+
+      const double grad_fd = (f_pert-f_ref)/pert;
+      const double grad_ex = grad_exact->local_data()[idx];
+      const double scale = ::std::max(grad_ex, ::std::max(::std::abs(grad_fd), derivative_check_tolerance));
+      double rel_error = ::std::abs(grad_fd - grad_ex) / scale;
+
+      char err_marker = rel_error > derivative_check_tolerance ? '!' : ' ';
+      if(rel_error > derivative_check_tolerance || print_all) {
+        std::cout << err_marker << " grad[" << std::setw(5) << idx << "]=" 
+                  << std::fixed << std::setprecision(14) << std::setw(21) << grad_ex << " " << grad_fd
+                  << " [" << std::scientific << std::setprecision(3) << std::setw(9) << rel_error << "]"
+                  << std::endl;
+      }
+      
+    }
+
+    std::cout << "Derivative checker for gradient finished: " << num_errs << " detected." << std::endl;
+    delete grad_exact;
+  }
+
+  delete x_pert;
+  delete it_hiop;
+  delete lambdas;
+}
+
 bool hiopNlpFormulation::get_starting_point(hiopVector& x0_for_hiop,
                                             bool& duals_avail,
                                             hiopVector& zL0_for_hiop,

--- a/src/Optimization/hiopNlpFormulation.cpp
+++ b/src/Optimization/hiopNlpFormulation.cpp
@@ -809,7 +809,9 @@ void hiopNlpFormulation::run_derivative_checker()
   // gradient and Jacobian
   //
   if(options->GetString("derivative_check") == "first-order") {
+    
     std::cout << "Starting derivative checker for gradient ..." << std::endl;
+    size_t num_errs = 0;
     double f_ref;
     bret = interface_base.eval_f(nlp_transformations_.n_pre(), x_ref.local_data_const(), true, f_ref);
     if(!bret) {
@@ -840,17 +842,23 @@ void hiopNlpFormulation::run_derivative_checker()
       const double scale = ::std::max(grad_ex, ::std::max(::std::abs(grad_fd), derivative_check_tolerance));
       double rel_error = ::std::abs(grad_fd - grad_ex) / scale;
 
-      char err_marker = rel_error > derivative_check_tolerance ? '!' : ' ';
-      if(rel_error > derivative_check_tolerance || print_all) {
-        std::cout << err_marker << " grad[" << std::setw(5) << idx << "]=" 
-                  << std::fixed << std::setprecision(14) << std::setw(21) << grad_ex << " " << grad_fd
-                  << " [" << std::scientific << std::setprecision(3) << std::setw(9) << rel_error << "]"
+      const bool b_err = rel_error > derivative_check_tolerance;
+      char err_marker = ' ';
+      if(b_err) {
+        err_marker = '!';
+        num_errs++;
+      }
+      if(b_err || print_all) {
+        std::cout << err_marker << " grad[" << std::setw(5) << idx << "] "
+                  << "user " << std::fixed << std::setprecision(14) << std::setw(21) << grad_ex << "  "
+                  << "fd " << std::fixed << std::setprecision(14) << std::setw(21) << grad_fd
+                  << " relerr [" << std::scientific << std::setprecision(3) << std::setw(9) << rel_error << "]"
                   << std::endl;
       }
       
     }
 
-    std::cout << "Derivative checker for gradient finished: " << num_errs << " detected." << std::endl;
+    std::cout << "Derivative checker for gradient finished: " << num_errs << " errors detected." << std::endl;
     delete grad_exact;
   }
 

--- a/src/Optimization/hiopNlpFormulation.hpp
+++ b/src/Optimization/hiopNlpFormulation.hpp
@@ -351,6 +351,14 @@ protected:
   /// @brief internal NLP transformations that relaxes the bounds
   hiopBoundsRelaxer* relax_bounds_;
 
+  /**
+   * @brief Temporary disable all NLP transformations in the 'eval' functions.
+   * 
+   * Used by derivative checker to disable NLP transformations used by NlpFormulation's eval functions 
+   * and to allow working dirrectly with user NLP functions.
+   */
+  bool disable_nlp_transformations_;
+  
 #ifdef HIOP_USE_MPI
   // inter-process distribution of vectors
   index_type* vec_distrib_;

--- a/src/Optimization/hiopNlpFormulation.hpp
+++ b/src/Optimization/hiopNlpFormulation.hpp
@@ -164,11 +164,23 @@ public:
   virtual hiopVector* alloc_dual_ineq_vec() const;
   virtual hiopVector* alloc_dual_vec() const;
   /* the implementation of the next two methods depends both on the interface and on the formulation */
+
+  /// @brief Allocate Jacobian of equalities in the internal (primal) size.
   virtual hiopMatrix* alloc_Jac_c() = 0;
+  /// @brief Allocate Jacobian of inequalities in the internal (primal) size.
   virtual hiopMatrix* alloc_Jac_d() = 0;
+  /// @brief Allocate Jacobian of constraints in the internal (primal) size.
   virtual hiopMatrix* alloc_Jac_cons() = 0;
+  /// @brief Allocate Jacobian of equalities in the user (primal) size.
+  virtual hiopMatrix* alloc_Jac_c_user() = 0;
+  /// @brief Allocate Jacobian of inequalities in the user (primal) size.
+  virtual hiopMatrix* alloc_Jac_d_user() = 0;
+  /// @brief Allocate Jacobian of constraints in the user (primal) size.
+  virtual hiopMatrix* alloc_Jac_cons_user() = 0;
+
   virtual hiopMatrix* alloc_Hess_Lagr() = 0;
 
+  
   virtual void user_callback_solution(hiopSolveStatus status,
                                       const hiopVector& x,
                                       hiopVector& z_L,
@@ -283,7 +295,12 @@ public:
   inline MPI_Comm get_comm() const { return comm_; }
   inline int get_rank() const { return rank_; }
   inline int get_num_ranks() const { return num_ranks_; }
-  inline index_type* getVecDistInfo() { return vec_distrib_; }
+
+  /// @brief Returns inter-process distribution of internal (primal) vectors.  
+  inline index_type* get_vector_distrib()
+  {
+    return vec_distrib_;
+  }
 #endif
 protected:
   /* Preprocess bounds in a form supported by the NLP formulation. Returns counts of
@@ -341,16 +358,21 @@ protected:
 
   /**
    * @brief Internal NLP transformations that supports fixing and relaxing variables as well as
-   * problem rescalings.
+   * problem rescaling(s).
    */
   hiopNlpTransformations nlp_transformations_;
 
-  // internal NLP transformations (currently gradient scaling implemented)
+  // @brief Gradient scaling NLP transformation
   hiopNLPObjGradScaling* nlp_scaling_;
 
-  /// @brief internal NLP transformations that relaxes the bounds
+  /// @brief NLP transformation that relaxes the bounds.
   hiopBoundsRelaxer* relax_bounds_;
 
+  /// @brief NLP transformation that removes fixed variables.
+  hiopFixedVarsRemover* fixed_vars_remover_;
+
+  /// @brief NLP transformation that relaxes bounds for the case when fixed variables are detected.
+  hiopFixedVarsRelaxer* fixed_vars_relaxer_;
   /**
    * @brief Temporary disable all NLP transformations in the 'eval' functions.
    * 
@@ -360,7 +382,7 @@ protected:
   bool disable_nlp_transformations_;
   
 #ifdef HIOP_USE_MPI
-  // inter-process distribution of vectors
+  // Inter-process distribution of vectors used internally, may differ from the user's one.
   index_type* vec_distrib_;
 #endif
 
@@ -452,10 +474,14 @@ public:
   virtual hiopMatrixDense* alloc_Jac_c();
   virtual hiopMatrixDense* alloc_Jac_d();
   virtual hiopMatrixDense* alloc_Jac_cons();
+  virtual hiopMatrixDense* alloc_Jac_c_user();
+  virtual hiopMatrixDense* alloc_Jac_d_user();
+  virtual hiopMatrixDense* alloc_Jac_cons_user();
+
   // returns HessianDiagPlusRowRank which (fakely) inherits from hiopMatrix
   virtual hiopMatrix* alloc_Hess_Lagr();
 
-  /* this is in general for a dense matrix with n_vars cols and a small number of
+  /* General method to allocate a dense matrix with n_vars cols and a small number of
    * 'nrows' rows. The second argument indicates how much total memory should the
    * matrix (pre)allocate.
    */
@@ -528,6 +554,39 @@ public:
     return new hiopMatrixSymBlockDiagMDS(nx_sparse, nx_dense, nnz_sparse_Hess_Lagr_SS, options->GetString("mem_space"));
   }
 
+  virtual hiopMatrix* alloc_Jac_c_user()
+  {
+    if(fixed_vars_remover_) {
+      assert(false && "at this moment we do not support removal of fixed variables with MDS problem structure.");
+      return nullptr;
+    }
+    assert(n_vars_ == nx_sparse + nx_dense);
+    return new hiopMatrixMDS(n_cons_eq_, nx_sparse, nx_dense, nnz_sparse_Jaceq, options->GetString("mem_space"));
+  }
+  virtual hiopMatrix* alloc_Jac_d_user()
+  {
+    if(fixed_vars_remover_) {
+      assert(false && "at this moment we do not support removal of fixed variables with MDS problem structure.");
+      return nullptr;
+    }
+    assert(n_vars_ == nx_sparse + nx_dense);
+    return new hiopMatrixMDS(n_cons_ineq_, nx_sparse, nx_dense, nnz_sparse_Jacineq, options->GetString("mem_space"));
+  }
+  virtual hiopMatrix* alloc_Jac_cons_user()
+  {
+    if(fixed_vars_remover_) {
+      assert(false && "at this moment we do not support removal of fixed variables with MDS problem structure.");
+      return nullptr;
+    }
+    assert(n_vars_ == nx_sparse + nx_dense);
+    return new hiopMatrixMDS(n_cons_,
+                             nx_sparse,
+                             nx_dense,
+                             nnz_sparse_Jaceq + nnz_sparse_Jacineq,
+                             options->GetString("mem_space"));
+  }
+
+  
   /** const accessors */
   virtual size_type nx_sp() const { return nx_sparse; }
   virtual size_type nx_de() const { return nx_dense; }
@@ -588,7 +647,6 @@ public:
                                                       n_cons_eq_,
                                                       n_vars_,
                                                       nnz_sparse_Jaceq_);
-    // return new hiopMatrixSparseTriplet(n_cons_eq_, n_vars_, nnz_sparse_Jaceq_);
   }
   virtual hiopMatrix* alloc_Jac_d()
   {
@@ -596,7 +654,6 @@ public:
                                                       n_cons_ineq_,
                                                       n_vars_,
                                                       nnz_sparse_Jacineq_);
-    // return new hiopMatrixSparseTriplet(n_cons_ineq_, n_vars_, nnz_sparse_Jacineq_);
   }
   virtual hiopMatrix* alloc_Jac_cons()
   {
@@ -604,13 +661,46 @@ public:
                                                       n_cons_,
                                                       n_vars_,
                                                       nnz_sparse_Jaceq_ + nnz_sparse_Jacineq_);
-    // return new hiopMatrixSparseTriplet(n_cons_, n_vars_, nnz_sparse_Jaceq_ + nnz_sparse_Jacineq_);
   }
   virtual hiopMatrix* alloc_Hess_Lagr()
   {
     return LinearAlgebraFactory::create_matrix_sym_sparse(options->GetString("mem_space"), n_vars_, nnz_sparse_Hess_Lagr_);
-    // return new hiopMatrixSymSparseTriplet(n_vars_, nnz_sparse_Hess_Lagr_);
   }
+
+  virtual hiopMatrix* alloc_Jac_c_user()
+  {
+    if(fixed_vars_remover_) {
+      assert(false && "at this moment we do not support removal of fixed variables for sparse problems.");
+      return nullptr;
+    }
+    return LinearAlgebraFactory::create_matrix_sparse(options->GetString("mem_space"),
+                                                      n_cons_eq_,
+                                                      n_vars_,
+                                                      nnz_sparse_Jaceq_);
+  }
+  virtual hiopMatrix* alloc_Jac_d_user()
+  {
+    if(fixed_vars_remover_) {
+      assert(false && "at this moment we do not support removal of fixed variables for sparse problems.");
+      return nullptr;
+    }
+    return LinearAlgebraFactory::create_matrix_sparse(options->GetString("mem_space"),
+                                                      n_cons_ineq_,
+                                                      n_vars_,
+                                                      nnz_sparse_Jacineq_);
+  }
+  virtual hiopMatrix* alloc_Jac_cons_user()
+  {
+    if(fixed_vars_remover_) {
+      assert(false && "at this moment we do not support removal of fixed variables for sparse problems.");
+      return nullptr;
+    }
+    return LinearAlgebraFactory::create_matrix_sparse(options->GetString("mem_space"),
+                                                      n_cons_,
+                                                      n_vars_,
+                                                      nnz_sparse_Jaceq_ + nnz_sparse_Jacineq_);
+  }
+  
   virtual size_type nx() const { return n_vars_; }
 
   // not inherited from NlpFormulation

--- a/src/Optimization/hiopNlpFormulation.hpp
+++ b/src/Optimization/hiopNlpFormulation.hpp
@@ -125,9 +125,13 @@ public:
    */
   void run_derivative_checker();
 protected:
-  // calls specific hiopInterfaceXXX::eval_Jac_cons and deals with specializations of hiopMatrix arguments
+  ///@brief Second-order derivative checker specialized to NLP formulations
+  virtual size_type run_derivative_checker_order2(hiopVector& x_ref,
+                                               hiopVector& grad_ref,
+                                               hiopMatrix& Jacc_ref,
+                                               hiopMatrix& Jacd_ref) = 0;
+  // Calls specific hiopInterfaceXXX::eval_Jac_cons and deals with specializations of hiopMatrix arguments
   virtual bool eval_Jac_c_d_interface_impl(hiopVector& x, bool new_x, hiopMatrix& Jac_c, hiopMatrix& Jac_d) = 0;
-
 public:
   virtual bool eval_Hess_Lagr(const hiopVector& x,
                               bool new_x,
@@ -163,7 +167,8 @@ public:
   virtual hiopVector* alloc_dual_eq_vec() const;
   virtual hiopVector* alloc_dual_ineq_vec() const;
   virtual hiopVector* alloc_dual_vec() const;
-  /* the implementation of the next two methods depends both on the interface and on the formulation */
+  
+  /* the implementation of the next methods depends both on the interface and on the formulation */
 
   /// @brief Allocate Jacobian of equalities in the internal (primal) size.
   virtual hiopMatrix* alloc_Jac_c() = 0;
@@ -451,6 +456,16 @@ public:
   virtual bool eval_Jac_d(hiopVector& x, bool new_x, double* Jac_d);
 
 protected:
+
+  size_type run_derivative_checker_order2(hiopVector& x_ref,
+                                          hiopVector& grad_ref,
+                                          hiopMatrix& Jacc_ref,
+                                          hiopMatrix& Jacd_ref)
+  {
+    log->printf(hovSummary, "Derivative checks of (user) Hessian is skipped since it is not provided by user.\n");
+    return 0;
+  }
+  
   // calls specific hiopInterfaceXXX::eval_Jac_cons and deals with specializations of
   // hiopMatrix arguments
   virtual bool eval_Jac_c_d_interface_impl(hiopVector& x, bool new_x, hiopMatrix& Jac_c, hiopMatrix& Jac_d);
@@ -513,7 +528,20 @@ public:
   virtual bool eval_Jac_c(hiopVector& x, bool new_x, hiopMatrix& Jac_c);
   virtual bool eval_Jac_d(hiopVector& x, bool new_x, hiopMatrix& Jac_d);
 
+  void run_derivative_checker()
+  {
+    hiopNlpFormulation::run_derivative_checker();
+  }
 protected:
+  size_type run_derivative_checker_order2(hiopVector& x_ref,
+                                          hiopVector& grad_ref,
+                                          hiopMatrix& Jacc_ref,
+                                          hiopMatrix& Jacd_ref)
+  {
+    log->printf(hovWarning, "Checks for second-order derivatives are not implemented for MDS and are skipped.\n");
+    return 0;
+  }
+
   // calls specific hiopInterfaceXXX::eval_Jac_cons and deals with specializations of hiopMatrix arguments
   virtual bool eval_Jac_c_d_interface_impl(hiopVector& x, bool new_x, hiopMatrix& Jac_c, hiopMatrix& Jac_d);
 
@@ -626,9 +654,16 @@ public:
   virtual bool eval_Jac_c(hiopVector& x, bool new_x, hiopMatrix& Jac_c);
   virtual bool eval_Jac_d(hiopVector& x, bool new_x, hiopMatrix& Jac_d);
 
+  void run_derivative_checker();
+
 protected:
   // calls specific hiopInterfaceXXX::eval_Jac_cons and deals with specializations of hiopMatrix arguments
   virtual bool eval_Jac_c_d_interface_impl(hiopVector& x, bool new_x, hiopMatrix& Jac_c, hiopMatrix& Jac_d);
+
+  size_type run_derivative_checker_order2(hiopVector& x_ref,
+                                          hiopVector& grad_ref,
+                                          hiopMatrix& Jacc_ref,
+                                          hiopMatrix& Jacd_ref);
 
 public:
   virtual bool eval_Hess_Lagr(const hiopVector& x,

--- a/src/Optimization/hiopNlpFormulation.hpp
+++ b/src/Optimization/hiopNlpFormulation.hpp
@@ -118,6 +118,12 @@ public:
   virtual bool eval_Jac_d(hiopVector& x, bool new_x, hiopMatrix& Jac_d) = 0;
   virtual bool eval_Jac_c_d(hiopVector& x, bool new_x, hiopMatrix& Jac_c, hiopMatrix& Jac_d);
 
+  /**
+   * @brief Runs a (slow) derivative checker using finite differences, controlled by user options.
+   *
+   * @pre Assumes option 'derivative_checker' is set to 'first-order' or 'second-order'.
+   */
+  void run_derivative_checker();
 protected:
   // calls specific hiopInterfaceXXX::eval_Jac_cons and deals with specializations of hiopMatrix arguments
   virtual bool eval_Jac_c_d_interface_impl(hiopVector& x, bool new_x, hiopMatrix& Jac_c, hiopMatrix& Jac_d) = 0;

--- a/src/Optimization/hiopNlpTransforms.cpp
+++ b/src/Optimization/hiopNlpTransforms.cpp
@@ -98,14 +98,14 @@ hiopFixedVarsRemover::~hiopFixedVarsRemover()
 
 #ifdef HIOP_USE_MPI
 /* saves the inter-process distribution of (primal) vectors distribution */
-void hiopFixedVarsRemover::setFSVectorDistrib(index_type* vec_distrib_in, int num_ranks)
+void hiopFixedVarsRemover::set_fs_vector_distrib(index_type* vec_distrib_in, int num_ranks)
 {
   assert(vec_distrib_in != NULL);
   fs_vec_distrib.resize(num_ranks + 1);
   std::copy(vec_distrib_in, vec_distrib_in + num_ranks + 1, fs_vec_distrib.begin());
 };
 /* allocates and returns the reduced-space column partitioning to be used internally by HiOp */
-index_type* hiopFixedVarsRemover::allocRSVectorDistrib()
+index_type* hiopFixedVarsRemover::alloc_rs_vector_distrib()
 {
   size_type nlen = fs_vec_distrib.size();  // nlen==nranks+1
   assert(nlen >= 1);
@@ -118,6 +118,7 @@ index_type* hiopFixedVarsRemover::allocRSVectorDistrib()
 
 #ifdef HIOP_USE_MPI
   int ierr;
+  MPI_Comm comm = nlp_->get_comm();
 #ifdef HIOP_DEEPCHECKS
   int nRanks = -1;
   ierr = MPI_Comm_size(comm, &nRanks);
@@ -172,26 +173,10 @@ bool hiopFixedVarsRemover::setupConstraintsPart(const int& neq, const int& nineq
   assert(Jacc_fs == NULL && "should not be allocated at this point");
   assert(Jacd_fs == NULL && "should not be allocated at this point");
 
-#ifdef HIOP_USE_MPI
-  if(fs_vec_distrib.size()) {
-    Jacc_fs = LinearAlgebraFactory::create_matrix_dense(nlp_->options->GetString("mem_space"),
-                                                        neq,
-                                                        n_fs,
-                                                        fs_vec_distrib.data(),
-                                                        comm);
-    Jacd_fs = LinearAlgebraFactory::create_matrix_dense(nlp_->options->GetString("mem_space"),
-                                                        nineq,
-                                                        n_fs,
-                                                        fs_vec_distrib.data(),
-                                                        comm);
-  } else {
-    Jacc_fs = LinearAlgebraFactory::create_matrix_dense(nlp_->options->GetString("mem_space"), neq, n_fs, NULL, comm);
-    Jacd_fs = LinearAlgebraFactory::create_matrix_dense(nlp_->options->GetString("mem_space"), nineq, n_fs, NULL, comm);
-  }
-#else
-  Jacc_fs = LinearAlgebraFactory::create_matrix_dense(nlp_->options->GetString("mem_space"), neq, n_fs);
-  Jacd_fs = LinearAlgebraFactory::create_matrix_dense(nlp_->options->GetString("mem_space"), nineq, n_fs);
-#endif
+  Jacc_fs = dynamic_cast<hiopMatrixDense*>(nlp_->alloc_Jac_c_user());
+  assert(neq == Jacc_fs->m());
+  Jacd_fs = dynamic_cast<hiopMatrixDense*>(nlp_->alloc_Jac_d_user());
+  assert(nineq == Jacd_fs->m());
   return true;
 }
 

--- a/src/Optimization/hiopNlpTransforms.hpp
+++ b/src/Optimization/hiopNlpTransforms.hpp
@@ -146,6 +146,10 @@ protected:
  *
  * applyInvToXXX: takes XXX as seen by the user calling code and returns the corresponding
  * reduced-space XXX object.
+ * 
+ * This class currently works only for the quasi-Newton solver and NlpDenseConstraints formulation. 
+ * Additional work is needed for NlpSparse formulation to source the transformations to sparse linear
+ * algebra matrix classes.
  */
 class hiopFixedVarsRemover : public hiopNlpTransformation
 {
@@ -263,11 +267,17 @@ public:
   bool setupDecisionVectorPart();
   bool setupConstraintsPart(const int& neq, const int& nineq);
 #ifdef HIOP_USE_MPI
-  /* saves the inter-process distribution of (primal) vectors distribution */
-  void setFSVectorDistrib(index_type* vec_distrib, int num_ranks);
-  /* allocates and returns the reduced-space column partitioning to be used internally by HiOp */
-  index_type* allocRSVectorDistrib();
-  inline void setMPIComm(const MPI_Comm& commIn) { comm = commIn; }
+  /// @brief Saves the inter-process distribution of user/fs (primal) vectors.
+  void set_fs_vector_distrib(index_type* vec_distrib, int num_ranks);
+
+  /// @brief Returns the inter-process distribution of user/fs (primal) vectors.
+  inline index_type* get_fs_vector_distrib()
+  {
+    return fs_vec_distrib.data();
+  }
+  
+  /// @brief Computes, allocates, and returns the distribution of reduced-space/internal (primal) vectors.
+  index_type* alloc_rs_vector_distrib();
 #endif
   /* "copies" a full space vector to a reduced space vector */
   void copyFsToRs(const hiopVector& fsVec, hiopVector& rsVec);
@@ -287,10 +297,6 @@ public:
   }
 
 protected:
-#if 0  // old interface
-  void applyToArray   (const double* vec_rs, double* vec_fs);
-  void applyInvToArray(const double* vec_fs, double* vec_rs);
-#endif
   void apply_inv_to_vector(const hiopVector* vec_rs, hiopVector* vec_fs);
   void apply_to_vector(const hiopVector* vec_fs, hiopVector* vec_rs);
 
@@ -308,15 +314,21 @@ protected:
 
   // working buffer used to hold the full-space (user's) vector of decision variables and other optimiz objects
   hiopVector *x_fs, *grad_fs;
-  // working buffers for the full-space Jacobians
-  hiopMatrixDense *Jacc_fs, *Jacd_fs;
+  // Full-space Jacobian of equality constraints
+  hiopMatrixDense* Jacc_fs;
+  // Full-space Jacobian of inequality constraints
+  hiopMatrixDense* Jacd_fs;
 
+  // Reference to reduced-space Jacobian of equality constraints, part of the NlpFormulation class
   hiopMatrixDense* Jacc_rs_ref;
+  // Reference to reduced-space Jacobian of inequality constraints, part of the NlpFormulation class
   hiopMatrixDense* Jacd_rs_ref;
 
-  // a copy of the lower and upper bounds provided by user
-  hiopVector *xl_fs, *xu_fs;
-  // indexes corresponding to fixed variables (local indexes)
+  // Copy of the lower bounds provided by user
+  hiopVector* xl_fs;
+  // Copy of the upper bounds provided by user
+  hiopVector* xu_fs;
+  // Indexes corresponding to fixed variables (local)
   std::vector<int> fs2rs_idx_map;
 
   // references to reduced-space buffers - returned in applyInvXXX
@@ -324,7 +336,6 @@ protected:
   hiopVector* grad_rs_ref;
 #ifdef HIOP_USE_MPI
   std::vector<index_type> fs_vec_distrib;
-  MPI_Comm comm;
 #endif
 };
 
@@ -338,10 +349,16 @@ public:
                        const size_type& numFixedVars_local);
   virtual ~hiopFixedVarsRelaxer();
 
-  /* number of vars in the NLP after the tranformation */
-  inline size_type n_post() { /*assert(xl_copy);*/ return n_vars; }  // xl_copy->get_size(); }
-  /* number of vars in the NLP to which the tranformation is to be applied */
-  virtual size_type n_pre() { /*assert(xl_copy);*/ return n_vars; }  // xl_copy->get_size(); }
+  /// Number of vars in the NLP after the transformation 
+  inline size_type n_post()
+  {
+    return n_vars;
+  } 
+  /// Number of vars in the NLP to which the transformation is to be applied 
+  virtual size_type n_pre()
+  {
+    return n_vars;
+  }
 
   inline size_type n_post_local() { return n_vars_local; }  // xl_copy->get_local_size(); }
   inline size_type n_pre_local() { return n_vars_local; }   // xl_copy->get_local_size(); }
@@ -566,11 +583,25 @@ public:
   inline void setUserNlpNumVars(const size_type& n_vars) { n_vars_usernlp = n_vars; }
   inline void setUserNlpNumLocalVars(const size_type& n_vars) { n_vars_local_usernlp = n_vars; }
   inline void append(hiopNlpTransformation* t) { list_trans_.push_back(t); }
-  inline void clear()
+  void clear()
   {
     std::list<hiopNlpTransformation*>::iterator it;
     for(it = list_trans_.begin(); it != list_trans_.end(); it++) delete(*it);
     list_trans_.clear();
+  }
+
+  /// @brief Remove and deallocate NLP transformation
+  void remove(hiopNlpTransformation* t)
+  {
+    std::list<hiopNlpTransformation*>::iterator it = list_trans_.begin();
+    while(it!=list_trans_.end()) {
+      if(t==*it) {
+        delete t;
+        list_trans_.erase(it);
+        return;
+      }
+    }
+    assert(false && "the transformation should be present in the list, but it is not");
   }
 
   /* number of vars in the NLP after the tranformation */

--- a/src/Utils/hiopOptions.cpp
+++ b/src/Utils/hiopOptions.cpp
@@ -734,12 +734,13 @@ void hiopOptionsNLP::register_options()
     register_str_option("fixed_var",
                         "relax",
                         range,
-                        "Treatment of fixed variables: 'remove' from the problem, 'relax' bounds "
+                        "Treatment of fixed variables: 'remove' from the problem, 'relax' all bounds "
                         "by 'fixed_var_perturb', or 'none', in which case the HiOp will terminate "
                         "with an error message if fixed variables are detected (default 'relax'). "
                         "Value 'remove' is available only when 'compute_mode' is 'hybrid' or 'cpu'. "
-                        "A nonzero value of 'bound_relax_perturb' option will trigger a different bounds "
-                        "relaxation strategy, which will ignore value of 'fixed_var_perturb'.");
+                        "A nonzero value of 'bound_relax_perturb' option or the use of 'elastic_mode' "
+                        "option will trigger different bounds relaxations strategies that will "
+                        "ignore value of 'fixed_var_perturb'.");
     register_num_option("fixed_var_tolerance",
                         1e-15,
                         1e-30,
@@ -1147,8 +1148,7 @@ void hiopOptionsNLP::register_options()
                         "'tighten_bound' tightens the bounds when `mu` changes; "
                         "'correct_it' tightens the bounds and corrects the slacks and slack duals when `mu` changes; "
                         "'correct_it_adjust_bound' tightens the bounds, corrects the slacks and slack duals, "
-                        "and adjusts the bounds again from the modified iterate. Requires a positive value for '"
-                        "option 'bound_relax_perturb'.");
+                        "and adjusts the bounds again from the modified iterate.");
 
     range = {"mu_projected", "mu_scaled"};
     register_str_option("elastic_bound_strategy",

--- a/src/Utils/hiopOptions.cpp
+++ b/src/Utils/hiopOptions.cpp
@@ -732,12 +732,14 @@ void hiopOptionsNLP::register_options()
     range[1] = "relax";
     range[2] = "none";
     register_str_option("fixed_var",
-                        "none",
+                        "relax",
                         range,
                         "Treatment of fixed variables: 'remove' from the problem, 'relax' bounds "
                         "by 'fixed_var_perturb', or 'none', in which case the HiOp will terminate "
-                        "with an error message if fixed variables are detected (default 'none'). "
-                        "Value 'remove' is available only when 'compute_mode' is 'hybrid' or 'cpu'.");
+                        "with an error message if fixed variables are detected (default 'relax'). "
+                        "Value 'remove' is available only when 'compute_mode' is 'hybrid' or 'cpu'. "
+                        "A nonzero value of 'bound_relax_perturb' option will trigger a different bounds "
+                        "relaxation strategy, which will ignore value of 'fixed_var_perturb'.");
     register_num_option("fixed_var_tolerance",
                         1e-15,
                         1e-30,
@@ -1145,7 +1147,8 @@ void hiopOptionsNLP::register_options()
                         "'tighten_bound' tightens the bounds when `mu` changes; "
                         "'correct_it' tightens the bounds and corrects the slacks and slack duals when `mu` changes; "
                         "'correct_it_adjust_bound' tightens the bounds, corrects the slacks and slack duals, "
-                        "and adjusts the bounds again from the modified iterate");
+                        "and adjusts the bounds again from the modified iterate. Requires a positive value for '"
+                        "option 'bound_relax_perturb'.");
 
     range = {"mu_projected", "mu_scaled"};
     register_str_option("elastic_bound_strategy",

--- a/src/Utils/hiopOptions.cpp
+++ b/src/Utils/hiopOptions.cpp
@@ -1291,6 +1291,33 @@ void hiopOptionsNLP::register_options()
         "specified by 'checkpoint_file' option.";
     register_str_option("checkpoint_load_on_start", range[1], range, msgclos);
   }
+
+  //
+  // Derivative checker
+  // 
+  {
+    vector<string> range = {"no", "first-order", "second-order"};
+    constexpr char msg_der[] =
+      "Check user-provided derivatives using finite differences and report comparison. "
+      "";
+    register_str_option("derivative_check", range[0], range, msg_der);
+
+    constexpr char msg_pert[] =
+      "Finite difference perturbation of 'x' variable entries, relative to entry's values.";
+    register_num_option("derivative_check_perturbation", 1e-8, 1e-20, 1000, msg_pert);
+
+    constexpr char msg_tol[] =
+      "Tolerance for marking a mismatch between user-provided derivative and finite difference, "
+      "relative to derivative value provided by the user.";
+    register_num_option("derivative_check_tolerance", 1e-4, 1e-20, 1000, msg_tol);
+      
+    range = {"no", "yes"};
+    constexpr char msg_printall[] =
+      "Print the comparison of user-provided derivatives and finite difference approximation "
+      "for all, including when no mismatch occurs.";
+    register_str_option("derivative_check_print_all", range[0], range, msg_printall);
+
+  }
 }
 void hiopOptionsNLP::ensure_consistence()
 {

--- a/src/hiopbbpy/opt/boalgorithm.py
+++ b/src/hiopbbpy/opt/boalgorithm.py
@@ -135,7 +135,7 @@ class BOAlgorithm(BOAlgorithmBase):
         acqf_obj_callback = lambda x: float(np.array(acqf.evaluate(np.atleast_2d(x))).flat[0])
         acqf_callback = {'obj': acqf_obj_callback}
         if acqf.has_gradient == True:
-            acqf_grad_callback = lambda x: np.array(acqf.eval_g(np.atleast_2d(x)))
+            acqf_grad_callback = lambda x: np.array(acqf.eval_g(np.atleast_2d(x))).flatten()
             acqf_callback['grad'] = acqf_grad_callback
 
         x_all = []

--- a/tests/LinAlg/vectorTests.hpp
+++ b/tests/LinAlg/vectorTests.hpp
@@ -136,6 +136,47 @@ public:
     return reduceReturn(fail, &x);
   }
 
+  /// Test set_elem method of HiOp vector
+  bool vector_set_elem(hiop::hiopVector& x, const int rank)
+  {
+    global_ordinal_type sz = x.get_size();
+    if(sz==0) {
+      return true;
+    }
+
+    //first set to zero, then set select entries to one and two
+    x.setToConstant(zero);
+    int fail = 0;
+    if(sz==1) {
+      x.set_elem(0, three);
+    } else {
+      const global_ordinal_type idx1 = 1;
+      const global_ordinal_type idx2 = sz-1;
+      
+      x.set_elem(idx1, two);
+      x.set_elem(idx2, one);
+    }
+    const real_type nrm1 = x.onenorm();
+    fail = (std::abs(nrm1-three) > std::numeric_limits<real_type>::epsilon());
+    return reduceReturn(fail, &x);
+  }
+
+  /// Test get_elem of HiOpVector
+  bool vector_get_elem(hiop::hiopVector& x, const int rank)
+  {
+    global_ordinal_type sz = x.get_size();
+    if(sz==0) {
+      return true;
+    }
+
+    x.setToConstant(quarter);
+
+    int fail = 0;
+    fail += (x.get_elem(0)!=quarter);
+    fail += (x.get_elem(sz-1)!=quarter);
+    return reduceReturn(fail, &x);
+  }
+  
   /// Test set_to_random_uniform method of hiop vector implementation
   bool vector_set_to_random_uniform(hiop::hiopVector& x, const int rank)
   {
@@ -147,12 +188,7 @@ public:
     }
 
     x.set_to_random_uniform(one, two);
-
     fail = verifyAnswer(&x, one, two);
-    if(fail > 0) {
-      std::cout << "num fails = " << fail << std::endl;
-    }
-
     printMessage(fail, __func__, rank);
 
     return reduceReturn(fail, &x);

--- a/tests/LinAlg/vectorTests.hpp
+++ b/tests/LinAlg/vectorTests.hpp
@@ -139,41 +139,40 @@ public:
   /// Test set_elem method of HiOp vector
   bool vector_set_elem(hiop::hiopVector& x, const int rank)
   {
-    global_ordinal_type sz = x.get_size();
-    if(sz==0) {
-      return true;
-    }
-
-    //first set to zero, then set select entries to one and two
-    x.setToConstant(zero);
     int fail = 0;
-    if(sz==1) {
-      x.set_elem(0, three);
-    } else {
-      const global_ordinal_type idx1 = 1;
-      const global_ordinal_type idx2 = sz-1;
+    global_ordinal_type sz = x.get_size();
+    if(sz>0) {
+
+      //first set to zero, then set select entries to one and two
+      x.setToConstant(zero);
       
-      x.set_elem(idx1, two);
-      x.set_elem(idx2, one);
+      if(sz==1) {
+        x.set_elem(0, three);
+      } else {
+        const global_ordinal_type idx1 = 1;
+        const global_ordinal_type idx2 = sz-1;
+        
+        x.set_elem(idx1, two);
+        x.set_elem(idx2, one);
+      }
+      const real_type nrm1 = x.onenorm();
+      fail = (std::abs(nrm1-three) > std::numeric_limits<real_type>::epsilon());
     }
-    const real_type nrm1 = x.onenorm();
-    fail = (std::abs(nrm1-three) > std::numeric_limits<real_type>::epsilon());
+    printMessage(fail, __func__);
     return reduceReturn(fail, &x);
   }
 
-  /// Test get_elem of HiOpVector
+  /// Test get_elem of HiOp vector
   bool vector_get_elem(hiop::hiopVector& x, const int rank)
   {
-    global_ordinal_type sz = x.get_size();
-    if(sz==0) {
-      return true;
-    }
-
-    x.setToConstant(quarter);
-
     int fail = 0;
-    fail += (x.get_elem(0)!=quarter);
-    fail += (x.get_elem(sz-1)!=quarter);
+    global_ordinal_type sz = x.get_size();
+    if(sz>0) {
+      x.setToConstant(quarter);
+      fail += (x.get_elem(0)!=quarter);
+      fail += (x.get_elem(sz-1)!=quarter);
+    }
+    printMessage(fail, __func__);
     return reduceReturn(fail, &x);
   }
   

--- a/tests/testVector.cpp
+++ b/tests/testVector.cpp
@@ -254,6 +254,8 @@ int runTests(const char* mem_space, MPI_Comm comm)
   fail += test.vectorSetToZero(*x, rank);
   fail += test.vectorSetToConstant(*x, rank);
   fail += test.vector_set_to_random_uniform(*x, rank);
+  fail += test.vector_set_elem(*x, rank);
+  fail += test.vector_get_elem(*x, rank);
   fail += test.vectorSetToConstant_w_patternSelect(*x, *y, rank);
   fail += test.vectorCopyFrom(*x, *y, rank);
   fail += test.vectorCopyTo(*x, *y, rank);


### PR DESCRIPTION
Tests user-provided derivatives using finite differences. Currently only first-order derivatives are checked. Hessians will be finished in a follow up PR. 

Other issues addressed 
 - clarified relationship between `relax_bounds` and `elastic_mode`
 - added a disabler of the NLP transformations in NLP problem formulations to allow finite differencing directly on user functions
 - bugs and some code cleaning related to handling of fixed variables
 - added getters and setters for vector classes.

Note: Hessian checks will not be supported for MDS problems. 

Partially addresses issue #683