### PR TITLE
Reduce code duplication by removing useless overrides

### DIFF
--- a/src/LinAlg/hiopMatrixDenseRaja.hpp
+++ b/src/LinAlg/hiopMatrixDenseRaja.hpp
@@ -251,15 +251,12 @@ public:
 #endif
   virtual size_type get_local_size_n() const { return n_local_; }
   virtual size_type get_local_size_m() const { return m_local_; }
-  virtual MPI_Comm get_mpi_comm() const { return comm_; }
 
   inline double* local_data_host() const { return data_host_; }
   double* local_data() { return data_dev_; }
   double* local_data_const() const { return data_dev_; }
 
 public:
-  virtual size_type m() const { return m_local_; }
-  virtual size_type n() const { return n_global_; }
 #ifdef HIOP_DEEPCHECKS
   virtual bool assertSymmetry(double tol = 1e-16) const;
 #endif

--- a/src/LinAlg/hiopMatrixDenseRowMajor.hpp
+++ b/src/LinAlg/hiopMatrixDenseRowMajor.hpp
@@ -223,7 +223,6 @@ public:
 #endif
   virtual size_type get_local_size_n() const { return n_local_; }
   virtual size_type get_local_size_m() const { return m_local_; }
-  virtual MPI_Comm get_mpi_comm() const { return comm_; }
 
   double* local_data_const() const { return M_[0]; }
   double* local_data() { return M_[0]; }
@@ -233,8 +232,6 @@ protected:
   inline double** get_M() { return M_; }
 
 public:
-  virtual size_type m() const { return m_local_; }
-  virtual size_type n() const { return n_global_; }
 #ifdef HIOP_DEEPCHECKS
   virtual bool assertSymmetry(double tol = 1e-16) const;
 #endif

--- a/src/LinAlg/hiopMatrixRajaSparseTriplet.hpp
+++ b/src/LinAlg/hiopMatrixRajaSparseTriplet.hpp
@@ -465,8 +465,6 @@ public:
   virtual bool assertSymmetry(double tol = 1e-16) const { return true; }
 #endif
 
-  virtual void extract_diagonal(hiopVector& diag_out) const { assert(false && "not yet implemented"); }
-
   virtual size_type numberOfOffDiagNonzeros() const;
 
   virtual void set_Jac_FR(const hiopMatrixSparse& Jac_c,

--- a/src/LinAlg/hiopVectorIntCompoundPD.cpp
+++ b/src/LinAlg/hiopVectorIntCompoundPD.cpp
@@ -99,8 +99,6 @@ void hiopVectorIntCompoundPD::addVector(hiopVectorInt* v)
 
 hiopVectorInt& hiopVectorIntCompoundPD::getVector(index_type index) const { return *(vectors_[index]); }
 
-size_type hiopVectorIntCompoundPD::get_local_size() const { return sz_; }
-
 size_type hiopVectorIntCompoundPD::get_num_parts() const { return n_parts_; }
 
 }  // namespace hiop

--- a/src/LinAlg/hiopVectorIntCompoundPD.hpp
+++ b/src/LinAlg/hiopVectorIntCompoundPD.hpp
@@ -79,8 +79,6 @@ public:
 
   hiopVectorInt& getVector(index_type index) const;
 
-  size_type get_local_size() const;
-
   /* @brief return the number of parts in this compound vector */
   size_type get_num_parts() const;
 


### PR DESCRIPTION
These functions were identical to the ones in the base classes.