### PR TITLE
Parallel performance profiler

### DIFF
--- a/src/Drivers/hiopbbpy/BODriverEX.py
+++ b/src/Drivers/hiopbbpy/BODriverEX.py
@@ -72,11 +72,12 @@ user_constraint_dict = {'cons': cons_vec, 'jac': cons_jac_vec, 'cl': cl, 'cu': c
 
 
 if __name__ == "__main__":
+  do_profiling = True
   for prob_type in prob_type_l:
     print()
     # ----- evaluator
-    obj_evaluator = MPIEvaluator()
-    opt_evaluator = MPIEvaluator(function_mode=False)
+    obj_evaluator = MPIEvaluator(profiling=do_profiling, task_name="MPI_OBJ_EVAL")
+    opt_evaluator = MPIEvaluator(function_mode=False, profiling=do_profiling, task_name="MPI_OPT_EVAL")
     if prob_type == "LpNorm":
       problem = LpNormProblem(nx, xlimits)
     else:

--- a/src/Drivers/hiopbbpy/EvaluationManagerCI.py
+++ b/src/Drivers/hiopbbpy/EvaluationManagerCI.py
@@ -9,32 +9,28 @@ import logging
 import argparse
 import time
 import sys
+import os
+import socket
+import threading
 from hiopbbpy.utils import EvaluationManager, is_running_with_mpi
 from concurrent.futures import ThreadPoolExecutor
 
-def _fn_for_test(x, sleep_time=0.1, slow_first=False):
-  processing_slow_task = False
+def _fn_for_test(x, sleep_time=0.1, slow_first=False, driver_rank=0):
+    hostname = socket.gethostname()
+    pid = os.getpid()
 
-  # Apply straggler only if enabled
-  if slow_first and x == 0:
-    actual_sleep = 3 * sleep_time   
-    processing_slow_task = True 
-  else:
-    actual_sleep = sleep_time
-  
-  if is_running_with_mpi():
-    from mpi4py import MPI
-    comm = MPI.COMM_WORLD
-    rank = comm.Get_rank()
-    if processing_slow_task:
-      print(f"Rank {rank}: Processing {x} (slow)", flush=True)
+    if slow_first and x == 0:
+        actual_sleep = 3 * sleep_time
     else:
-      print(f"Rank {rank}: Processing {x}", flush=True)
+        actual_sleep = sleep_time
 
-  time.sleep(actual_sleep)
-  return x * x
+    print(
+        f"rank={driver_rank} pid={pid} host={hostname}: processing x={x}",
+        flush=True,
+    )
 
-
+    time.sleep(actual_sleep)
+    return x * x
 
 if __name__ == "__main__":
   # Arguments for command line
@@ -62,8 +58,11 @@ if __name__ == "__main__":
 
   # Choose executor type
   if is_running_with_mpi():
+    from mpi4py import MPI
+    driver_rank = MPI.COMM_WORLD.Get_rank()
     executor_type = "mpi"
   else:
+    driver_rank = 0
     executor_type = "cpu"
 
   # Set up logging
@@ -85,6 +84,7 @@ if __name__ == "__main__":
       execute_at=executor_type,
       sleep_time=args.sleep_time,
       slow_first=args.slow_first,
+      driver_rank=driver_rank,
   )
 
   # Do some other work while tasks are running

--- a/src/Drivers/hiopbbpy/EvaluationManagerCI.py
+++ b/src/Drivers/hiopbbpy/EvaluationManagerCI.py
@@ -12,13 +12,26 @@ import sys
 from hiopbbpy.utils import EvaluationManager, is_running_with_mpi
 from concurrent.futures import ThreadPoolExecutor
 
-def _fn_for_test(x, sleep_time=0.1):
+def _fn_for_test(x, sleep_time=0.1, slow_first=False):
+  processing_slow_task = False
+
+  # Apply straggler only if enabled
+  if slow_first and x == 0:
+    actual_sleep = 3 * sleep_time   
+    processing_slow_task = True 
+  else:
+    actual_sleep = sleep_time
+  
   if is_running_with_mpi():
     from mpi4py import MPI
     comm = MPI.COMM_WORLD
     rank = comm.Get_rank()
-    print(f"Rank {rank}: Processing {x}")
-  time.sleep(sleep_time)  # Simulate some work
+    if processing_slow_task:
+      print(f"Rank {rank}: Processing {x} (slow)", flush=True)
+    else:
+      print(f"Rank {rank}: Processing {x}", flush=True)
+
+  time.sleep(actual_sleep)
   return x * x
 
 
@@ -29,12 +42,25 @@ if __name__ == "__main__":
     description="Execute n function calls with t duration.",
     epilog="To properly run the example with mpi4py, use: env MPI4PY_FUTURES_MAX_WORKERS=<N> mpiexec -n 1 python evaluation_manager.py",
   )
-  parser.add_argument("-n", type=int, default=100, help="Number of tasks to execute")
+  parser.add_argument("-n", type=int, default=20, help="Number of tasks to execute")
   parser.add_argument(
       "-t", "--sleep_time", type=float, default=1, help="Sleep time for each task"
   )
+  parser.add_argument(
+      "-p",
+      "--profile",
+      action="store_true",
+      help="Enable profiling",
+  )
+  parser.add_argument(
+    "-s",
+    "--slow_first",
+    action="store_true",
+    help="Make the first task slower (3x sleep time)",
+  )
   args = parser.parse_args()
 
+  # Choose executor type
   if is_running_with_mpi():
     executor_type = "mpi"
   else:
@@ -45,23 +71,27 @@ if __name__ == "__main__":
 
   # Create manager
   cpu_executor = ThreadPoolExecutor()
-  manager = EvaluationManager(cpu_executor=cpu_executor)
+  manager = EvaluationManager(
+      cpu_executor=cpu_executor,
+      profiling=args.profile,
+      task_name="CI_TASK"
+  )
 
-  # Submit tasks to the manager
+  # Submit tasks
   t0 = time.perf_counter()
   manager.submit_tasks(
       _fn_for_test,
       [i for i in range(args.n)],
       execute_at=executor_type,
       sleep_time=args.sleep_time,
+      slow_first=args.slow_first,
   )
 
   # Do some other work while tasks are running
-  print("Doing other work", end="", flush=True)
   for i in range(5):
-    print(".", end="", flush=True)
+    print("Doing other work (Master)", flush=True)
     time.sleep(args.sleep_time)
-  print(" Done.")
+  print("Doing other work (Master) --- Done.")
 
   # Wait for all tasks to complete
   print("Waiting for tasks to complete...")
@@ -76,5 +106,4 @@ if __name__ == "__main__":
 
   # Clean up
   del manager
-  retval = 0
-  sys.exit(retval)
+  sys.exit(0)

--- a/src/hiopbbpy/surrogate_modeling/krg.py
+++ b/src/hiopbbpy/surrogate_modeling/krg.py
@@ -16,7 +16,7 @@ class smtKRG(GaussianProcess):
     super().__init__(ndim, xlimits)
     if random_state is None:
       random_state = 42
-    design_space = DesignSpace(xlimits, random_state=random_state)
+    design_space = DesignSpace(xlimits, seed=random_state)
     if noise0 is None:
       self.surrogatesmt = KRG(design_space=design_space,
                        print_global=False,

--- a/src/hiopbbpy/utils/evaluation_manager.py
+++ b/src/hiopbbpy/utils/evaluation_manager.py
@@ -230,11 +230,6 @@ class EvaluationManager:
           if self._first_submit_time is not None else 0.0
       )
 
-      efficiency = (
-          ideal_walltime / actual_walltime
-          if actual_walltime > 0.0 else 0.0
-      )
-
       print("\n=== Parallel Performance ===")
       print(f"{self.task_name} Workers:                                     {num_workers}")
       print(f"{self.task_name} Total work in seconds:                       {total_work:.6e}")
@@ -243,15 +238,3 @@ class EvaluationManager:
 
     return list(X), list(F)
   
-  
-  ###
-# print
-# work execution apparenet wall clock time
-# ideal wallclock time (workers' side)
-#      total wall time devide by the number of MPI
-# manager wallclock time
-
-
-#. 20. 1 1 
-# mpi rank 1: 20
-# mpi rank 2: 1 1 

--- a/src/hiopbbpy/utils/evaluation_manager.py
+++ b/src/hiopbbpy/utils/evaluation_manager.py
@@ -10,6 +10,8 @@ import threading
 import logging
 import copy
 import os
+import time
+import math
 from concurrent.futures import ProcessPoolExecutor, CancelledError
 from collections import deque
 
@@ -18,9 +20,9 @@ def is_running_with_mpi():
   """Returns True if the code is running in an MPI environment."""
   _MPI_RANK_ENV_VARS = [
       "OMPI_COMM_WORLD_RANK",  # Open MPI
-      "PMI_RANK",  # MPICH, Intel MPI, Cray MPI
-      "MPI_RANK",  # Intel MPI (sometimes)
-      "MV2_COMM_WORLD_RANK",  # MVAPICH
+      "PMI_RANK",              # MPICH, Intel MPI, Cray MPI
+      "MPI_RANK",              # Intel MPI (sometimes)
+      "MV2_COMM_WORLD_RANK",   # MVAPICH
   ]
   return any(var in os.environ for var in _MPI_RANK_ENV_VARS)
 
@@ -34,46 +36,55 @@ else:
   from concurrent.futures import wait
 
 
+def _timed_call(fn, x, kwargs):
+  """Run fn(x, **kwargs) and record worker-side timing."""
+  start_time = time.perf_counter()
+  fx = fn(x, **kwargs)
+  done_time = time.perf_counter()
+  return {
+      "result": fx,
+      "start_time": start_time,
+      "done_time": done_time,
+      "execution_time": done_time - start_time,
+  }
+
+
+def _summary_stats(values):
+  """Return mean, std_dev, min, max for a sequence."""
+  if not values:
+    return None
+
+  n = len(values)
+  mean = sum(values) / n
+  if n > 1:
+    var = sum((v - mean) ** 2 for v in values) / n
+    std_dev = math.sqrt(var)
+  else:
+    std_dev = 0.0
+
+  return {
+      "mean": mean,
+      "std_dev": std_dev,
+      "min": min(values),
+      "max": max(values),
+  }
+
+
 class EvaluationManager:
-  """Class that manages the evaluation of functions using multiple executors.
-
-  It allows for the submission of tasks to different executors:
-
-  - Intra-node parallelism using ProcessPoolExecutor (default)
-  - Inter-node parallelism using MPIPoolExecutor (if available)
-
-  Tasks are submitted to the executors, and their results can be retrieved
-  once they are completed. The submission of tasks is asynchronous, and the
-  retrieval of results is done in a blocking manner. The syncronization of all
-  tasks is done using the `sync` method, which waits for all tasks to complete
-  before proceeding.
-
-  :param cpu_executor: The executor to use for intra-node parallelism, i.e.,
-      that controls tasks on the executor's local node. If None, a new
-      ProcessPoolExecutor is created.
-  :param mpi_executor: The executor to use for inter-node parallelism, i.e.,
-      that controls tasks on the executor's remote nodes. If None, a new
-      MPIPoolExecutor is created. If MPI is not available, this parameter is
-      ignored.
-
-  .. attribute:: logger:
-
-      The logger for the EvaluationManager. It is used to log messages.
-
-  .. attribute:: executors:
-      A dictionary of executors used for task submission. The keys are
-      "cpu" and "mpi", and the values are the corresponding executors.
-      The default is a ProcessPoolExecutor for "cpu" and an MPIPoolExecutor
-      for "mpi" if MPI is available.
-  """
+  """Class that manages the evaluation of functions using multiple executors."""
 
   def __init__(
     self,
     cpu_executor=None,
-    mpi_executor=None) -> None:
+    mpi_executor=None,
+    profiling=False,
+    task_name="TASK") -> None:
     self._queue = deque([])
     self._queue_lock = threading.Lock()
     self.logger = logging.getLogger(self.__class__.__name__)
+    self.profiling = profiling
+    self._first_submit_time = None
+    self.task_name = task_name
 
     self.executors = {
         "cpu": ProcessPoolExecutor() if cpu_executor is None else cpu_executor
@@ -92,67 +103,155 @@ class EvaluationManager:
   def __del__(self) -> None:
     for executor in self.executors.values():
       executor.shutdown(wait=False)
-    self.logger.info("EvaluationManager destroyed and executors shut down.")
+    self.logger.info(f"{self.task_name} EvaluationManager destroyed and executors shut down.")
+
+  def _get_num_workers(self):
+    """Return number of workers."""
+    if "mpi" in self.executors and is_running_with_mpi():
+      return int(os.environ.get("MPI4PY_FUTURES_MAX_WORKERS", 1))
+    try:
+      return self.executors["cpu"]._max_workers
+    except AttributeError:
+      return 1
+
+  def set_task_name(self, task_name):
+    self.task_name = task_name
+
+  def _print_timing_stats(self, label, values):
+    stats = _summary_stats(values)
+    if stats is None:
+      print(f"{label}: no completed tasks")
+      return
+
+    print(
+        f"{label:<18} "
+        f"Mean={stats['mean']:.6e}  "
+        f"StdDev={stats['std_dev']:.6e}  "
+        f"Min={stats['min']:.6e}  "
+        f"Max={stats['max']:.6e}"
+    )
 
   def sync(self) -> None:
-    """Synchronizes all tasks by waiting for their completion.
-
-    Results can be retrieved using :meth:`retrieve_results()`.
-    """
-    future_objs = [queue_obj[1] for queue_obj in self._queue]
+    """Wait for all submitted tasks to complete."""
+    future_objs = [queue_obj["future"] for queue_obj in self._queue]
     wait(future_objs)
 
   def submit_tasks(self, fn, X, execute_at="cpu", **kwargs) -> None:
-    """Submits tasks to the specified executor.
-
-    :param fn: The function to be executed.
-    :param X: The sequence of input data for the function.
-    :param execute_at: The executor to use for task submission. It can be
-        "cpu" for intra-node parallelism or "mpi" for inter-node
-        parallelism.
-    :param kwargs: Additional keyword arguments to be passed to the
-        function.
-    """
+    """Submits tasks to the specified executor."""
     key = execute_at.lower()
     with self._queue_lock:
       for x in X:
-        future_obj = self.executors[key].submit(fn, x, **kwargs)
-        self._queue.append([copy.deepcopy(x), future_obj])
-        self.logger.info(f"Submitted f({x})")
+        submit_time = time.perf_counter()
+        if self._first_submit_time is None:
+          self._first_submit_time = submit_time
+
+        if self.profiling:
+          future_obj = self.executors[key].submit(_timed_call, fn, x, kwargs)
+        else:
+          future_obj = self.executors[key].submit(fn, x, **kwargs)
+
+        self._queue.append({
+            "x": copy.deepcopy(x),
+            "future": future_obj,
+            "submit_time": submit_time,
+        })
+        self.logger.info(f"{self.task_name} Submitted f({x})")
 
   def retrieve_results(self) -> tuple[list, list]:
-    """Retrieves the results of completed tasks.
-
-    :return: A tuple containing two lists: the inputs and the results of
-        the completed tasks.
-    """
+    """Retrieves the results of completed tasks."""
     X = deque([])
     F = deque([])
 
+    execution_times = []
+    wait_times = []
+    turnaround_times = []
+
+    # Master-side wall clock for the whole batch
+    batch_done_time = time.perf_counter()
+
     with self._queue_lock:
       new_queue = deque([])
+
       for item in self._queue:
-        x = item[0]
-        future = item[1]
+        x = item["x"]
+        future = item["future"]
+        submit_time = item["submit_time"]
+
         if future.done():
-          # Try to get result
           try:
             fx = future.result()
           except CancelledError:
-            self.logger.warning(f"The execution of x={x} was cancelled.")
+            self.logger.warning(f"{self.task_name} The execution of x={x} was cancelled.")
             continue
 
-          # Add result to the output
+          if self.profiling:
+            # These are fine for local inspection, but note:
+            # worker_start_time / worker_done_time are on worker clocks.
+            worker_start_time = fx["start_time"]
+            worker_done_time = fx["done_time"]
+
+            execution_time = fx["execution_time"]
+
+            # These are not robust across different node clocks, but kept here
+            # because you already had them.
+            wait_time = worker_start_time - submit_time
+            turnaround_time = worker_done_time - submit_time
+
+            execution_times.append(execution_time)
+            wait_times.append(wait_time)
+            turnaround_times.append(turnaround_time)
+
+            fx = fx["result"]
+
           X.append(x)
           F.append(fx)
-          self.logger.info(f"Completed: f({x}) = {fx}")
+          self.logger.info(f"{self.task_name} Completed: f({x}) = {fx}")
         else:
-          # Keep the future in the queue
           new_queue.append(item)
 
-      # Remove completed tasks from the queue
       self._queue = new_queue
 
+    if self.profiling and execution_times:
+      self._print_timing_stats(f"{self.task_name} Execution times", execution_times)
+
+      # Optional: only print these if you are comfortable with cross-clock values
+      # self._print_timing_stats("Wait times", wait_times)
+      # self._print_timing_stats("Turnaround times", turnaround_times)
+
+      num_workers = self._get_num_workers()
+      total_work = sum(execution_times)
+
+      # Ideal walltime = total work / number of workers
+      ideal_walltime = total_work / num_workers if num_workers > 0 else 0.0
+
+      # Actual walltime = master-side elapsed time for the whole batch
+      actual_walltime = (
+          batch_done_time - self._first_submit_time
+          if self._first_submit_time is not None else 0.0
+      )
+
+      efficiency = (
+          ideal_walltime / actual_walltime
+          if actual_walltime > 0.0 else 0.0
+      )
+
+      print("\n=== Parallel Performance ===")
+      print(f"{self.task_name} Workers:                                     {num_workers}")
+      print(f"{self.task_name} Total work in seconds:                       {total_work:.6e}")
+      print(f"{self.task_name} Ideal walltime in seconds (perfect balance): {ideal_walltime:.6e}")
+      print(f"{self.task_name} Actual walltime in seconds (observed):       {actual_walltime:.6e}")
+
     return list(X), list(F)
+  
+  
+  ###
+# print
+# work execution apparenet wall clock time
+# ideal wallclock time (workers' side)
+#      total wall time devide by the number of MPI
+# manager wallclock time
 
 
+#. 20. 1 1 
+# mpi rank 1: 20
+# mpi rank 2: 1 1 

--- a/src/hiopbbpy/utils/util.py
+++ b/src/hiopbbpy/utils/util.py
@@ -74,8 +74,8 @@ class MPIEvaluator(Evaluator):
   We reformat to 
   [eval0, eval1, eval2,...]
   """
-  def __init__(self, function_mode=True,cpu_executor=None, mpi_executor=None):
-    self.manager = EvaluationManager(cpu_executor,mpi_executor)
+  def __init__(self, function_mode=True,cpu_executor=None, mpi_executor=None, profiling=False, task_name="MPITASK"):
+    self.manager = EvaluationManager(cpu_executor,mpi_executor,profiling=profiling, task_name=task_name)
     self.function_mode = function_mode
     if is_running_with_mpi():
       self.executor_type = "mpi"
@@ -83,6 +83,8 @@ class MPIEvaluator(Evaluator):
       self.executor_type = "cpu"
   def __del__(self):
     del self.manager
+  def set_task_name(self, task_name):
+    self.manager.set_task_name(task_name)
   def run(self, fun, Xin):
     nevals = Xin.shape[0]
     self.manager.submit_tasks(fun, [np.atleast_2d(Xin[i]) for i in range(nevals)], execute_at=self.executor_type)


### PR DESCRIPTION
This PR adds instrumentation for performance profiling of parallel evaluations done with EvaluationManager. Parallel performance statistics are printed after each chunck of parallel blocks is finished/retrieved.

Also fixes a name of the input arguments for a SMT function that was causing a CI pipeline to fail.