### PR TITLE
Fix HiOp version component reporting

### DIFF
--- a/src/Interface/hiopVersion.hpp
+++ b/src/Interface/hiopVersion.hpp
@@ -1,7 +1,6 @@
 #pragma once
 #include <string>
 #include <sstream>
-#include <cstdlib>
 #include "hiop_defs.hpp"
 
 namespace hiop
@@ -84,9 +83,9 @@ struct hiopVersion
 
   static inline void version(int& major, int& minor, int& patch)
   {
-    major = std::atoi(HIOP_VERSION_MAJOR);
-    minor = std::atoi(HIOP_VERSION_MINOR);
-    patch = std::atoi(HIOP_VERSION_PATCH);
+    major = HIOP_VERSION_MAJOR;
+    minor = HIOP_VERSION_MINOR;
+    patch = HIOP_VERSION_PATCH;
   }
 
   static inline std::string version() { return HIOP_VERSION; }


### PR DESCRIPTION
## Description

`hiopVersion::version(int&, int&, int&)` passed the integer version macros to `std::atoi()`, which expects a string. This caused external programs that call the integer version overload to fail to compile.

Closes #765.

## Proposed changes

Assign the integer version values directly and remove the unused `<cstdlib>` include.

I verified the change by compiling and running an external program that includes `hiopVersion.hpp`, calls the integer version overload, and prints `fullVersionInfo()`.
