### PR TITLE
Avoid unnecessary string copies

### DIFF
--- a/src/Utils/hiopOptions.cpp
+++ b/src/Utils/hiopOptions.cpp
@@ -1585,13 +1585,13 @@ void hiopOptionsNLP::ensure_consistence()
                                       "checkpoint_save_every_N_iter",
                                       "checkpoint_file",
                                       "checkpoint_load_on_start"};
-  for(string opt: chkpnt_opts) {
+  for(const auto& opt: chkpnt_opts) {
     if(is_user_defined(opt.c_str())) {
       log_printf(hovWarning,
                  "Checkpointing not available since HiOp was not built with AXOM. All checkpointing options "
                  "are ignored.\n");
       // reset them to as not being user defined to avoid triggering the message.
-      for(auto opt2: chkpnt_opts) {
+      for(const auto& opt2: chkpnt_opts) {
         mOptions_[opt2]->specifiedInFile = false;
         mOptions_[opt2]->specifiedAtRuntime = false;
       }


### PR DESCRIPTION
Use const references in range-based for loops to avoid copying strings.