### PR TITLE
BO report feasible training points if points generated by BO are not more optimal.

### DIFF
--- a/src/hiopbbpy/opt/boalgorithm.py
+++ b/src/hiopbbpy/opt/boalgorithm.py
@@ -23,6 +23,7 @@ class BOAlgorithmBase:
     self.batch_type = "KB"        # strategy for qEI
     self.xtrain = None            # Training data
     self.ytrain = None            # Training data
+    self.init_ntrain = 0          # Initial (prior to BO optimization) number of GP training pts 
     self.prob   = None            # Problem structure
     self.obj_evaluator = Evaluator()  # (batch) objective function evaluations
     self.opt_evaluator = Evaluator()  # (multi-start) local optimizer evaluations
@@ -74,8 +75,9 @@ class BOAlgorithm(BOAlgorithmBase):
                options = {}):
     super().__init__()
     assert isinstance(gpsurrogate, GaussianProcess)
-
+    assert len(xtrain) == len(ytrain), "xtrain, ytrain must be the same length"
     self.setTrainingData(xtrain, ytrain)
+    self.init_ntrain = len(ytrain)
     self.prob = prob
     self.gpsurrogate = gpsurrogate
     self.bounds = self.gpsurrogate.get_bounds()
@@ -323,9 +325,17 @@ class BOAlgorithm(BOAlgorithmBase):
     self.logger.critical("Bayesian Optimization completed")
     self.logger.critical(f"Total evaluations for initial samples: {len(self.ytrain)-len(self.y_hist)}")
     self.logger.critical(f"Total evaluations for BO iterations: {len(self.y_hist)}")
-    self.logger.critical(f"Optimal at BO iteration: {self.idx_opt//self.batch_size+1} ")
-    self.logger.debug(f"Best point: {self.x_opt.flatten()}")
-    self.logger.critical(f"Best value: {self.y_opt[0]}")
+    train_idx_opt = np.argmin(self.ytrain[:self.init_ntrain])
+    x_train_opt = self.xtrain[train_idx_opt]
+    y_train_opt = self.ytrain[train_idx_opt][0]
+    if self.y_opt < y_train_opt:    
+      self.logger.critical(f"Optimal at BO iteration: {self.idx_opt//self.batch_size+1} ")
+      self.logger.critical(f"Best point: {self.x_opt.flatten()}")
+      self.logger.critical(f"Best objective value: {self.y_opt[0]}")
+    else:
+      self.logger.critical(f"Optimal at training point: {train_idx_opt}")
+      self.logger.critical(f"Best (training) point: {x_train_opt}")
+      self.logger.critical(f"Best (training) point objective value: {y_train_opt}")
     self.logger.critical("===================================")
 
 

--- a/src/hiopbbpy/opt/boalgorithm.py
+++ b/src/hiopbbpy/opt/boalgorithm.py
@@ -251,9 +251,16 @@ class BOAlgorithm(BOAlgorithmBase):
       best_constrained_train_y = y_train_fea[best_fea_idx][0]
       best_constrained_train_x = x_train_fea[best_fea_idx]
       
-      matching_idxs = np.where((x_train == best_constrained_train_x).all(axis=1))[0]
-      assert len(matching_idxs) > 0, "error, contact developer"
-      train_idx_opt = matching_idxs[0]
+      count = 0
+      train_idx_opt = -1
+      for i, is_feasible in enumerate(fea_idxs):
+        if is_feasible:
+          if count == best_fea_idx:
+            train_idx_opt = i
+          count = count + 1
+      assert train_idx_opt >= 0, "error, contact developer"
+
+
       self.logger.info(
           f"Best objective: {best_constrained_train_y:.4e} from {y_train_fea.size} feasible initial training points"
         )

--- a/src/hiopbbpy/opt/boalgorithm.py
+++ b/src/hiopbbpy/opt/boalgorithm.py
@@ -33,9 +33,10 @@ class BOAlgorithmBase:
     # save some internal member train
     self.y_hist = None            # History of evaluations
     self.x_hist = None            # History of evaluations
-    self.x_opt = None             # Best observed point
-    self.y_opt = None             # Best observed value
-    self.idx_opt = None           # Index of the best observed value in the history
+    self.x_BO_opt = None          # Best point generated via BO
+    self.y_BO_opt = None          # Best objective value generated via BO
+    self.x_opt = None             # Best feasible point  (BO + feasible initial training points)
+    self.y_opt = None             # Best objective value (BO + feasible initial training points) 
     self.logger = Logger()        # logger
 
   # Sets the acquisition function type and batch size
@@ -237,21 +238,32 @@ class BOAlgorithm(BOAlgorithmBase):
     y_train = self.ytrain
     self.logger.iterations(f"Best UNCONSTRAINED objective from {np.size(x_train, 0)} initial samples: {np.min(y_train):.4e} ")
 
-    # filter feasible points
-    fea_idx = self.prob.if_feasible(x_train, y_train)
-    y_fea = y_train[fea_idx]
-    if y_fea.size > 0:
-      best_constrained = np.min(y_fea)
+    # determine which initial training points are feasible
+    fea_idxs = self.prob.if_feasible(x_train, y_train) # determine which points are feasible
+    y_train_fea = y_train[fea_idxs] 
+    x_train_fea = x_train[fea_idxs]
+
+    # determine the most optimal objective value from the set of feasible initial training points
+    if y_train_fea.size > 0:
+      best_fea_idx = np.argmin(y_train_fea)
+      best_constrained_train_y = y_train_fea[best_fea_idx][0]
+      best_constrained_train_x = x_train_fea[best_fea_idx]
+      
+      matching_idxs = np.where((x_train == best_constrained_train_x).all(axis=1))[0]
+      assert len(matching_idxs) > 0, "error, contact developer"
+      train_idx_opt = matching_idxs[0]
       self.logger.info(
-            f"Best CONSTRAINED objective from {y_fea.size} feasible initial samples: {np.min(y_fea):.4e}"
+            f"Best CONSTRAINED objective from {y_train_fea.size} feasible initial samples: {best_constrained_train_y:.4e}"
         )
+
     else:
+      best_constrained_train_y = np.inf
       self.logger.info("No feasible samples found.")
 
     self.x_hist = []
     self.y_hist = []
     
-    prev_best_y = np.inf
+    prev_best_y = best_constrained_train_y
     for i in range(self.bo_maxiter):
       self.logger.critical(f"*****************************")
       self.logger.critical(f"Iteration {i+1}/{self.bo_maxiter}")
@@ -286,7 +298,7 @@ class BOAlgorithm(BOAlgorithmBase):
       self.logger.debug(f"Feasible samples: {np.sum(feas_new)}/{self.batch_size}")
 
       min_y_new = np.min(y_new)
-      curr_best_y = np.minimum(prev_best_y, min_y_new)
+      curr_best_y = np.min([prev_best_y, min_y_new])
 
       self.logger.iterations(f"Best objective found in this iteration: {min_y_new:.4e} ")
       self.logger.scalars(f"Training set size is now {x_train.shape[0]}")
@@ -315,27 +327,32 @@ class BOAlgorithm(BOAlgorithmBase):
 
       prev_best_y = curr_best_y
 
-    # Save the optimal results and all the training data
-    self.idx_opt = np.argmin(self.y_hist)
-    self.x_opt = self.x_hist[self.idx_opt]
-    self.y_opt = self.y_hist[self.idx_opt]
     self.setTrainingData(x_train, y_train)
-
+    
+    # Save the BO optimal (excluding initial training pts) results
+    idx_BO_opt = np.argmin(self.y_hist)
+    self.x_BO_opt = self.x_hist[idx_BO_opt]
+    self.y_BO_opt = self.y_hist[idx_BO_opt][0]
+    
     self.logger.critical("===================================")
     self.logger.critical("Bayesian Optimization completed")
-    self.logger.critical(f"Total evaluations for initial samples: {len(self.ytrain)-len(self.y_hist)}")
-    self.logger.critical(f"Total evaluations for BO iterations: {len(self.y_hist)}")
-    train_idx_opt = np.argmin(self.ytrain[:self.init_ntrain])
-    x_train_opt = self.xtrain[train_idx_opt]
-    y_train_opt = self.ytrain[train_idx_opt][0]
-    if self.y_opt < y_train_opt:    
-      self.logger.critical(f"Optimal at BO iteration: {self.idx_opt//self.batch_size+1} ")
-      self.logger.critical(f"Best point: {self.x_opt.flatten()}")
-      self.logger.critical(f"Best objective value: {self.y_opt[0]}")
+    self.logger.critical(f"Total objective evaluations for initial samples: {self.init_ntrain}")
+    self.logger.critical(f"Total objective evaluations for BO iterations: {len(self.y_hist)}")
+    if self.y_BO_opt < best_constrained_train_y:
+      self.logger.critical(f"Optimal at BO iteration: {idx_BO_opt//self.batch_size+1} ")
+    else:
+      self.logger.critical(f"BO did not generate points more optimal than initial training points")
+    self.logger.critical(f"Best (BO) point: {self.x_BO_opt.flatten()}")
+    self.logger.critical(f"Best (BO) objective value: {self.y_BO_opt}")
+    if self.y_BO_opt < best_constrained_train_y:
+      self.x_opt = self.x_BO_opt
+      self.y_opt = self.y_BO_opt
     else:
       self.logger.critical(f"Optimal at training point: {train_idx_opt}")
-      self.logger.critical(f"Best (training) point: {x_train_opt}")
-      self.logger.critical(f"Best (training) point objective value: {y_train_opt}")
+      self.logger.critical(f"Best (training) point: {best_constrained_train_x.flatten()}")
+      self.logger.critical(f"Best (training) point objective value: {best_constrained_train_y}")
+      self.x_opt = best_constrained_train_x
+      self.y_opt = best_constrained_train_y
     self.logger.critical("===================================")
 
 

--- a/src/hiopbbpy/opt/boalgorithm.py
+++ b/src/hiopbbpy/opt/boalgorithm.py
@@ -79,8 +79,8 @@ class BOAlgorithm(BOAlgorithmBase):
     super().__init__()
     assert isinstance(gpsurrogate, GaussianProcess)
     assert len(xtrain) == len(ytrain), "xtrain, ytrain must be the same length"
-    assert len(ytrain.shape) == 2 and ytrain.shape[1] == 1, "ytrain must be a (n, 1) array"
-    assert len(xtrain.shape), "xtrain must be a (n, d) array"
+    assert ytrain.ndim == 2 and ytrain.shape[1] == 1, "ytrain must be a (n, 1) array"
+    assert xtrain.ndim == 2, "xtrain must be a (n, d) array"
     self.setTrainingData(xtrain, ytrain)
     self.init_ntrain = len(ytrain)
     self.prob = prob

--- a/src/hiopbbpy/opt/boalgorithm.py
+++ b/src/hiopbbpy/opt/boalgorithm.py
@@ -253,12 +253,12 @@ class BOAlgorithm(BOAlgorithmBase):
       assert len(matching_idxs) > 0, "error, contact developer"
       train_idx_opt = matching_idxs[0]
       self.logger.info(
-            f"Best CONSTRAINED objective from {y_train_fea.size} feasible initial samples: {best_constrained_train_y:.4e}"
+          f"Best objective: {best_constrained_train_y:.4e} from {y_train_fea.size} feasible initial training points"
         )
 
     else:
       best_constrained_train_y = np.inf
-      self.logger.info("No feasible samples found.")
+      self.logger.info("No feasible initial training points.")
 
     self.x_hist = []
     self.y_hist = []

--- a/src/hiopbbpy/opt/boalgorithm.py
+++ b/src/hiopbbpy/opt/boalgorithm.py
@@ -79,6 +79,8 @@ class BOAlgorithm(BOAlgorithmBase):
     super().__init__()
     assert isinstance(gpsurrogate, GaussianProcess)
     assert len(xtrain) == len(ytrain), "xtrain, ytrain must be the same length"
+    assert len(ytrain.shape) == 2 and ytrain.shape[1] == 1, "ytrain must be a (n, 1) array"
+    assert len(xtrain.shape), "xtrain must be a (n, d) array"
     self.setTrainingData(xtrain, ytrain)
     self.init_ntrain = len(ytrain)
     self.prob = prob

--- a/src/hiopbbpy/opt/boalgorithm.py
+++ b/src/hiopbbpy/opt/boalgorithm.py
@@ -20,7 +20,7 @@ import os
 class BOAlgorithmBase:
   def __init__(self):
     self.acquisition_type = "LCB" # Type of acquisition function (default = "LCB")
-    self.batch_type = "KB"        # strategy for qEI
+    self.batch_type = "KB"        # Batched BO strategy
     self.xtrain = None            # Training data
     self.ytrain = None            # Training data
     self.init_ntrain = 0          # Initial (prior to BO optimization) number of GP training pts 
@@ -42,6 +42,8 @@ class BOAlgorithmBase:
   # Sets the acquisition function type and batch size
   def setAcquisitionType(self, acquisition_type, batch_size=1):
     self.acquisition_type = acquisition_type
+    assert isinstance(batch_size, int), f"batch_size {batch_size} not an integer"
+    assert batch_size > 0, f"batch_size {batch_size} is not strictly positive"
     self.batch_size = batch_size
 
   # Sets the training data
@@ -97,8 +99,6 @@ class BOAlgorithm(BOAlgorithmBase):
     assert acquisition_type in ["LCB", "EI"], f"Invalid acquisition_type: {acquisition_type}"
 
     batch_size = options.get('batch_size', 1)
-    assert isinstance(batch_size, int), f"batch_size {batch_size} not an integer"
-    assert batch_size > 0, f"batch_size {batch_size} is not strictly positive"
 
     self.setAcquisitionType(acquisition_type, batch_size)
 

--- a/src/hiopbbpy/opt/boalgorithm.py
+++ b/src/hiopbbpy/opt/boalgorithm.py
@@ -251,15 +251,8 @@ class BOAlgorithm(BOAlgorithmBase):
       best_constrained_train_y = y_train_fea[best_fea_idx][0]
       best_constrained_train_x = x_train_fea[best_fea_idx]
       
-      count = 0
-      train_idx_opt = -1
-      for i, is_feasible in enumerate(fea_idxs):
-        if is_feasible:
-          if count == best_fea_idx:
-            train_idx_opt = i
-          count = count + 1
-      assert train_idx_opt >= 0, "error, contact developer"
-
+      feasible_train_indices = np.flatnonzero(fea_idxs)
+      train_idx_opt = int(feasible_train_indices[best_fea_idx])
 
       self.logger.info(
           f"Best objective: {best_constrained_train_y:.4e} from {y_train_fea.size} feasible initial training points"

--- a/src/hiopbbpy/opt/boalgorithm.py
+++ b/src/hiopbbpy/opt/boalgorithm.py
@@ -354,6 +354,7 @@ class BOAlgorithm(BOAlgorithmBase):
       self.x_opt = best_constrained_train_x
       self.y_opt = best_constrained_train_y
     self.logger.critical("===================================")
+    self.y_opt = np.array([self.y_opt])
 
 
 class minimizer_wrapper:

--- a/src/hiopbbpy/opt/boalgorithm.py
+++ b/src/hiopbbpy/opt/boalgorithm.py
@@ -239,7 +239,7 @@ class BOAlgorithm(BOAlgorithmBase):
     self.logger.iterations(f"Best UNCONSTRAINED objective from {np.size(x_train, 0)} initial samples: {np.min(y_train):.4e} ")
 
     # determine which initial training points are feasible
-    fea_idxs = self.prob.if_feasible(x_train, y_train) # determine which points are feasible
+    fea_idxs = self.prob.if_feasible(x_train) # determine which points are feasible
     y_train_fea = y_train[fea_idxs] 
     x_train_fea = x_train[fea_idxs]
 

--- a/src/hiopbbpy/utils/util.py
+++ b/src/hiopbbpy/utils/util.py
@@ -128,7 +128,6 @@ class MPIEvaluator(Evaluator):
   
   def run(self, fun, Xin):  
     nevals = Xin.shape[0]
-    print("in Evaluator::run")
 
     # unique batch directory so repeated calls do not reuse temp_dir_0, temp_dir_1, ...
     batch_id = f"{self.manager.task_name}_{os.getpid()}_{time.time_ns()}_{uuid.uuid4().hex[:8]}"
@@ -150,13 +149,8 @@ class MPIEvaluator(Evaluator):
         [(fun, i, xi)],
         **kwargs,
       )
-      print(f"Submitted task {i + 1}", flush=True)
 
     self.manager.sync()
-    print(f"\n{'='*50}")
-    print(f"Retrieving results for {self.manager.task_name}...")
-    print(f"Profiling enabled: {self.manager.profiling}")
-    print(f"{'='*50}\n", flush=True)
     Xout, Fout = self.manager.retrieve_results()
 
     # restore original order using returned indices


### PR DESCRIPTION
This PR is a response to Issue #770. The BO algorithm has been updated to

1. Determine the most optimal feasible point from the set of initial training points.
2. If BO does not generate a more optimal point then that from the set of initial (feasible) training points to report that the best point is an initial training point and to also report what is the best value generated via BO.
3. If BO does generate a more optimal value then to just report that and to suppress any mention of the best value from the set of initial training points.
4. If the black box objective is non-finite at all BO sample points and if each initial GP training point is either not feasible or the BB objective is non-finite at it then report that. This is a corner case that would likely not actually be encountered as the GP training would fail when we attempt to train it with non-finite BB objective function values but nonetheless I believe this increase in robustness is valuable.